### PR TITLE
Bazarr: History and Blacklist tabs

### DIFF
--- a/services/service_bazarr/lib/src/bazarr_api.dart
+++ b/services/service_bazarr/lib/src/bazarr_api.dart
@@ -238,4 +238,116 @@ class BazarrApi {
       throw NetworkException.fromDio(e);
     }
   }
+
+  /// Episode subtitle history (`GET /episodes/history`), newest first.
+  Future<List<BazarrHistoryItem>> getEpisodeHistory({int length = 50}) async {
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>(
+        'api/episodes/history',
+        queryParameters: <String, dynamic>{'start': 0, 'length': length},
+      );
+      return _parseHistory(resp.data, isMovie: false);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  /// Movie subtitle history (`GET /movies/history`), newest first.
+  Future<List<BazarrHistoryItem>> getMovieHistory({int length = 50}) async {
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>(
+        'api/movies/history',
+        queryParameters: <String, dynamic>{'start': 0, 'length': length},
+      );
+      return _parseHistory(resp.data, isMovie: true);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  List<BazarrHistoryItem> _parseHistory(dynamic data, {required bool isMovie}) {
+    final List<dynamic> list = data is Map<String, dynamic>
+        ? ((data['data'] as List<dynamic>?) ?? const <dynamic>[])
+        : (data as List<dynamic>);
+    return list
+        .map(
+          (dynamic e) => BazarrHistoryItem.fromJson(e as Map<String, dynamic>)
+              .copyWith(isMovie: isMovie),
+        )
+        .toList();
+  }
+
+  /// Blacklisted episode subtitles (`GET /episodes/blacklist`). No paging params
+  /// are sent: Bazarr 500s on an empty movies blacklist when they are present.
+  Future<List<BazarrBlacklistItem>> getEpisodeBlacklist() async {
+    try {
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('api/episodes/blacklist');
+      return _parseBlacklist(resp.data, isMovie: false);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  /// Blacklisted movie subtitles (`GET /movies/blacklist`).
+  Future<List<BazarrBlacklistItem>> getMovieBlacklist() async {
+    try {
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('api/movies/blacklist');
+      return _parseBlacklist(resp.data, isMovie: true);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  List<BazarrBlacklistItem> _parseBlacklist(
+    dynamic data, {
+    required bool isMovie,
+  }) {
+    final List<dynamic> list = data is Map<String, dynamic>
+        ? ((data['data'] as List<dynamic>?) ?? const <dynamic>[])
+        : (data as List<dynamic>);
+    return list
+        .map(
+          (dynamic e) => BazarrBlacklistItem.fromJson(e as Map<String, dynamic>)
+              .copyWith(isMovie: isMovie),
+        )
+        .toList();
+  }
+
+  /// Removes a blacklisted episode subtitle (`DELETE /episodes/blacklist`).
+  Future<void> removeEpisodeBlacklist({
+    required String provider,
+    required String subsId,
+  }) async {
+    try {
+      await _dio.delete<dynamic>(
+        'api/episodes/blacklist',
+        queryParameters: <String, dynamic>{
+          'provider': provider,
+          'subs_id': subsId,
+        },
+      );
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  /// Removes a blacklisted movie subtitle (`DELETE /movies/blacklist`).
+  Future<void> removeMovieBlacklist({
+    required String provider,
+    required String subsId,
+  }) async {
+    try {
+      await _dio.delete<dynamic>(
+        'api/movies/blacklist',
+        queryParameters: <String, dynamic>{
+          'provider': provider,
+          'subs_id': subsId,
+        },
+      );
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
 }

--- a/services/service_bazarr/lib/src/bazarr_blacklist_tab.dart
+++ b/services/service_bazarr/lib/src/bazarr_blacklist_tab.dart
@@ -1,0 +1,140 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'bazarr_api.dart';
+import 'bazarr_providers.dart';
+import 'models/bazarr_models.dart';
+
+/// The Blacklist tab: subtitles that have been blacklisted (so Bazarr never
+/// re-downloads them), across episodes and movies, each removable.
+class BazarrBlacklistTab extends ConsumerWidget {
+  const BazarrBlacklistTab({required this.instance, super.key});
+
+  final Instance instance;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<List<BazarrBlacklistItem>> blacklist =
+        ref.watch(bazarrBlacklistProvider(instance));
+    return RefreshIndicator(
+      onRefresh: () async => ref.invalidate(bazarrBlacklistProvider(instance)),
+      child: AsyncValueView<List<BazarrBlacklistItem>>(
+        value: blacklist,
+        onRetry: () => ref.invalidate(bazarrBlacklistProvider(instance)),
+        data: (List<BazarrBlacklistItem> items) {
+          if (items.isEmpty) {
+            return const EmptyView(
+              icon: Icons.block,
+              title: 'Blacklist empty',
+              message: 'Blacklisted subtitles will appear here.',
+            );
+          }
+          return ListView.builder(
+            padding: Insets.pageH,
+            itemCount: items.length,
+            itemBuilder: (BuildContext context, int i) => _BlacklistTile(
+              instance: instance,
+              item: items[i],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _BlacklistTile extends ConsumerWidget {
+  const _BlacklistTile({required this.instance, required this.item});
+
+  final Instance instance;
+  final BazarrBlacklistItem item;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final String title = item.isMovie
+        ? item.title
+        : <String>[
+            item.seriesTitle,
+            if (item.episodeNumber.isNotEmpty) item.episodeNumber,
+          ].join(' · ');
+    final String lang = item.language?.code2.toUpperCase() ?? '';
+    final String detail = <String>[
+      if (lang.isNotEmpty) lang,
+      if (item.provider.isNotEmpty) item.provider,
+      if (item.timestamp.isNotEmpty) item.timestamp,
+    ].join(' · ');
+    return ListTile(
+      leading: const Icon(Icons.block),
+      title: Text(
+        title.isEmpty ? 'Unknown' : title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(detail, style: theme.textTheme.bodySmall),
+      trailing: IconButton(
+        tooltip: 'Remove from blacklist',
+        icon: const Icon(Icons.delete_outline),
+        onPressed: () => _confirmRemove(context, ref),
+      ),
+    );
+  }
+
+  Future<void> _confirmRemove(BuildContext context, WidgetRef ref) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: const Text('Remove from blacklist?'),
+        content: const Text(
+          'Bazarr will be allowed to download this subtitle again.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Remove'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) {
+      return;
+    }
+    try {
+      final BazarrApi api = await ref.read(bazarrApiProvider(instance).future);
+      if (item.isMovie) {
+        await api.removeMovieBlacklist(
+          provider: item.provider,
+          subsId: item.subsId,
+        );
+      } else {
+        await api.removeEpisodeBlacklist(
+          provider: item.provider,
+          subsId: item.subsId,
+        );
+      }
+      ref.invalidate(bazarrBlacklistProvider(instance));
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Removed from blacklist')),
+      );
+    } on Object catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Remove failed: ${_err(e)}')),
+      );
+    }
+  }
+}
+
+String _err(Object e) {
+  if (e is NetworkException && e.message.isNotEmpty) {
+    return e.message;
+  }
+  return 'request failed';
+}

--- a/services/service_bazarr/lib/src/bazarr_history_tab.dart
+++ b/services/service_bazarr/lib/src/bazarr_history_tab.dart
@@ -1,0 +1,95 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'bazarr_providers.dart';
+import 'models/bazarr_models.dart';
+
+/// The History tab: a unified, newest-first log of subtitle downloads,
+/// upgrades, and deletions across episodes and movies.
+class BazarrHistoryTab extends ConsumerWidget {
+  const BazarrHistoryTab({required this.instance, super.key});
+
+  final Instance instance;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<List<BazarrHistoryItem>> history =
+        ref.watch(bazarrHistoryProvider(instance));
+    return RefreshIndicator(
+      onRefresh: () async => ref.invalidate(bazarrHistoryProvider(instance)),
+      child: AsyncValueView<List<BazarrHistoryItem>>(
+        value: history,
+        onRetry: () => ref.invalidate(bazarrHistoryProvider(instance)),
+        data: (List<BazarrHistoryItem> items) {
+          if (items.isEmpty) {
+            return const EmptyView(
+              icon: Icons.history,
+              title: 'No history',
+              message: 'Subtitle downloads and changes will appear here.',
+            );
+          }
+          return ListView.builder(
+            padding: Insets.pageH,
+            itemCount: items.length,
+            itemBuilder: (BuildContext context, int i) =>
+                _HistoryTile(item: items[i]),
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _HistoryTile extends StatelessWidget {
+  const _HistoryTile({required this.item});
+
+  final BazarrHistoryItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String title = item.isMovie
+        ? item.title
+        : <String>[
+            item.seriesTitle,
+            if (item.episodeNumber.isNotEmpty) item.episodeNumber,
+          ].join(' · ');
+    final String detail = <String>[
+      if (item.description.isNotEmpty) item.description,
+      if (item.timestamp.isNotEmpty) item.timestamp,
+    ].join(' · ');
+    return ListTile(
+      contentPadding: const EdgeInsets.symmetric(vertical: 2),
+      leading: Icon(_icon(item.action)),
+      title: Text(
+        title.isEmpty ? 'Unknown' : title,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+      ),
+      subtitle: Text(
+        detail,
+        maxLines: 3,
+        style: theme.textTheme.bodySmall,
+      ),
+    );
+  }
+
+  // Bazarr history action codes: 0 deleted, 1 downloaded, 2 manually
+  // downloaded, 3 upgraded.
+  IconData _icon(int action) {
+    switch (action) {
+      case 0:
+        return Icons.delete_outline;
+      case 1:
+        return Icons.download_done;
+      case 2:
+        return Icons.download_outlined;
+      case 3:
+        return Icons.upgrade;
+      default:
+        return Icons.history;
+    }
+  }
+}

--- a/services/service_bazarr/lib/src/bazarr_home.dart
+++ b/services/service_bazarr/lib/src/bazarr_home.dart
@@ -1,13 +1,17 @@
 import 'package:core_models/core_models.dart';
 import 'package:flutter/material.dart';
 
+import 'bazarr_blacklist_tab.dart';
+import 'bazarr_history_tab.dart';
 import 'bazarr_movies_tab.dart';
 import 'bazarr_series_tab.dart';
 import 'bazarr_wanted_tab.dart';
 
-/// Bazarr's per-instance UI: a tabbed Series / Movies / Wanted view. Series and
-/// Movies browse Sonarr/Radarr-backed content with subtitle status; Wanted is
-/// the unified "missing subtitles" list with badge counts.
+/// Bazarr's per-instance UI: tabbed Series / Movies / Wanted / History /
+/// Blacklist. Series and Movies browse Sonarr/Radarr-backed content with
+/// subtitle status (and manual search, download, delete); Wanted lists what is
+/// still missing; History logs subtitle activity; Blacklist manages blocked
+/// subtitles.
 class BazarrHome extends StatefulWidget {
   const BazarrHome({required this.instance, super.key});
 
@@ -24,7 +28,7 @@ class _BazarrHomeState extends State<BazarrHome>
   @override
   void initState() {
     super.initState();
-    _tab = TabController(length: 3, vsync: this);
+    _tab = TabController(length: 5, vsync: this);
   }
 
   @override
@@ -40,10 +44,14 @@ class _BazarrHomeState extends State<BazarrHome>
         children: <Widget>[
           TabBar(
             controller: _tab,
+            isScrollable: true,
+            tabAlignment: TabAlignment.start,
             tabs: const <Widget>[
               Tab(text: 'Series'),
               Tab(text: 'Movies'),
               Tab(text: 'Wanted'),
+              Tab(text: 'History'),
+              Tab(text: 'Blacklist'),
             ],
           ),
           Expanded(
@@ -53,6 +61,8 @@ class _BazarrHomeState extends State<BazarrHome>
                 BazarrSeriesTab(instance: widget.instance),
                 BazarrMoviesTab(instance: widget.instance),
                 BazarrWantedTab(instance: widget.instance),
+                BazarrHistoryTab(instance: widget.instance),
+                BazarrBlacklistTab(instance: widget.instance),
               ],
             ),
           ),

--- a/services/service_bazarr/lib/src/bazarr_providers.dart
+++ b/services/service_bazarr/lib/src/bazarr_providers.dart
@@ -127,3 +127,71 @@ final bazarrMovieSearchProvider = FutureProvider.autoDispose
           await ref.watch(bazarrApiProvider(args.instance).future);
       return api.searchMovieSubtitles(args.id);
     });
+
+/// Unified subtitle history (episodes + movies), newest first.
+final bazarrHistoryProvider =
+    FutureProvider.family<List<BazarrHistoryItem>, Instance>((
+      Ref ref,
+      Instance instance,
+    ) async {
+      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+      final List<BazarrHistoryItem> eps = await api.getEpisodeHistory();
+      final List<BazarrHistoryItem> movies = await api.getMovieHistory();
+      final List<BazarrHistoryItem> all = <BazarrHistoryItem>[...eps, ...movies];
+      all.sort((BazarrHistoryItem a, BazarrHistoryItem b) {
+        final DateTime? da = _parseHistoryTs(a.parsedTimestamp);
+        final DateTime? db = _parseHistoryTs(b.parsedTimestamp);
+        if (da == null || db == null) {
+          return 0;
+        }
+        return db.compareTo(da);
+      });
+      return all;
+    });
+
+/// Unified blacklist (episodes + movies). The movies endpoint errors on some
+/// Bazarr versions, so it is tolerated independently of the episodes one.
+final bazarrBlacklistProvider =
+    FutureProvider.family<List<BazarrBlacklistItem>, Instance>((
+      Ref ref,
+      Instance instance,
+    ) async {
+      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+      final List<BazarrBlacklistItem> eps = await api.getEpisodeBlacklist();
+      List<BazarrBlacklistItem> movies = const <BazarrBlacklistItem>[];
+      try {
+        movies = await api.getMovieBlacklist();
+      } on Object catch (_) {
+        // Tolerate the movies-blacklist quirk; show episodes regardless.
+      }
+      return <BazarrBlacklistItem>[...eps, ...movies];
+    });
+
+/// Parses Bazarr's `parsed_timestamp` ("MM/DD/YY HH:MM:SS") for sorting.
+DateTime? _parseHistoryTs(String s) {
+  try {
+    final List<String> parts = s.trim().split(' ');
+    if (parts.length < 2) {
+      return null;
+    }
+    final List<String> d = parts[0].split('/');
+    final List<String> t = parts[1].split(':');
+    if (d.length < 3 || t.length < 3) {
+      return null;
+    }
+    int yy = int.parse(d[2]);
+    if (yy < 100) {
+      yy += 2000;
+    }
+    return DateTime(
+      yy,
+      int.parse(d[0]),
+      int.parse(d[1]),
+      int.parse(t[0]),
+      int.parse(t[1]),
+      int.parse(t[2]),
+    );
+  } on Object {
+    return null;
+  }
+}

--- a/services/service_bazarr/lib/src/models/bazarr_models.dart
+++ b/services/service_bazarr/lib/src/models/bazarr_models.dart
@@ -175,6 +175,56 @@ abstract class BazarrSubtitleSearchResult with _$BazarrSubtitleSearchResult {
       _$BazarrSubtitleSearchResultFromJson(json);
 }
 
+/// One entry from `GET /episodes/history` or `/movies/history`. [isMovie] is
+/// set by the client (not in the JSON) so the two can share a unified list.
+/// [action] is Bazarr's history action code (1 downloaded, 2 deleted,
+/// 3 upgraded, ...); [description] is the human-readable summary.
+@freezed
+abstract class BazarrHistoryItem with _$BazarrHistoryItem {
+  const factory BazarrHistoryItem({
+    @JsonKey(name: 'seriesTitle') @Default('') String seriesTitle,
+    @Default('') String title,
+    @JsonKey(name: 'episode_number') @Default('') String episodeNumber,
+    @JsonKey(name: 'episodeTitle') @Default('') String episodeTitle,
+    @Default('') String description,
+    @Default('') String timestamp,
+    @JsonKey(name: 'parsed_timestamp') @Default('') String parsedTimestamp,
+    @Default('') String provider,
+    @Default('') String score,
+    @Default(0) int action,
+    BazarrSubtitle? language,
+    @Default(false) bool blacklisted,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    @Default(false)
+    bool isMovie,
+  }) = _BazarrHistoryItem;
+
+  factory BazarrHistoryItem.fromJson(Map<String, dynamic> json) =>
+      _$BazarrHistoryItemFromJson(json);
+}
+
+/// One entry from `GET /episodes/blacklist` or `/movies/blacklist`. Removal
+/// (`DELETE`) is keyed by [provider] + [subsId]. [isMovie] is client-set.
+@freezed
+abstract class BazarrBlacklistItem with _$BazarrBlacklistItem {
+  const factory BazarrBlacklistItem({
+    @JsonKey(name: 'seriesTitle') @Default('') String seriesTitle,
+    @Default('') String title,
+    @JsonKey(name: 'episode_number') @Default('') String episodeNumber,
+    @Default('') String provider,
+    @JsonKey(name: 'subs_id') @Default('') String subsId,
+    @Default('') String timestamp,
+    @JsonKey(name: 'parsed_timestamp') @Default('') String parsedTimestamp,
+    BazarrSubtitle? language,
+    @JsonKey(includeFromJson: false, includeToJson: false)
+    @Default(false)
+    bool isMovie,
+  }) = _BazarrBlacklistItem;
+
+  factory BazarrBlacklistItem.fromJson(Map<String, dynamic> json) =>
+      _$BazarrBlacklistItemFromJson(json);
+}
+
 /// A flattened "needs subtitles" row, unifying episodes + movies for the UI.
 class BazarrWantedRow {
   const BazarrWantedRow({


### PR DESCRIPTION
P3 of the Bazarr depth work.

- **History** tab: a unified, newest-first log of subtitle downloads, manual downloads, upgrades, and deletions (episodes + movies) with per-action icons and relative timestamps.
- **Blacklist** tab: blocked subtitles, each removable. The movies endpoint is queried without paging to dodge a Bazarr 500.
- The home tab bar is now scrollable to fit five tabs (Series / Movies / Wanted / History / Blacklist).

New BazarrHistoryItem / BazarrBlacklistItem models and unified providers.

Verified live on the emulator; analyze clean; app render tests pass.
