### PR TITLE
feat(sonarr): redesign series details and add seasonal interactive search

### DIFF
--- a/packages/core_networking/lib/src/network_exception.dart
+++ b/packages/core_networking/lib/src/network_exception.dart
@@ -11,7 +11,8 @@ sealed class NetworkException implements Exception {
     return switch (e.type) {
       DioExceptionType.connectionTimeout ||
       DioExceptionType.sendTimeout ||
-      DioExceptionType.receiveTimeout =>
+      DioExceptionType.receiveTimeout ||
+      DioExceptionType.transformTimeout =>
         const NetworkTimeoutException('Server took too long to respond.'),
       DioExceptionType.connectionError =>
         NetworkUnreachableException(e.message ?? 'Could not reach the server.'),

--- a/services/service_sonarr/lib/service_sonarr.dart
+++ b/services/service_sonarr/lib/service_sonarr.dart
@@ -11,4 +11,5 @@ export 'src/sonarr_api.dart';
 export 'src/sonarr_home.dart';
 export 'src/sonarr_providers.dart';
 
-final sonarrActiveTabBarIndexProvider = StateProvider.family<int, Instance>((ref, instance) => 0);
+final sonarrActiveTabBarIndexProvider =
+    StateProvider.family<int, Instance>((ref, instance) => 0);

--- a/services/service_sonarr/lib/src/home/series_tab.dart
+++ b/services/service_sonarr/lib/src/home/series_tab.dart
@@ -25,7 +25,8 @@ class _SeriesTabState extends ConsumerState<SeriesTab> {
   @override
   void initState() {
     super.initState();
-    final String initialQuery = ref.read(sonarrSearchQueryProvider(widget.instance));
+    final String initialQuery =
+        ref.read(sonarrSearchQueryProvider(widget.instance));
     _searchController = TextEditingController(text: initialQuery);
     _scrollController = ScrollController();
     _searchFocusNode = FocusNode();
@@ -45,9 +46,11 @@ class _SeriesTabState extends ConsumerState<SeriesTab> {
     final AsyncValue<List<SonarrSeries>> filtered =
         ref.watch(sonarrFilteredSeriesProvider(widget.instance));
     final SonarrApi? api = ref.watch(sonarrApiProvider(widget.instance)).value;
-    final SonarrViewMode viewMode = ref.watch(sonarrViewModeProvider(widget.instance));
+    final SonarrViewMode viewMode =
+        ref.watch(sonarrViewModeProvider(widget.instance));
 
-    ref.listen<int>(sonarrSeriesScrollToTopProvider(widget.instance), (previous, next) {
+    ref.listen<int>(sonarrSeriesScrollToTopProvider(widget.instance),
+        (previous, next) {
       if (next > 0 && _scrollController.hasClients) {
         _scrollController.animateTo(
           0.0,
@@ -74,7 +77,8 @@ class _SeriesTabState extends ConsumerState<SeriesTab> {
         setState(() {
           _searchController.clear();
         });
-        ref.read(sonarrSearchQueryProvider(widget.instance).notifier).state = '';
+        ref.read(sonarrSearchQueryProvider(widget.instance).notifier).state =
+            '';
       },
       child: Scaffold(
         body: GestureDetector(
@@ -82,7 +86,8 @@ class _SeriesTabState extends ConsumerState<SeriesTab> {
           behavior: HitTestBehavior.translucent,
           child: AsyncValueView<List<SonarrSeries>>(
             value: filtered,
-            onRetry: () => ref.invalidate(sonarrSeriesProvider(widget.instance)),
+            onRetry: () =>
+                ref.invalidate(sonarrSeriesProvider(widget.instance)),
             data: (List<SonarrSeries> list) {
               return RefreshIndicator(
                 onRefresh: () async {
@@ -106,7 +111,8 @@ class _SeriesTabState extends ConsumerState<SeriesTab> {
                         icon: const Icon(Icons.menu),
                         onPressed: () {
                           ScaffoldMessenger.of(context).showSnackBar(
-                            const SnackBar(content: Text('Menu button pressed')),
+                            const SnackBar(
+                                content: Text('Menu button pressed')),
                           );
                         },
                       ),
@@ -126,110 +132,135 @@ class _SeriesTabState extends ConsumerState<SeriesTab> {
                                 setState(() {
                                   _searchController.clear();
                                 });
-                                ref.read(sonarrSearchQueryProvider(widget.instance).notifier).state = '';
+                                ref
+                                    .read(sonarrSearchQueryProvider(
+                                            widget.instance)
+                                        .notifier)
+                                    .state = '';
                               },
                             ),
                         ],
                         onChanged: (String value) {
                           setState(() {});
-                          ref.read(sonarrSearchQueryProvider(widget.instance).notifier).state = value;
+                          ref
+                              .read(sonarrSearchQueryProvider(widget.instance)
+                                  .notifier)
+                              .state = value;
                         },
                       ),
-                    actions: <Widget>[
-                      IconButton(
-                        icon: Icon(viewMode == SonarrViewMode.grid ? Icons.view_list : Icons.grid_view),
-                        tooltip: viewMode == SonarrViewMode.grid ? 'Switch to list view' : 'Switch to grid view',
-                        onPressed: () {
-                          ref.read(sonarrViewModeProvider(widget.instance).notifier).state =
-                              viewMode == SonarrViewMode.grid ? SonarrViewMode.list : SonarrViewMode.grid;
-                        },
-                      ),
-                      const SizedBox(width: Insets.sm),
-                    ],
-                  ),
-                  if (list.isEmpty)
-                    const SliverFillRemaining(
-                      hasScrollBody: false,
-                      child: EmptyView(
-                        icon: Icons.live_tv_outlined,
-                        title: 'No series found',
-                        message: 'Try adjusting your search query or active filters.',
-                      ),
-                    )
-                  else if (viewMode == SonarrViewMode.grid)
-                    SliverPadding(
-                      padding: const EdgeInsets.all(Insets.md),
-                      sliver: SliverGrid(
-                        gridDelegate: const SliverGridDelegateWithMaxCrossAxisExtent(
-                          maxCrossAxisExtent: 140,
-                          childAspectRatio: 0.5,
-                          crossAxisSpacing: Insets.md,
-                          mainAxisSpacing: Insets.md,
-                        ),
-                        delegate: SliverChildBuilderDelegate(
-                          (BuildContext context, int index) {
-                            final SonarrSeries s = list[index];
-                            final SonarrImage? poster = s.images
-                                .firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
-                            return _SeriesCard(
-                              series: s,
-                              imageUrl: poster == null ? null : api?.posterUrl(poster, width: 500),
-                              onTap: () {
-                                Navigator.push(
-                                  context,
-                                  FadePageRoute<void>(
-                                    builder: (BuildContext context) => SeriesDetailScreen(
-                                      instance: widget.instance,
-                                      seriesId: s.id,
-                                    ),
-                                  ),
-                                );
-                              },
-                            );
+                      actions: <Widget>[
+                        IconButton(
+                          icon: Icon(viewMode == SonarrViewMode.grid
+                              ? Icons.view_list
+                              : Icons.grid_view),
+                          tooltip: viewMode == SonarrViewMode.grid
+                              ? 'Switch to list view'
+                              : 'Switch to grid view',
+                          onPressed: () {
+                            ref
+                                .read(sonarrViewModeProvider(widget.instance)
+                                    .notifier)
+                                .state = viewMode ==
+                                    SonarrViewMode.grid
+                                ? SonarrViewMode.list
+                                : SonarrViewMode.grid;
                           },
-                          childCount: list.length,
                         ),
-                      ),
-                    )
-                  else
-                    SliverPadding(
-                      padding: const EdgeInsets.symmetric(horizontal: Insets.md),
-                      sliver: SliverList(
-                        delegate: SliverChildBuilderDelegate(
-                          (BuildContext context, int index) {
-                            final SonarrSeries s = list[index];
-                            return Padding(
-                              padding: const EdgeInsets.only(bottom: Insets.md),
-                              child: _SeriesBannerCard(
-                                instance: widget.instance,
+                        const SizedBox(width: Insets.sm),
+                      ],
+                    ),
+                    if (list.isEmpty)
+                      const SliverFillRemaining(
+                        hasScrollBody: false,
+                        child: EmptyView(
+                          icon: Icons.live_tv_outlined,
+                          title: 'No series found',
+                          message:
+                              'Try adjusting your search query or active filters.',
+                        ),
+                      )
+                    else if (viewMode == SonarrViewMode.grid)
+                      SliverPadding(
+                        padding: const EdgeInsets.all(Insets.md),
+                        sliver: SliverGrid(
+                          gridDelegate:
+                              const SliverGridDelegateWithMaxCrossAxisExtent(
+                            maxCrossAxisExtent: 140,
+                            childAspectRatio: 0.5,
+                            crossAxisSpacing: Insets.md,
+                            mainAxisSpacing: Insets.md,
+                          ),
+                          delegate: SliverChildBuilderDelegate(
+                            (BuildContext context, int index) {
+                              final SonarrSeries s = list[index];
+                              final SonarrImage? poster = s.images
+                                  .firstWhereOrNull((SonarrImage i) =>
+                                      i.coverType == 'poster');
+                              return _SeriesCard(
                                 series: s,
+                                imageUrl: poster == null
+                                    ? null
+                                    : api?.posterUrl(poster, width: 500),
                                 onTap: () {
                                   Navigator.push(
                                     context,
                                     FadePageRoute<void>(
-                                      builder: (BuildContext context) => SeriesDetailScreen(
+                                      builder: (BuildContext context) =>
+                                          SeriesDetailScreen(
                                         instance: widget.instance,
-                                        seriesId: s.id,
+                                        series: s,
                                       ),
                                     ),
                                   );
                                 },
-                              ),
-                            );
-                          },
-                          childCount: list.length,
+                              );
+                            },
+                            childCount: list.length,
+                          ),
+                        ),
+                      )
+                    else
+                      SliverPadding(
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: Insets.md),
+                        sliver: SliverList(
+                          delegate: SliverChildBuilderDelegate(
+                            (BuildContext context, int index) {
+                              final SonarrSeries s = list[index];
+                              return Padding(
+                                padding:
+                                    const EdgeInsets.only(bottom: Insets.md),
+                                child: _SeriesBannerCard(
+                                  instance: widget.instance,
+                                  series: s,
+                                  onTap: () {
+                                    Navigator.push(
+                                      context,
+                                      FadePageRoute<void>(
+                                        builder: (BuildContext context) =>
+                                            SeriesDetailScreen(
+                                          instance: widget.instance,
+                                          series: s,
+                                        ),
+                                      ),
+                                    );
+                                  },
+                                ),
+                              );
+                            },
+                            childCount: list.length,
+                          ),
                         ),
                       ),
-                    ),
-                ],
-              ),
-            );
-          },
+                  ],
+                ),
+              );
+            },
+          ),
         ),
       ),
-    ),
-  );
-}
+    );
+  }
 }
 
 class _SeriesCard extends StatelessWidget {
@@ -342,11 +373,12 @@ class _SeriesBannerCard extends ConsumerWidget {
 
     final SonarrImage? banner = series.images
         .firstWhereOrNull((SonarrImage i) => i.coverType == 'banner');
-    final String? bannerUrl = banner == null ? null : api?.posterUrl(banner, width: 70);
+    final String? bannerUrl = banner == null ? null : api?.posterUrl(banner);
 
     final SonarrImage? poster = series.images
         .firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
-    final String? posterUrl = poster == null ? null : api?.posterUrl(poster, width: 500);
+    final String? posterUrl =
+        poster == null ? null : api?.posterUrl(poster, width: 500);
 
     final Color surfaceColor = theme.colorScheme.surface;
 
@@ -366,15 +398,12 @@ class _SeriesBannerCard extends ConsumerWidget {
             children: <Widget>[
               if (bannerUrl != null)
                 Positioned.fill(
-                  child: Hero(
-                    tag: 'series-banner-${series.id}',
-                    child: CachedNetworkImage(
-                      imageUrl: bannerUrl,
-                      fit: BoxFit.cover,
-                      alignment: Alignment.centerRight,
-                      errorWidget: (_, __, ___) => Container(
-                        color: theme.colorScheme.surfaceContainerHighest,
-                      ),
+                  child: CachedNetworkImage(
+                    imageUrl: bannerUrl,
+                    fit: BoxFit.cover,
+                    alignment: Alignment.centerRight,
+                    errorWidget: (_, __, ___) => Container(
+                      color: theme.colorScheme.surfaceContainerHighest,
                     ),
                   ),
                 )
@@ -415,10 +444,12 @@ class _SeriesBannerCard extends ConsumerWidget {
                                 imageUrl: posterUrl,
                                 fit: BoxFit.cover,
                                 placeholder: (_, __) => Container(
-                                  color: theme.colorScheme.surfaceContainerHighest,
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
                                 ),
                                 errorWidget: (_, __, ___) => Container(
-                                  color: theme.colorScheme.surfaceContainerHighest,
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
                                   child: const Icon(Icons.live_tv, size: 20),
                                 ),
                               ),
@@ -468,7 +499,8 @@ class _SeriesBannerCard extends ConsumerWidget {
                       child: Container(
                         padding: const EdgeInsets.all(4),
                         decoration: BoxDecoration(
-                          color: theme.colorScheme.primary.withValues(alpha: 0.15),
+                          color:
+                              theme.colorScheme.primary.withValues(alpha: 0.15),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -541,9 +573,13 @@ class _Badge extends StatelessWidget {
 class FadePageRoute<T> extends PageRouteBuilder<T> {
   FadePageRoute({required WidgetBuilder builder, super.settings})
       : super(
-          pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) =>
+          pageBuilder: (BuildContext context, Animation<double> animation,
+                  Animation<double> secondaryAnimation) =>
               builder(context),
-          transitionsBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+          transitionsBuilder: (BuildContext context,
+              Animation<double> animation,
+              Animation<double> secondaryAnimation,
+              Widget child) {
             return FadeTransition(
               opacity: animation,
               child: child,

--- a/services/service_sonarr/lib/src/home/sonarr_rename_dialog.dart
+++ b/services/service_sonarr/lib/src/home/sonarr_rename_dialog.dart
@@ -1,0 +1,163 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../sonarr_providers.dart';
+
+class SonarrRenameDialog extends ConsumerStatefulWidget {
+  const SonarrRenameDialog({
+    required this.instance,
+    required this.seriesId,
+    super.key,
+  });
+
+  final Instance instance;
+  final int seriesId;
+
+  @override
+  ConsumerState<SonarrRenameDialog> createState() => _SonarrRenameDialogState();
+}
+
+class _SonarrRenameDialogState extends ConsumerState<SonarrRenameDialog> {
+  bool _renaming = false;
+
+  Future<void> _executeRename(List<int> fileIds) async {
+    setState(() => _renaming = true);
+    final api = await ref.read(sonarrApiProvider(widget.instance).future);
+
+    try {
+      await api.renameFiles(widget.seriesId, fileIds);
+      ref.invalidate(
+          sonarrSeriesByIdProvider((widget.instance, widget.seriesId)));
+      ref.invalidate(
+          sonarrEpisodesProvider((widget.instance, widget.seriesId)));
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Files renamed successfully!')),
+        );
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Rename failed: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _renaming = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final previewAsync = ref
+        .watch(sonarrRenamePreviewProvider((widget.instance, widget.seriesId)));
+    final ThemeData theme = Theme.of(context);
+    final colors = theme.colorScheme;
+
+    return AlertDialog(
+      title: const Text('Rename Files'),
+      content: SizedBox(
+        width: double.maxFinite,
+        height: 350,
+        child: previewAsync.when(
+          loading: () => const Center(child: CircularProgressIndicator()),
+          error: (err, stack) =>
+              Center(child: Text('Error loading rename preview: $err')),
+          data: (files) {
+            if (files.isEmpty) {
+              return const Center(
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.check_circle_outline,
+                        color: Colors.green, size: 48),
+                    SizedBox(height: Insets.sm),
+                    Text(
+                      'All files are correctly named.',
+                      textAlign: TextAlign.center,
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return ListView.builder(
+              itemCount: files.length,
+              itemBuilder: (context, index) {
+                final f = files[index];
+                final current =
+                    (f['existingPath'] as String?)?.split('/').last ??
+                        'Unknown Name';
+                final proposed = (f['newPath'] as String?)?.split('/').last ??
+                    'Unknown Name';
+
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: Insets.md),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Season ${f['seasonNumber'] ?? '?'} • Episode ${(f['episodeNumbers'] as List?)?.first ?? '?'}',
+                        style: theme.textTheme.labelMedium?.copyWith(
+                          color: colors.primary,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      const SizedBox(height: 4),
+                      Text(
+                        current,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: colors.error,
+                          decoration: TextDecoration.lineThrough,
+                        ),
+                      ),
+                      const SizedBox(height: 2),
+                      Text(
+                        proposed,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: Colors.green,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ),
+                );
+              },
+            );
+          },
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: _renaming ? null : () => Navigator.pop(context),
+          child: const Text('Cancel'),
+        ),
+        previewAsync.maybeWhen(
+          data: (files) => files.isEmpty
+              ? const SizedBox.shrink()
+              : ElevatedButton(
+                  onPressed: _renaming
+                      ? null
+                      : () {
+                          final List<int> ids = files
+                              .map((f) => f['episodeFileId'] as int)
+                              .toList();
+                          _executeRename(ids);
+                        },
+                  child: _renaming
+                      ? const SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Rename'),
+                ),
+          orElse: () => const SizedBox.shrink(),
+        ),
+      ],
+    );
+  }
+}

--- a/services/service_sonarr/lib/src/models/sonarr_episode.dart
+++ b/services/service_sonarr/lib/src/models/sonarr_episode.dart
@@ -18,6 +18,7 @@ abstract class SonarrEpisode with _$SonarrEpisode {
     String? airDateUtc,
     int? runtime,
     int? absoluteEpisodeNumber,
+    int? episodeFileId,
   }) = _SonarrEpisode;
 
   factory SonarrEpisode.fromJson(Map<String, dynamic> json) =>

--- a/services/service_sonarr/lib/src/models/sonarr_series.dart
+++ b/services/service_sonarr/lib/src/models/sonarr_series.dart
@@ -17,6 +17,13 @@ abstract class SonarrSeries with _$SonarrSeries {
     @Default(<SonarrImage>[]) List<SonarrImage> images,
     @Default(<SonarrSeason>[]) List<SonarrSeason> seasons,
     SonarrSeriesStatistics? statistics,
+    String? seriesType,
+    int? runtime,
+    String? certification,
+    @Default(<String>[]) List<String> genres,
+    String? path,
+    String? nextAiring,
+    String? previousAiring,
   }) = _SonarrSeries;
 
   factory SonarrSeries.fromJson(Map<String, dynamic> json) =>

--- a/services/service_sonarr/lib/src/series_detail_screen.dart
+++ b/services/service_sonarr/lib/src/series_detail_screen.dart
@@ -5,375 +5,236 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import 'home/sonarr_rename_dialog.dart';
 import 'models/sonarr_episode.dart';
 import 'models/sonarr_series.dart';
 import 'sonarr_api.dart';
 import 'sonarr_providers.dart';
+import 'sonarr_release_search_screen.dart';
+import 'sonarr_settings_form_screen.dart';
 
 class SeriesDetailScreen extends ConsumerWidget {
   const SeriesDetailScreen({
     required this.instance,
-    required this.seriesId,
+    required this.series,
     super.key,
   });
 
   final Instance instance;
-  final int seriesId;
+  final SonarrSeries series;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<SonarrSeries> seriesAsync =
-        ref.watch(sonarrSeriesByIdProvider((instance, seriesId)));
+        ref.watch(sonarrSeriesByIdProvider((instance, series.id)));
     final AsyncValue<List<SonarrEpisode>> episodesAsync =
-        ref.watch(sonarrEpisodesProvider((instance, seriesId)));
+        ref.watch(sonarrEpisodesProvider((instance, series.id)));
+
+    final SonarrSeries activeSeries = seriesAsync.value ?? series;
 
     return Scaffold(
-      body: AsyncValueView<SonarrSeries>(
-        value: seriesAsync,
-        onRetry: () => ref.invalidate(sonarrSeriesByIdProvider((instance, seriesId))),
-        data: (SonarrSeries series) {
-          return AsyncValueView<List<SonarrEpisode>>(
-            value: episodesAsync,
-            onRetry: () => ref.invalidate(sonarrEpisodesProvider((instance, seriesId))),
-            data: (List<SonarrEpisode> episodes) {
-              return _SeriesDetailBody(
-                instance: instance,
-                series: series,
-                episodes: episodes,
-              );
-            },
-          );
-        },
+      body: _SeriesDetailBody(
+        instance: instance,
+        series: activeSeries,
+        episodesAsync: episodesAsync,
       ),
     );
   }
 }
+
+// ---------------------------------------------------------------------------
+// Main body
+// ---------------------------------------------------------------------------
 
 class _SeriesDetailBody extends ConsumerWidget {
   const _SeriesDetailBody({
     required this.instance,
     required this.series,
-    required this.episodes,
+    required this.episodesAsync,
   });
 
   final Instance instance;
   final SonarrSeries series;
-  final List<SonarrEpisode> episodes;
+  final AsyncValue<List<SonarrEpisode>> episodesAsync;
 
-  void _refresh(WidgetRef ref) {
+  Future<void> _refresh(BuildContext context, WidgetRef ref) async {
+    try {
+      final api = await ref.read(sonarrApiProvider(instance).future);
+      await api.runCommand(<String, dynamic>{
+        'name': 'RefreshSeries',
+        'seriesId': series.id,
+      });
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to refresh: $e')),
+        );
+      }
+    } finally {
+      _invalidateProviders(ref);
+    }
+  }
+
+  void _invalidateProviders(WidgetRef ref) {
     ref.invalidate(sonarrSeriesByIdProvider((instance, series.id)));
     ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
     ref.invalidate(sonarrSeriesProvider(instance));
   }
 
-  String _formatSize(int bytes) {
-    if (bytes <= 0) return '0 B';
-    const suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
-    var i = 0;
-    double size = bytes.toDouble();
-    while (size >= 1024 && i < suffixes.length - 1) {
-      size /= 1024;
-      i++;
-    }
-    return '${size.toStringAsFixed(1)} ${suffixes[i]}';
-  }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
     final SonarrApi? api = ref.watch(sonarrApiProvider(instance)).value;
 
     final SonarrImage? poster = series.images
         .firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
-    final String? posterUrl = poster == null ? null : api?.posterUrl(poster, width: 500);
+    final String? posterUrl =
+        poster == null ? null : api?.posterUrl(poster, width: 500);
 
-    final SonarrImage? fanart = series.images
-        .firstWhereOrNull((SonarrImage i) => i.coverType == 'fanart') ??
-        series.images.firstWhereOrNull((SonarrImage i) => i.coverType == 'banner');
-    final String? fanartUrl = fanart == null ? null : api?.posterUrl(fanart);
+    final int downloadedCount = series.statistics?.episodeFileCount ?? 0;
+    final int totalEpisodes = series.statistics?.episodeCount ?? 0;
 
-    final Map<int, List<SonarrEpisode>> episodesBySeason = groupBy(episodes, (e) => e.seasonNumber);
-    final List<int> sortedSeasons = episodesBySeason.keys.toList()..sort();
-
-    final int downloadedEpisodesCount = episodes.where((e) => e.hasFile).length;
-
-    return Stack(
-      children: <Widget>[
-        // Enhanced Backdrop fanart image stacked in background
-        if (fanartUrl != null)
-          Positioned(
-            top: 0,
-            left: 0,
-            right: 0,
-            height: 400,
-            child: Hero(
-              tag: 'series-banner-${series.id}',
-              child: ShaderMask(
-                shaderCallback: (Rect bounds) {
-                  return LinearGradient(
-                    begin: Alignment.topCenter,
-                    end: Alignment.bottomCenter,
-                    colors: <Color>[
-                      Colors.black,
-                      Colors.black.withValues(alpha: 0.1),
-                      Colors.transparent,
-                    ],
-                    stops: const <double>[0.0, 0.6, 1.0],
-                  ).createShader(bounds);
-                },
-                blendMode: BlendMode.dstIn,
-                child: CachedNetworkImage(
-                  imageUrl: fanartUrl,
-                  fit: BoxFit.cover,
-                ),
-              ),
+    return RefreshIndicator(
+      onRefresh: () => _refresh(context, ref),
+      child: CustomScrollView(
+        slivers: <Widget>[
+          // -- AppBar --
+          SliverAppBar(
+            pinned: true,
+            title: Text(
+              series.title,
+              style: const TextStyle(fontWeight: FontWeight.w600),
             ),
+            actions: <Widget>[
+              _OverflowMenu(
+                instance: instance,
+                series: series,
+                onRefreshed: () => _invalidateProviders(ref),
+              ),
+            ],
           ),
 
-        // Scrollable content on top of background
-        Scaffold(
-          backgroundColor: Colors.transparent,
-          body: RefreshIndicator(
-            onRefresh: () async => _refresh(ref),
-            child: CustomScrollView(
-              slivers: <Widget>[
-                const SliverAppBar(
-                  pinned: true,
-                  backgroundColor: Colors.transparent,
-                  elevation: 0,
-                  scrolledUnderElevation: 0,
-                  surfaceTintColor: Colors.transparent,
+          // -- Content --
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(
+              Insets.lg,
+              Insets.sm,
+              Insets.lg,
+              Insets.xl,
+            ),
+            sliver: SliverList.list(
+              children: <Widget>[
+                // Hero info card
+                _HeroInfoCard(
+                  series: series,
+                  posterUrl: posterUrl,
                 ),
-                SliverPadding(
-                  padding: const EdgeInsets.symmetric(horizontal: Insets.md),
-                  sliver: SliverList(
-                    delegate: SliverChildListDelegate([
-                      const SizedBox(height: 120),
-                      // Full Title wrapping naturally
-                      Text(
-                        series.title,
-                        style: theme.textTheme.headlineMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                          color: Colors.white,
-                          shadows: <Shadow>[
-                            Shadow(
-                              color: Colors.black.withValues(alpha: 0.7),
-                              offset: const Offset(0, 2),
-                              blurRadius: 4,
+
+                const SizedBox(height: Insets.lg),
+
+                // Stats card with progress bar
+                _StatsCard(
+                  downloadedCount: downloadedCount,
+                  totalEpisodes: totalEpisodes,
+                  sizeOnDisk: series.statistics?.sizeOnDisk ?? 0,
+                ),
+
+                const SizedBox(height: Insets.lg),
+
+                // Action buttons row
+                _ActionsRow(
+                  instance: instance,
+                  series: series,
+                  onRefreshed: () => _invalidateProviders(ref),
+                ),
+
+                // Genre chips
+                if (series.genres.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: Insets.lg),
+                  Wrap(
+                    spacing: Insets.sm,
+                    runSpacing: Insets.sm,
+                    children: series.genres
+                        .map(
+                          (String g) => Chip(
+                            label: Text(g),
+                            backgroundColor: cs.tertiaryContainer,
+                            labelStyle: TextStyle(
+                              color: cs.onTertiaryContainer,
+                              fontSize: 12,
+                            ),
+                            side: BorderSide.none,
+                            visualDensity: VisualDensity.compact,
+                            padding: EdgeInsets.zero,
+                          ),
+                        )
+                        .toList(),
+                  ),
+                ],
+
+                // Overview
+                if (series.overview != null &&
+                    series.overview!.isNotEmpty) ...<Widget>[
+                  const SizedBox(height: Insets.lg),
+                  _OverviewSection(overview: series.overview!),
+                ],
+
+                // Info section (path, next airing)
+                if (series.path != null ||
+                    series.nextAiring != null) ...<Widget>[
+                  const SizedBox(height: Insets.lg),
+                  _InfoSection(series: series),
+                ],
+
+                const SizedBox(height: Insets.xl),
+
+                // Season & Episodes header
+                Text(
+                  'Seasons & Episodes',
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: Insets.md),
+
+                // Episodes content
+                ...episodesAsync.when(
+                  data: (List<SonarrEpisode> episodes) =>
+                      _buildSeasonCards(context, ref, episodes),
+                  loading: () => <Widget>[
+                    const Center(
+                      child: Padding(
+                        padding: EdgeInsets.symmetric(vertical: Insets.xl),
+                        child: CircularProgressIndicator(),
+                      ),
+                    ),
+                  ],
+                  error: (error, stack) => <Widget>[
+                    Center(
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.symmetric(vertical: Insets.xl),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: <Widget>[
+                            Text(
+                              'Failed to load episodes.',
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: cs.error,
+                              ),
+                            ),
+                            const SizedBox(height: Insets.sm),
+                            FilledButton.tonal(
+                              onPressed: () => ref.invalidate(
+                                sonarrEpisodesProvider((instance, series.id)),
+                              ),
+                              child: const Text('Retry'),
                             ),
                           ],
                         ),
                       ),
-                      const SizedBox(height: Insets.md),
-
-                      _Header(
-                        series: series,
-                        posterUrl: posterUrl,
-                        downloadedCount: downloadedEpisodesCount,
-                        totalEpisodes: episodes.length,
-                        formattedSize: _formatSize(series.statistics?.sizeOnDisk ?? 0),
-                      ),
-                      if (series.overview != null && series.overview!.isNotEmpty) ...[
-                        const SizedBox(height: Insets.md),
-                        _OverviewCard(overview: series.overview!),
-                      ],
-                      const SizedBox(height: Insets.lg),
-                      Text(
-                        'Seasons & Episodes',
-                        style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-                      ),
-                      const SizedBox(height: Insets.sm),
-                      ...sortedSeasons.map((seasonNum) {
-                        final List<SonarrEpisode> seasonEpisodes = episodesBySeason[seasonNum]!
-                          ..sort((a, b) => a.episodeNumber.compareTo(b.episodeNumber));
-                        final int seasonDownloaded = seasonEpisodes.where((e) => e.hasFile).length;
-
-                        return Card(
-                          margin: const EdgeInsets.only(bottom: Insets.sm),
-                          clipBehavior: Clip.antiAlias,
-                          color: theme.colorScheme.surfaceContainerHigh,
-                          elevation: 0,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(12),
-                          ),
-                          child: ExpansionTile(
-                            shape: const Border(),
-                            title: Text(
-                              seasonNum == 0 ? 'Specials' : 'Season $seasonNum',
-                              style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
-                            ),
-                            subtitle: Text(
-                              '$seasonDownloaded / ${seasonEpisodes.length} downloaded',
-                              style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.outline),
-                            ),
-                            children: seasonEpisodes.map((episode) {
-                              final String airDateStr = episode.airDate ?? 'Unknown Air Date';
-                              return ListTile(
-                                contentPadding: const EdgeInsets.symmetric(horizontal: Insets.md),
-                                leading: Icon(
-                                  episode.hasFile
-                                      ? Icons.check_circle
-                                      : Icons.radio_button_unchecked,
-                                  color: episode.hasFile
-                                      ? Colors.green
-                                      : theme.colorScheme.outline,
-                                  size: 20,
-                                ),
-                                title: Text(
-                                  'E${episode.episodeNumber.toString().padLeft(2, '0')}: ${episode.title}',
-                                  style: theme.textTheme.bodyMedium?.copyWith(
-                                    fontWeight: FontWeight.w500,
-                                  ),
-                                ),
-                                subtitle: Text(
-                                  airDateStr,
-                                  style: theme.textTheme.bodySmall?.copyWith(
-                                    color: theme.colorScheme.outline,
-                                  ),
-                                ),
-                                trailing: Icon(
-                                  episode.monitored
-                                      ? Icons.bookmark
-                                      : Icons.bookmark_border,
-                                  color: episode.monitored
-                                      ? theme.colorScheme.primary
-                                      : theme.colorScheme.outline,
-                                  size: 18,
-                                ),
-                              );
-                            }).toList(),
-                          ),
-                        );
-                      }),
-                      const SizedBox(height: Insets.xl),
-                    ]),
-                  ),
-                ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _Header extends StatelessWidget {
-  const _Header({
-    required this.series,
-    required this.posterUrl,
-    required this.downloadedCount,
-    required this.totalEpisodes,
-    required this.formattedSize,
-  });
-
-  final SonarrSeries series;
-  final String? posterUrl;
-  final int downloadedCount;
-  final int totalEpisodes;
-  final String formattedSize;
-
-  Color _statusColor(String? status, ThemeData theme) {
-    if (status == null) return theme.colorScheme.outline;
-    if (status.toLowerCase() == 'continuing') return Colors.green;
-    return theme.colorScheme.outline;
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
-
-    return Container(
-      decoration: BoxDecoration(
-        color: isDark
-            ? theme.colorScheme.surfaceContainerLow.withValues(alpha: 0.65)
-            : theme.colorScheme.surfaceContainerLowest.withValues(alpha: 0.75),
-        borderRadius: BorderRadius.circular(16),
-        border: Border.all(
-          color: theme.colorScheme.outlineVariant.withValues(alpha: 0.4),
-        ),
-      ),
-      padding: const EdgeInsets.all(Insets.md),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          if (posterUrl != null)
-            Hero(
-              tag: 'series-poster-${series.id}',
-              child: ClipRRect(
-                borderRadius: BorderRadius.circular(8),
-                child: SizedBox(
-                  width: 80,
-                  height: 120,
-                  child: CachedNetworkImage(
-                    imageUrl: posterUrl!,
-                    fit: BoxFit.cover,
-                  ),
-                ),
-              ),
-            )
-          else
-            Container(
-              width: 80,
-              height: 120,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainerHighest,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              child: const Icon(Icons.live_tv, size: 24),
-            ),
-          const SizedBox(width: Insets.md),
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Row(
-                  children: [
-                    Container(
-                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
-                      decoration: BoxDecoration(
-                        color: _statusColor(series.status, theme).withValues(alpha: 0.15),
-                        borderRadius: BorderRadius.circular(4),
-                        border: Border.all(
-                          color: _statusColor(series.status, theme).withValues(alpha: 0.5),
-                        ),
-                      ),
-                      child: Text(
-                        series.status ?? 'Unknown',
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: _statusColor(series.status, theme),
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
                     ),
-                    const SizedBox(width: Insets.xs),
-                    if (series.monitored)
-                      Icon(
-                        Icons.bookmark,
-                        size: 16,
-                        color: theme.colorScheme.primary,
-                      ),
                   ],
-                ),
-                const SizedBox(height: Insets.xs),
-                Text(
-                  '${series.year ?? 'Unknown'} • ${series.network ?? 'Unknown'}',
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    color: theme.colorScheme.outline,
-                  ),
-                ),
-                const SizedBox(height: Insets.xs),
-                Text(
-                  '$downloadedCount / $totalEpisodes episodes',
-                  style: theme.textTheme.bodyMedium,
-                ),
-                const SizedBox(height: Insets.xs),
-                Text(
-                  'Size on disk: $formattedSize',
-                  style: theme.textTheme.bodySmall?.copyWith(
-                    color: theme.colorScheme.outline,
-                  ),
                 ),
               ],
             ),
@@ -382,42 +243,1227 @@ class _Header extends StatelessWidget {
       ),
     );
   }
+
+  List<Widget> _buildSeasonCards(
+    BuildContext context,
+    WidgetRef ref,
+    List<SonarrEpisode> episodes,
+  ) {
+    final Map<int, List<SonarrEpisode>> episodesBySeason =
+        groupBy(episodes, (e) => e.seasonNumber);
+    final List<int> sortedSeasons = episodesBySeason.keys.toList()
+      ..sort((a, b) => b.compareTo(a)); // newest first
+
+    return sortedSeasons.map((int seasonNum) {
+      final List<SonarrEpisode> seasonEpisodes = episodesBySeason[seasonNum]!
+        ..sort((a, b) => b.episodeNumber.compareTo(a.episodeNumber));
+
+      // Get per-season stats from the series model if available
+      final SonarrSeason? seasonMeta =
+          series.seasons.firstWhereOrNull((s) => s.seasonNumber == seasonNum);
+
+      return Padding(
+        padding: const EdgeInsets.only(bottom: Insets.md),
+        child: _SeasonCard(
+          instance: instance,
+          series: series,
+          seasonNumber: seasonNum,
+          episodes: seasonEpisodes,
+          seasonMeta: seasonMeta,
+          onRefreshed: () => _refresh,
+        ),
+      );
+    }).toList();
+  }
 }
 
-class _OverviewCard extends StatelessWidget {
-  const _OverviewCard({required this.overview});
+// ---------------------------------------------------------------------------
+// Hero Info Card — poster + metadata on a tinted surface
+// ---------------------------------------------------------------------------
 
-  final String overview;
+class _HeroInfoCard extends StatelessWidget {
+  const _HeroInfoCard({required this.series, required this.posterUrl});
+
+  final SonarrSeries series;
+  final String? posterUrl;
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    return Card(
-      margin: EdgeInsets.zero,
-      color: theme.colorScheme.surfaceContainerHigh,
-      elevation: 0,
-      shape: RoundedRectangleBorder(
-        borderRadius: BorderRadius.circular(12),
+    final ColorScheme cs = theme.colorScheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.primaryContainer.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(Radii.xl),
       ),
-      child: Padding(
-        padding: const EdgeInsets.all(Insets.md),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Text(
-              'Overview',
-              style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
-            ),
-            const SizedBox(height: Insets.xs),
-            Text(
-              overview,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+      padding: const EdgeInsets.all(Insets.lg),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          // Poster
+          Hero(
+            tag: 'series-poster-${series.id}',
+            child: Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(Radii.md),
+                boxShadow: <BoxShadow>[
+                  BoxShadow(
+                    color: Colors.black.withValues(alpha: 0.15),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
               ),
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(Radii.md),
+                child: SizedBox(
+                  width: 110,
+                  height: 165,
+                  child: posterUrl != null
+                      ? CachedNetworkImage(
+                          imageUrl: posterUrl!,
+                          fit: BoxFit.cover,
+                          memCacheWidth: 500,
+                          placeholder: (_, __) => Container(
+                            color: cs.surfaceContainerHighest,
+                            child: const Center(
+                              child: SizedBox(
+                                width: 24,
+                                height: 24,
+                                child:
+                                    CircularProgressIndicator(strokeWidth: 2),
+                              ),
+                            ),
+                          ),
+                          errorWidget: (_, __, ___) => Container(
+                            color: cs.surfaceContainerHighest,
+                            child: Icon(
+                              Icons.live_tv,
+                              color: cs.outline,
+                              size: 32,
+                            ),
+                          ),
+                        )
+                      : Container(
+                          color: cs.surfaceContainerHighest,
+                          child:
+                              Icon(Icons.live_tv, color: cs.outline, size: 32),
+                        ),
+                ),
+              ),
+            ),
+          ),
+
+          const SizedBox(width: Insets.lg),
+
+          // Metadata column
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                // Title
+                Text(
+                  series.title,
+                  style: theme.textTheme.titleLarge
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: Insets.sm),
+
+                // Info chips row
+                Wrap(
+                  spacing: Insets.xs,
+                  runSpacing: Insets.xs,
+                  children: <Widget>[
+                    if (series.year != null) _MetaChip(label: '${series.year}'),
+                    if (series.network != null)
+                      _MetaChip(label: series.network!),
+                    if (series.runtime != null && series.runtime! > 0)
+                      _MetaChip(label: '${series.runtime} min'),
+                    if (series.certification != null &&
+                        series.certification!.isNotEmpty)
+                      _MetaChip(label: series.certification!),
+                    if (series.seriesType != null)
+                      _MetaChip(label: _capitalise(series.seriesType!)),
+                  ],
+                ),
+
+                const SizedBox(height: Insets.md),
+
+                // Status pill
+                _StatusPill(status: series.status),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _capitalise(String s) =>
+      s.isEmpty ? s : s[0].toUpperCase() + s.substring(1);
+}
+
+// ---------------------------------------------------------------------------
+// Stats Card — progress bar + numbers
+// ---------------------------------------------------------------------------
+
+class _StatsCard extends StatelessWidget {
+  const _StatsCard({
+    required this.downloadedCount,
+    required this.totalEpisodes,
+    required this.sizeOnDisk,
+  });
+
+  final int downloadedCount;
+  final int totalEpisodes;
+  final int sizeOnDisk;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final double progress =
+        totalEpisodes > 0 ? downloadedCount / totalEpisodes : 0.0;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: cs.secondaryContainer.withValues(alpha: 0.3),
+        borderRadius: BorderRadius.circular(Radii.lg),
+      ),
+      padding: const EdgeInsets.all(Insets.lg),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Icon(Icons.tv, size: 18, color: cs.onSecondaryContainer),
+              const SizedBox(width: Insets.xs),
+              Text(
+                '$downloadedCount of $totalEpisodes episodes',
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: cs.onSecondaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              Icon(Icons.storage, size: 18, color: cs.onSecondaryContainer),
+              const SizedBox(width: Insets.xs),
+              Text(
+                _formatSize(sizeOnDisk),
+                style: theme.textTheme.labelLarge?.copyWith(
+                  color: cs.onSecondaryContainer,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: Insets.md),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(Radii.sm),
+            child: LinearProgressIndicator(
+              value: progress,
+              minHeight: 8,
+              backgroundColor: cs.surfaceContainerHighest,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                progress >= 1.0 ? Colors.green : cs.primary,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Actions Row — pill-shaped tonal buttons
+// ---------------------------------------------------------------------------
+
+class _ActionsRow extends ConsumerWidget {
+  const _ActionsRow({
+    required this.instance,
+    required this.series,
+    required this.onRefreshed,
+  });
+
+  final Instance instance;
+  final SonarrSeries series;
+  final VoidCallback onRefreshed;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Row(
+      children: <Widget>[
+        // Monitor toggle
+        Expanded(
+          child: series.monitored
+              ? FilledButton.tonalIcon(
+                  style: FilledButton.styleFrom(
+                    backgroundColor: cs.secondaryContainer,
+                    foregroundColor: cs.onSecondaryContainer,
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    shape: const StadiumBorder(),
+                  ),
+                  icon: const Icon(Icons.bookmark, size: 20),
+                  label: const Text(
+                    'Monitored',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  onPressed: () => _toggleMonitored(context, ref),
+                )
+              : OutlinedButton.icon(
+                  style: OutlinedButton.styleFrom(
+                    padding: const EdgeInsets.symmetric(vertical: 12),
+                    side: BorderSide(color: cs.outline),
+                    shape: const StadiumBorder(),
+                  ),
+                  icon: const Icon(Icons.bookmark_border, size: 20),
+                  label: const Text('Unmonitored'),
+                  onPressed: () => _toggleMonitored(context, ref),
+                ),
+        ),
+
+        const SizedBox(width: Insets.sm),
+
+        // Search button
+        Expanded(
+          child: FilledButton.icon(
+            style: FilledButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 12),
+              shape: const StadiumBorder(),
+            ),
+            icon: const Icon(Icons.search, size: 20),
+            label: const Text(
+              'Search',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            onPressed: () => _searchSeries(context, ref),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _toggleMonitored(BuildContext context, WidgetRef ref) async {
+    final api = await ref.read(sonarrApiProvider(instance).future);
+    try {
+      final raw = await api.getSeriesRaw(series.id);
+      raw['monitored'] = !series.monitored;
+      await api.updateSeriesRaw(raw);
+      onRefreshed();
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to toggle monitored: $e')),
+        );
+      }
+    }
+  }
+
+  Future<void> _searchSeries(BuildContext context, WidgetRef ref) async {
+    final api = await ref.read(sonarrApiProvider(instance).future);
+    try {
+      await api.runCommand(<String, dynamic>{
+        'name': 'SeriesSearch',
+        'seriesId': series.id,
+      });
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Search started for series.')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to trigger search: $e')),
+        );
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Overview Section — expandable synopsis
+// ---------------------------------------------------------------------------
+
+class _OverviewSection extends StatefulWidget {
+  const _OverviewSection({required this.overview});
+
+  final String overview;
+
+  @override
+  State<_OverviewSection> createState() => _OverviewSectionState();
+}
+
+class _OverviewSectionState extends State<_OverviewSection> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(Insets.lg),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(Radii.lg),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            'Overview',
+            style: theme.textTheme.titleSmall
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(height: Insets.sm),
+          AnimatedCrossFade(
+            firstChild: Text(
+              widget.overview,
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: cs.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            secondChild: Text(
+              widget.overview,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: cs.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            crossFadeState: _expanded
+                ? CrossFadeState.showSecond
+                : CrossFadeState.showFirst,
+            duration: const Duration(milliseconds: 250),
+          ),
+          if (widget.overview.length > 150) ...<Widget>[
+            const SizedBox(height: Insets.xs),
+            GestureDetector(
+              onTap: () => setState(() => _expanded = !_expanded),
+              child: Text(
+                _expanded ? 'Show less' : 'Show more',
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: cs.primary,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Info Section — path, next airing
+// ---------------------------------------------------------------------------
+
+class _InfoSection extends StatelessWidget {
+  const _InfoSection({required this.series});
+
+  final SonarrSeries series;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(Insets.lg),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(Radii.lg),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          if (series.path != null) ...<Widget>[
+            _InfoRow(
+              icon: Icons.folder_outlined,
+              label: 'Path',
+              value: series.path!,
+            ),
+          ],
+          if (series.nextAiring != null) ...<Widget>[
+            if (series.path != null) const SizedBox(height: Insets.sm),
+            _InfoRow(
+              icon: Icons.schedule,
+              label: 'Next Airing',
+              value: _formatDateTime(series.nextAiring!),
+            ),
+          ],
+          if (series.previousAiring != null) ...<Widget>[
+            const SizedBox(height: Insets.sm),
+            _InfoRow(
+              icon: Icons.history,
+              label: 'Previous Airing',
+              value: _formatDateTime(series.previousAiring!),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  static String _formatDateTime(String isoDate) {
+    try {
+      final DateTime dt = DateTime.parse(isoDate).toLocal();
+      return '${dt.year}-${dt.month.toString().padLeft(2, '0')}-${dt.day.toString().padLeft(2, '0')}';
+    } catch (_) {
+      return isoDate;
+    }
+  }
+}
+
+class _InfoRow extends StatelessWidget {
+  const _InfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Icon(icon, size: 16, color: cs.outline),
+        const SizedBox(width: Insets.sm),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: cs.outline,
+                ),
+              ),
+              Text(
+                value,
+                style: theme.textTheme.bodySmall,
+                maxLines: 2,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Season Card — expandable card with progress bar
+// ---------------------------------------------------------------------------
+
+class _SeasonCard extends ConsumerStatefulWidget {
+  const _SeasonCard({
+    required this.instance,
+    required this.series,
+    required this.seasonNumber,
+    required this.episodes,
+    required this.seasonMeta,
+    required this.onRefreshed,
+  });
+
+  final Instance instance;
+  final SonarrSeries series;
+  final int seasonNumber;
+  final List<SonarrEpisode> episodes;
+  final SonarrSeason? seasonMeta;
+  final VoidCallback onRefreshed;
+
+  @override
+  ConsumerState<_SeasonCard> createState() => _SeasonCardState();
+}
+
+class _SeasonCardState extends ConsumerState<_SeasonCard> {
+  bool _expanded = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    final int downloaded = widget.episodes.where((e) => e.hasFile).length;
+    final int total = widget.episodes.length;
+    final double progress = total > 0 ? downloaded / total : 0.0;
+    final bool isMonitored = widget.seasonMeta?.monitored ?? false;
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerLow,
+        borderRadius: BorderRadius.circular(Radii.lg),
+        border: Border.all(
+          color: cs.outlineVariant.withValues(alpha: 0.3),
+        ),
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        children: <Widget>[
+          // Header
+          InkWell(
+            onTap: () => setState(() => _expanded = !_expanded),
+            borderRadius: BorderRadius.circular(Radii.lg),
+            child: Padding(
+              padding: const EdgeInsets.fromLTRB(
+                Insets.lg,
+                Insets.md,
+                Insets.sm,
+                Insets.md,
+              ),
+              child: Row(
+                children: <Widget>[
+                  // Monitor indicator
+                  Icon(
+                    isMonitored ? Icons.bookmark : Icons.bookmark_border,
+                    size: 18,
+                    color: isMonitored ? cs.primary : cs.outline,
+                  ),
+                  const SizedBox(width: Insets.sm),
+
+                  // Season title
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          widget.seasonNumber == 0
+                              ? 'Specials'
+                              : 'Season ${widget.seasonNumber}',
+                          style: theme.textTheme.titleSmall
+                              ?.copyWith(fontWeight: FontWeight.bold),
+                        ),
+                        const SizedBox(height: 2),
+                        Row(
+                          children: <Widget>[
+                            // Progress bar (inline)
+                            Expanded(
+                              child: ClipRRect(
+                                borderRadius: BorderRadius.circular(4),
+                                child: LinearProgressIndicator(
+                                  value: progress,
+                                  minHeight: 4,
+                                  backgroundColor: cs.surfaceContainerHighest,
+                                  valueColor: AlwaysStoppedAnimation<Color>(
+                                    progress >= 1.0 ? Colors.green : cs.primary,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            const SizedBox(width: Insets.sm),
+                            Text(
+                              '$downloaded/$total',
+                              style: theme.textTheme.labelSmall?.copyWith(
+                                color: cs.outline,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+
+                  // Search season (automatic)
+                  IconButton(
+                    icon: const Icon(Icons.search, size: 20),
+                    tooltip: 'Automatic Search',
+                    onPressed: () =>
+                        _searchSeason(context, widget.seasonNumber),
+                    visualDensity: VisualDensity.compact,
+                  ),
+
+                  // Search season (interactive)
+                  IconButton(
+                    icon: const Icon(Icons.person_search, size: 20),
+                    tooltip: 'Interactive Search',
+                    onPressed: () => _openSeasonInteractiveSearch(
+                      context,
+                      widget.seasonNumber,
+                    ),
+                    visualDensity: VisualDensity.compact,
+                  ),
+
+                  // Expand indicator
+                  AnimatedRotation(
+                    turns: _expanded ? 0.5 : 0,
+                    duration: const Duration(milliseconds: 200),
+                    child: const Icon(Icons.expand_more, size: 24),
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          // Episode list
+          AnimatedCrossFade(
+            firstChild: const SizedBox(width: double.infinity, height: 0),
+            secondChild: Column(
+              children: <Widget>[
+                Divider(
+                  height: 1,
+                  color: cs.outlineVariant.withValues(alpha: 0.3),
+                ),
+                ...widget.episodes.map(
+                  (SonarrEpisode episode) => _EpisodeRow(
+                    instance: widget.instance,
+                    series: widget.series,
+                    episode: episode,
+                  ),
+                ),
+              ],
+            ),
+            crossFadeState: _expanded
+                ? CrossFadeState.showSecond
+                : CrossFadeState.showFirst,
+            duration: const Duration(milliseconds: 250),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _searchSeason(BuildContext context, int seasonNum) async {
+    final api = await ref.read(sonarrApiProvider(widget.instance).future);
+    try {
+      await api.runCommand(<String, dynamic>{
+        'name': 'SeasonSearch',
+        'seriesId': widget.series.id,
+        'seasonNumber': seasonNum,
+      });
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Search queued for Season $seasonNum.')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed: $e')),
+        );
+      }
+    }
+  }
+
+  void _openSeasonInteractiveSearch(BuildContext context, int seasonNum) {
+    Navigator.push(
+      context,
+      MaterialPageRoute<void>(
+        builder: (_) => SonarrReleaseSearchScreen(
+          instance: widget.instance,
+          series: widget.series,
+          seasonNumber: seasonNum,
+        ),
+      ),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Episode Row — clean row with popup menu
+// ---------------------------------------------------------------------------
+
+class _EpisodeRow extends ConsumerWidget {
+  const _EpisodeRow({
+    required this.instance,
+    required this.series,
+    required this.episode,
+  });
+
+  final Instance instance;
+  final SonarrSeries series;
+  final SonarrEpisode episode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    final Color statusColor =
+        episode.hasFile ? Colors.green : cs.outlineVariant;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Insets.lg,
+        vertical: Insets.sm,
+      ),
+      child: Row(
+        children: <Widget>[
+          // Episode number circle
+          Container(
+            width: 32,
+            height: 32,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: episode.hasFile
+                  ? Colors.green.withValues(alpha: 0.15)
+                  : cs.surfaceContainerHighest,
+              border: Border.all(color: statusColor, width: 1.5),
+            ),
+            child: Center(
+              child: Text(
+                '${episode.episodeNumber}',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: episode.hasFile ? Colors.green : cs.outline,
+                ),
+              ),
+            ),
+          ),
+
+          const SizedBox(width: Insets.md),
+
+          // Title + air date
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  episode.title,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                if (episode.airDate != null)
+                  Text(
+                    episode.airDate!,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: cs.outline,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+
+          // Monitored indicator
+          Icon(
+            episode.monitored ? Icons.bookmark : Icons.bookmark_border,
+            size: 16,
+            color: episode.monitored ? cs.primary : cs.outline,
+          ),
+
+          // Popup menu
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert, size: 20),
+            padding: EdgeInsets.zero,
+            onSelected: (String action) => _handleAction(context, ref, action),
+            itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+              PopupMenuItem<String>(
+                value: 'monitor',
+                child: ListTile(
+                  leading: Icon(
+                    episode.monitored
+                        ? Icons.bookmark_remove
+                        : Icons.bookmark_add,
+                  ),
+                  title: Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+              const PopupMenuItem<String>(
+                value: 'auto_search',
+                child: ListTile(
+                  leading: Icon(Icons.search),
+                  title: Text('Automatic Search'),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+              const PopupMenuItem<String>(
+                value: 'manual_search',
+                child: ListTile(
+                  leading: Icon(Icons.manage_search),
+                  title: Text('Interactive Search'),
+                  contentPadding: EdgeInsets.zero,
+                  dense: true,
+                ),
+              ),
+              if (episode.hasFile && episode.episodeFileId != null)
+                const PopupMenuItem<String>(
+                  value: 'delete_file',
+                  child: ListTile(
+                    leading: Icon(Icons.delete_outline, color: Colors.red),
+                    title: Text(
+                      'Delete File',
+                      style: TextStyle(color: Colors.red),
+                    ),
+                    contentPadding: EdgeInsets.zero,
+                    dense: true,
+                  ),
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleAction(
+    BuildContext context,
+    WidgetRef ref,
+    String action,
+  ) async {
+    final api = await ref.read(sonarrApiProvider(instance).future);
+
+    switch (action) {
+      case 'monitor':
+        try {
+          final updated = episode.copyWith(monitored: !episode.monitored);
+          await api.updateEpisode(updated.toJson());
+          ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+        } catch (e) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Failed: $e')),
+            );
+          }
+        }
+
+      case 'auto_search':
+        try {
+          await api.runCommand(<String, dynamic>{
+            'name': 'EpisodeSearch',
+            'episodeIds': [episode.id],
+          });
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Automatic search queued.')),
+            );
+          }
+        } catch (e) {
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text('Failed: $e')),
+            );
+          }
+        }
+
+      case 'manual_search':
+        if (context.mounted) {
+          await Navigator.push(
+            context,
+            MaterialPageRoute<void>(
+              builder: (_) => SonarrReleaseSearchScreen(
+                instance: instance,
+                episode: episode,
+              ),
+            ),
+          );
+        }
+
+      case 'delete_file':
+        if (context.mounted) {
+          await _confirmDeleteFile(context, ref);
+        }
+    }
+  }
+
+  Future<void> _confirmDeleteFile(BuildContext context, WidgetRef ref) async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Episode File'),
+        content: const Text(
+          'Are you sure? This will delete the file from disk and cannot be undone.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(context).colorScheme.error,
+              foregroundColor: Theme.of(context).colorScheme.onError,
+            ),
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true && episode.episodeFileId != null) {
+      final api = await ref.read(sonarrApiProvider(instance).future);
+      try {
+        await api.deleteEpisodeFile(episode.episodeFileId!);
+        ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('File deleted.')),
+          );
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Failed to delete: $e')),
+          );
+        }
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Overflow Menu — edit, rename, delete
+// ---------------------------------------------------------------------------
+
+class _OverflowMenu extends ConsumerWidget {
+  const _OverflowMenu({
+    required this.instance,
+    required this.series,
+    required this.onRefreshed,
+  });
+
+  final Instance instance;
+  final SonarrSeries series;
+  final VoidCallback onRefreshed;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return PopupMenuButton<String>(
+      onSelected: (String value) => _handleAction(context, ref, value),
+      itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
+        const PopupMenuItem<String>(
+          value: 'edit',
+          child: ListTile(
+            leading: Icon(Icons.edit_outlined),
+            title: Text('Edit Series'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'rename',
+          child: ListTile(
+            leading: Icon(Icons.drive_file_rename_outline),
+            title: Text('Rename Files'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuDivider(),
+        PopupMenuItem<String>(
+          value: 'delete',
+          child: ListTile(
+            leading: Icon(
+              Icons.delete_outline,
+              color: Theme.of(context).colorScheme.error,
+            ),
+            title: Text(
+              'Delete Series',
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
+            ),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _handleAction(BuildContext context, WidgetRef ref, String action) {
+    switch (action) {
+      case 'edit':
+        Navigator.push(
+          context,
+          MaterialPageRoute<void>(
+            builder: (_) => SonarrSettingsFormScreen(
+              instance: instance,
+              series: series,
+            ),
+          ),
+        );
+
+      case 'rename':
+        showDialog<void>(
+          context: context,
+          builder: (_) => SonarrRenameDialog(
+            instance: instance,
+            seriesId: series.id,
+          ),
+        );
+
+      case 'delete':
+        _confirmDelete(context, ref);
+    }
+  }
+
+  Future<void> _confirmDelete(BuildContext context, WidgetRef ref) async {
+    bool deleteFiles = false;
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => StatefulBuilder(
+        builder: (BuildContext ctx, StateSetter setState) => AlertDialog(
+          title: const Text('Delete Series'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text('Are you sure you want to delete "${series.title}"?'),
+              const SizedBox(height: Insets.md),
+              CheckboxListTile(
+                title: const Text(
+                  'Delete files from disk',
+                  style: TextStyle(fontSize: 14),
+                ),
+                dense: true,
+                contentPadding: EdgeInsets.zero,
+                value: deleteFiles,
+                onChanged: (val) {
+                  if (val != null) setState(() => deleteFiles = val);
+                },
+              ),
+            ],
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: Theme.of(ctx).colorScheme.error,
+                foregroundColor: Theme.of(ctx).colorScheme.onError,
+              ),
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Delete'),
             ),
           ],
         ),
       ),
     );
+
+    if (ok == true) {
+      final api = await ref.read(sonarrApiProvider(instance).future);
+      try {
+        await api.deleteSeries(series.id, deleteFiles: deleteFiles);
+        ref.invalidate(sonarrSeriesProvider(instance));
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Series deleted.')),
+          );
+          Navigator.pop(context);
+        }
+      } catch (e) {
+        if (context.mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Failed to delete: $e')),
+          );
+        }
+      }
+    }
   }
+}
+
+// ---------------------------------------------------------------------------
+// Small reusable widgets
+// ---------------------------------------------------------------------------
+
+class _MetaChip extends StatelessWidget {
+  const _MetaChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+      decoration: BoxDecoration(
+        color: cs.outlineVariant.withValues(alpha: 0.25),
+        borderRadius: BorderRadius.circular(Radii.xl),
+      ),
+      child: Text(
+        label,
+        style: theme.textTheme.labelSmall?.copyWith(
+          color: cs.onSurfaceVariant,
+          fontWeight: FontWeight.w500,
+        ),
+      ),
+    );
+  }
+}
+
+class _StatusPill extends StatelessWidget {
+  const _StatusPill({required this.status});
+
+  final String? status;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final bool isContinuing = status?.toLowerCase() == 'continuing';
+    final Color tint = isContinuing ? Colors.green : theme.colorScheme.outline;
+    final String label = status ?? 'Unknown';
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      decoration: BoxDecoration(
+        color: tint.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(Radii.xl),
+        border: Border.all(color: tint.withValues(alpha: 0.25)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Container(
+            width: 8,
+            height: 8,
+            decoration: BoxDecoration(
+              shape: BoxShape.circle,
+              color: tint,
+            ),
+          ),
+          const SizedBox(width: 6),
+          Text(
+            _capitalise(label),
+            style: theme.textTheme.labelSmall?.copyWith(
+              color: tint,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static String _capitalise(String s) =>
+      s.isEmpty ? s : s[0].toUpperCase() + s.substring(1);
+}
+
+String _formatSize(int bytes) {
+  if (bytes <= 0) return '0 B';
+  const suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+  var i = 0;
+  double size = bytes.toDouble();
+  while (size >= 1024 && i < suffixes.length - 1) {
+    size /= 1024;
+    i++;
+  }
+  return '${size.toStringAsFixed(1)} ${suffixes[i]}';
 }

--- a/services/service_sonarr/lib/src/sonarr_api.dart
+++ b/services/service_sonarr/lib/src/sonarr_api.dart
@@ -28,7 +28,8 @@ class SonarrApi {
 
   Future<SonarrSeries> getSeriesById(int id) async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/series/$id');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/series/$id');
       return SonarrSeries.fromJson(resp.data as Map<String, dynamic>);
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -92,12 +93,14 @@ class SonarrApi {
     if (remote != null && remote.isNotEmpty) {
       final Uri base = Uri.parse(_dio.options.baseUrl);
       String pathOrUrl = remote;
-      
+
       if (width != null) {
         final int queryIdx = pathOrUrl.indexOf('?');
-        final String pathPart = queryIdx == -1 ? pathOrUrl : pathOrUrl.substring(0, queryIdx);
-        final String queryPart = queryIdx == -1 ? '' : pathOrUrl.substring(queryIdx);
-        
+        final String pathPart =
+            queryIdx == -1 ? pathOrUrl : pathOrUrl.substring(0, queryIdx);
+        final String queryPart =
+            queryIdx == -1 ? '' : pathOrUrl.substring(queryIdx);
+
         final int dotIdx = pathPart.lastIndexOf('.');
         if (dotIdx != -1) {
           final String basePart = pathPart.substring(0, dotIdx);
@@ -107,11 +110,121 @@ class SonarrApi {
       }
 
       if (pathOrUrl.startsWith('/MediaCover/')) {
-        pathOrUrl = '$_base/mediacover${pathOrUrl.substring('/MediaCover'.length)}';
+        pathOrUrl =
+            '$_base/mediacover${pathOrUrl.substring('/MediaCover'.length)}';
       }
       final String separator = pathOrUrl.contains('?') ? '&' : '?';
       return base.resolve('$pathOrUrl${separator}apikey=$apiKey').toString();
     }
     return upstream;
+  }
+
+  Future<void> runCommand(Map<String, dynamic> body) async {
+    try {
+      await _dio.post<dynamic>('$_base/command', data: body);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getRenamePreview(int seriesId) async {
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>(
+        '$_base/rename',
+        queryParameters: <String, dynamic>{'seriesId': seriesId},
+      );
+      return (resp.data as List<dynamic>)
+          .map((dynamic e) => e as Map<String, dynamic>)
+          .toList();
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<void> renameFiles(int seriesId, List<int> fileIds) async {
+    try {
+      await runCommand(<String, dynamic>{
+        'name': 'RenameFiles',
+        'seriesId': seriesId,
+        'files': fileIds,
+      });
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getReleases({
+    int? episodeId,
+    int? seriesId,
+    int? seasonNumber,
+  }) async {
+    try {
+      final Map<String, dynamic> qParams = <String, dynamic>{};
+      if (episodeId != null) {
+        qParams['episodeId'] = episodeId;
+      }
+      if (seriesId != null) {
+        qParams['seriesId'] = seriesId;
+      }
+      if (seasonNumber != null) {
+        qParams['seasonNumber'] = seasonNumber;
+      }
+      final Response<dynamic> resp = await _dio.get<dynamic>(
+        '$_base/release',
+        queryParameters: qParams,
+      );
+      return (resp.data as List<dynamic>)
+          .map((dynamic e) => e as Map<String, dynamic>)
+          .toList();
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<void> downloadRelease(Map<String, dynamic> release) async {
+    try {
+      await _dio.post<dynamic>('$_base/release', data: release);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<void> deleteEpisodeFile(int fileId) async {
+    try {
+      await _dio.delete<dynamic>('$_base/episodefile/$fileId');
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<void> updateEpisode(Map<String, dynamic> episode) async {
+    try {
+      await _dio.put<dynamic>('$_base/episode/${episode['id']}', data: episode);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getQualityProfiles() async {
+    try {
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/qualityprofile');
+      return (resp.data as List<dynamic>)
+          .map((dynamic e) => e as Map<String, dynamic>)
+          .toList();
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getTags() async {
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/tag');
+      return (resp.data as List<dynamic>)
+          .map((dynamic e) => e as Map<String, dynamic>)
+          .toList();
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
   }
 }

--- a/services/service_sonarr/lib/src/sonarr_home.dart
+++ b/services/service_sonarr/lib/src/sonarr_home.dart
@@ -11,7 +11,7 @@ import 'home/wanted_tab.dart';
 
 class SonarrHome extends ConsumerWidget {
   const SonarrHome({required this.instance, this.onEdit, super.key});
-  
+
   final Instance instance;
   final VoidCallback? onEdit;
 
@@ -32,9 +32,11 @@ class SonarrHome extends ConsumerWidget {
       onNotification: (UserScrollNotification notification) {
         final ScrollDirection direction = notification.direction;
         if (direction == ScrollDirection.reverse) {
-          ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state = false;
+          ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
+              false;
         } else if (direction == ScrollDirection.forward) {
-          ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state = true;
+          ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
+              true;
         }
         return false;
       },
@@ -54,9 +56,15 @@ class SonarrHome extends ConsumerWidget {
                 selectedIndex: currentIndex,
                 onDestinationSelected: (index) {
                   if (index == 0 && currentIndex == 0) {
-                    ref.read(sonarrSeriesScrollToTopProvider(instance).notifier).update((state) => state + 1);
+                    ref
+                        .read(
+                            sonarrSeriesScrollToTopProvider(instance).notifier)
+                        .update((state) => state + 1);
                   } else {
-                    ref.read(sonarrActiveTabBarIndexProvider(instance).notifier).state = index;
+                    ref
+                        .read(
+                            sonarrActiveTabBarIndexProvider(instance).notifier)
+                        .state = index;
                   }
                 },
                 destinations: const [

--- a/services/service_sonarr/lib/src/sonarr_providers.dart
+++ b/services/service_sonarr/lib/src/sonarr_providers.dart
@@ -11,73 +11,74 @@ import 'sonarr_api.dart';
 const Duration sonarrLibraryPollInterval = Duration(seconds: 60);
 
 /// A [SonarrApi] bound to a specific instance.
-final sonarrApiProvider =
-    FutureProvider.family<SonarrApi, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      final String? apiKey = switch (instance.auth) {
-        InstanceAuthApiKey(:final String apiKey) => apiKey,
-        _ => null,
-      };
-      return SonarrApi(dio, apiKey: apiKey);
-    });
+final sonarrApiProvider = FutureProvider.family<SonarrApi, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  final String? apiKey = switch (instance.auth) {
+    InstanceAuthApiKey(:final String apiKey) => apiKey,
+    _ => null,
+  };
+  return SonarrApi(dio, apiKey: apiKey);
+});
 
 /// All series for an instance, sorted by title. Polls slowly while watched.
 final sonarrSeriesProvider =
     FutureProvider.autoDispose.family<List<SonarrSeries>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(sonarrLibraryPollInterval);
-      final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
-      final List<SonarrSeries> series = await api.getSeries();
-      series.sort(
-        (SonarrSeries a, SonarrSeries b) =>
-            a.title.toLowerCase().compareTo(b.title.toLowerCase()),
-      );
-      return series;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(sonarrLibraryPollInterval);
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  final List<SonarrSeries> series = await api.getSeries();
+  series.sort(
+    (SonarrSeries a, SonarrSeries b) =>
+        a.title.toLowerCase().compareTo(b.title.toLowerCase()),
+  );
+  return series;
+});
 
 /// One series by id. Refreshed on demand.
 final sonarrSeriesByIdProvider =
     FutureProvider.autoDispose.family<SonarrSeries, (Instance, int)>((
-      Ref ref,
-      (Instance, int) key,
-    ) async {
-      final (Instance instance, int id) = key;
-      final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
-      return api.getSeriesById(id);
-    });
+  Ref ref,
+  (Instance, int) key,
+) async {
+  final (Instance instance, int id) = key;
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  return api.getSeriesById(id);
+});
 
 /// Active layout view mode for the series tab (grid or list).
 enum SonarrViewMode { grid, list }
 
 /// Persistent view mode preference for Sonarr series.
-final sonarrViewModeProvider =
-    StateProvider.family<SonarrViewMode, Instance>((ref, instance) => SonarrViewMode.grid);
+final sonarrViewModeProvider = StateProvider.family<SonarrViewMode, Instance>(
+    (ref, instance) => SonarrViewMode.grid);
 
 /// Search query string for Sonarr series.
 final sonarrSearchQueryProvider =
     StateProvider.family<String, Instance>((ref, instance) => '');
 
 /// Dynamic filtered series provider based on active search query.
-final sonarrFilteredSeriesProvider =
-    Provider.autoDispose.family<AsyncValue<List<SonarrSeries>>, Instance>((ref, instance) {
-      final String query = ref.watch(sonarrSearchQueryProvider(instance));
-      final AsyncValue<List<SonarrSeries>> seriesAsync = ref.watch(sonarrSeriesProvider(instance));
+final sonarrFilteredSeriesProvider = Provider.autoDispose
+    .family<AsyncValue<List<SonarrSeries>>, Instance>((ref, instance) {
+  final String query = ref.watch(sonarrSearchQueryProvider(instance));
+  final AsyncValue<List<SonarrSeries>> seriesAsync =
+      ref.watch(sonarrSeriesProvider(instance));
 
-      return seriesAsync.whenData((List<SonarrSeries> list) {
-        if (query.isEmpty) {
-          return list;
-        }
-        final String lowercaseQuery = query.toLowerCase();
-        return list
-            .where((SonarrSeries s) => s.title.toLowerCase().contains(lowercaseQuery))
-            .toList();
-      });
-    });
+  return seriesAsync.whenData((List<SonarrSeries> list) {
+    if (query.isEmpty) {
+      return list;
+    }
+    final String lowercaseQuery = query.toLowerCase();
+    return list
+        .where(
+            (SonarrSeries s) => s.title.toLowerCase().contains(lowercaseQuery))
+        .toList();
+  });
+});
 
 /// Manages visibility of the Sonarr bottom navigation bar.
 final sonarrBottomNavVisibleProvider =
@@ -98,3 +99,55 @@ final sonarrEpisodesProvider =
   return api.getEpisodes(seriesId);
 });
 
+/// All releases for an episode (interactive search).
+final sonarrReleasesProvider = FutureProvider.autoDispose
+    .family<List<Map<String, dynamic>>, (Instance, int)>((
+  Ref ref,
+  (Instance, int) key,
+) async {
+  final (Instance instance, int episodeId) = key;
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  return api.getReleases(episodeId: episodeId);
+});
+
+/// All releases for a season (interactive search).
+final sonarrSeasonReleasesProvider = FutureProvider.autoDispose
+    .family<List<Map<String, dynamic>>, (Instance, int, int)>((
+  Ref ref,
+  (Instance, int, int) key,
+) async {
+  final (Instance instance, int seriesId, int seasonNumber) = key;
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  return api.getReleases(seriesId: seriesId, seasonNumber: seasonNumber);
+});
+
+/// Rename preview files for a series.
+final sonarrRenamePreviewProvider = FutureProvider.autoDispose
+    .family<List<Map<String, dynamic>>, (Instance, int)>((
+  Ref ref,
+  (Instance, int) key,
+) async {
+  final (Instance instance, int seriesId) = key;
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  return api.getRenamePreview(seriesId);
+});
+
+/// All quality profiles for an instance.
+final sonarrQualityProfilesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  return api.getQualityProfiles();
+});
+
+/// All tags for an instance.
+final sonarrTagsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
+  return api.getTags();
+});

--- a/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
@@ -1,0 +1,707 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models/sonarr_episode.dart';
+import 'models/sonarr_series.dart';
+import 'sonarr_providers.dart';
+
+class SonarrReleaseSearchScreen extends ConsumerStatefulWidget {
+  const SonarrReleaseSearchScreen({
+    required this.instance,
+    this.episode,
+    this.series,
+    this.seasonNumber,
+    super.key,
+  }) : assert(episode != null || (series != null && seasonNumber != null));
+
+  final Instance instance;
+  final SonarrEpisode? episode;
+  final SonarrSeries? series;
+  final int? seasonNumber;
+
+  @override
+  ConsumerState<SonarrReleaseSearchScreen> createState() =>
+      _SonarrReleaseSearchScreenState();
+}
+
+class _ScrollBehavior extends ScrollBehavior {
+  @override
+  Widget buildScrollbar(
+    BuildContext context,
+    Widget child,
+    ScrollableDetails details,
+  ) {
+    return child;
+  }
+}
+
+class _SonarrReleaseSearchScreenState
+    extends ConsumerState<SonarrReleaseSearchScreen> {
+  final TextEditingController _searchController = TextEditingController();
+  String _searchQuery = '';
+  String _selectedProtocol = 'All'; // 'All', 'Torrent', 'Usenet'
+  bool _approvedOnly = false;
+  String _sortBy = 'Age'; // 'Age', 'Size', 'Seeders'
+  bool _sortAscending = true;
+  final Map<String, bool> _downloadingMap = {};
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  double _getAgeMinutes(Map<String, dynamic> r) {
+    if (r['ageMinutes'] != null) return (r['ageMinutes'] as num).toDouble();
+    if (r['ageHours'] != null) return (r['ageHours'] as num).toDouble() * 60;
+    if (r['age'] != null) return (r['age'] as num).toDouble() * 1440;
+    return double.maxFinite;
+  }
+
+  String _formatAge(Map<String, dynamic> r) {
+    final double mins = _getAgeMinutes(r);
+    if (mins == double.maxFinite) return 'Unknown age';
+    if (mins < 60) return '${mins.toStringAsFixed(0)}m';
+    final double hours = mins / 60;
+    if (hours < 24) return '${hours.toStringAsFixed(0)}h';
+    final double days = hours / 24;
+    return '${days.toStringAsFixed(0)}d';
+  }
+
+  String _formatSize(int bytes) {
+    if (bytes <= 0) return '0 B';
+    const suffixes = ['B', 'KB', 'MB', 'GB', 'TB'];
+    var i = 0;
+    double size = bytes.toDouble();
+    while (size >= 1024 && i < suffixes.length - 1) {
+      size /= 1024;
+      i++;
+    }
+    return '${size.toStringAsFixed(1)} ${suffixes[i]}';
+  }
+
+  Future<void> _download(
+    Map<String, dynamic> release, {
+    bool bypassWarnings = false,
+  }) async {
+    final String guid =
+        (release['guid'] as String?) ?? release['title'] as String;
+    final rejections =
+        List<String>.from((release['rejections'] as Iterable?) ?? <String>[]);
+
+    if (rejections.isNotEmpty && !bypassWarnings) {
+      final bool? proceed = await showDialog<bool>(
+        context: context,
+        builder: (ctx) => AlertDialog(
+          title: const Row(
+            children: [
+              Icon(Icons.warning_amber_rounded, color: Colors.orange),
+              SizedBox(width: Insets.sm),
+              Text('Rejection Warnings'),
+            ],
+          ),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              const Text(
+                'This release has warnings / rejections:',
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: Insets.sm),
+              ...rejections.map(
+                (r) => Padding(
+                  padding: const EdgeInsets.only(bottom: 4.0),
+                  child: Text('• $r', style: const TextStyle(fontSize: 13)),
+                ),
+              ),
+              const SizedBox(height: Insets.md),
+              const Text('Are you sure you want to download it anyway?'),
+            ],
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(ctx, false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.pop(ctx, true),
+              child: const Text('Proceed Download'),
+            ),
+          ],
+        ),
+      );
+      if (proceed != true) return;
+    }
+
+    setState(() => _downloadingMap[guid] = true);
+    final api = await ref.read(sonarrApiProvider(widget.instance).future);
+
+    try {
+      await api.downloadRelease(release);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Release grabbed successfully!')),
+        );
+        final int seriesId = widget.episode?.seriesId ?? widget.series!.id;
+        ref.invalidate(sonarrEpisodesProvider((widget.instance, seriesId)));
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to grab release: $e')),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _downloadingMap[guid] = false);
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<List<Map<String, dynamic>>> releasesValue =
+        widget.episode != null
+            ? ref.watch(
+                sonarrReleasesProvider((widget.instance, widget.episode!.id)),
+              )
+            : ref.watch(
+                sonarrSeasonReleasesProvider(
+                  (widget.instance, widget.series!.id, widget.seasonNumber!),
+                ),
+              );
+
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme colors = theme.colorScheme;
+
+    final String titleText = widget.episode != null
+        ? 'Interactive Episode Search'
+        : 'Interactive Season Search';
+
+    final String subtitleText = widget.episode != null
+        ? 'E${widget.episode!.episodeNumber.toString().padLeft(2, '0')}: ${widget.episode!.title}'
+        : 'Season ${widget.seasonNumber}';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(titleText),
+            Text(
+              subtitleText,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: colors.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+      body: Column(
+        children: <Widget>[
+          // Search & Filter header panel (M3 style)
+          Card(
+            margin: const EdgeInsets.all(Insets.md),
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(Radii.lg),
+              side: BorderSide(
+                color: colors.outlineVariant.withValues(alpha: 0.3),
+              ),
+            ),
+            color: colors.surfaceContainerLow,
+            child: Padding(
+              padding: const EdgeInsets.all(Insets.md),
+              child: Column(
+                children: <Widget>[
+                  TextField(
+                    controller: _searchController,
+                    decoration: InputDecoration(
+                      hintText: 'Filter by title or indexer...',
+                      prefixIcon: const Icon(Icons.search),
+                      suffixIcon: _searchQuery.isNotEmpty
+                          ? IconButton(
+                              icon: const Icon(Icons.clear),
+                              onPressed: () {
+                                _searchController.clear();
+                                setState(() => _searchQuery = '');
+                              },
+                            )
+                          : null,
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(Radii.md),
+                        borderSide: BorderSide.none,
+                      ),
+                      filled: true,
+                      fillColor:
+                          colors.surfaceContainerHighest.withValues(alpha: 0.5),
+                      contentPadding: const EdgeInsets.symmetric(
+                        horizontal: Insets.md,
+                        vertical: Insets.sm,
+                      ),
+                    ),
+                    onChanged: (String val) =>
+                        setState(() => _searchQuery = val),
+                  ),
+                  const SizedBox(height: Insets.md),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: DropdownButtonFormField<String>(
+                          initialValue: _selectedProtocol,
+                          decoration: InputDecoration(
+                            labelText: 'Protocol',
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 8,
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(Radii.md),
+                            ),
+                          ),
+                          items: const [
+                            DropdownMenuItem(value: 'All', child: Text('All')),
+                            DropdownMenuItem(
+                              value: 'Torrent',
+                              child: Text('Torrent'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'Usenet',
+                              child: Text('Usenet'),
+                            ),
+                          ],
+                          onChanged: (val) {
+                            if (val != null) {
+                              setState(() => _selectedProtocol = val);
+                            }
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: Insets.sm),
+                      Expanded(
+                        child: DropdownButtonFormField<String>(
+                          initialValue: _sortBy,
+                          decoration: InputDecoration(
+                            labelText: 'Sort By',
+                            contentPadding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 8,
+                            ),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(Radii.md),
+                            ),
+                          ),
+                          items: const [
+                            DropdownMenuItem(value: 'Age', child: Text('Age')),
+                            DropdownMenuItem(
+                              value: 'Size',
+                              child: Text('Size'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'Seeders',
+                              child: Text('Seeders'),
+                            ),
+                          ],
+                          onChanged: (val) {
+                            if (val != null) {
+                              setState(() => _sortBy = val);
+                            }
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: Insets.sm),
+                      IconButton.filledTonal(
+                        icon: Icon(
+                          _sortAscending
+                              ? Icons.arrow_upward
+                              : Icons.arrow_downward,
+                        ),
+                        tooltip: 'Toggle Sort Order',
+                        onPressed: () =>
+                            setState(() => _sortAscending = !_sortAscending),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: Insets.xs),
+                  CheckboxListTile(
+                    title: const Text(
+                      'Approved Releases Only',
+                      style: TextStyle(fontSize: 14),
+                    ),
+                    dense: true,
+                    contentPadding: EdgeInsets.zero,
+                    value: _approvedOnly,
+                    onChanged: (val) {
+                      if (val != null) {
+                        setState(() => _approvedOnly = val);
+                      }
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+
+          Expanded(
+            child: ScrollConfiguration(
+              behavior: _ScrollBehavior(),
+              child: AsyncValueView<List<Map<String, dynamic>>>(
+                value: releasesValue,
+                onRetry: () {
+                  if (widget.episode != null) {
+                    ref.invalidate(
+                      sonarrReleasesProvider(
+                        (widget.instance, widget.episode!.id),
+                      ),
+                    );
+                  } else {
+                    ref.invalidate(
+                      sonarrSeasonReleasesProvider(
+                        (
+                          widget.instance,
+                          widget.series!.id,
+                          widget.seasonNumber!
+                        ),
+                      ),
+                    );
+                  }
+                },
+                data: (releases) {
+                  // Apply filters
+                  final filtered = releases.where((r) {
+                    final String title =
+                        (r['title'] as String?)?.toLowerCase() ?? '';
+                    final String indexer =
+                        (r['indexer'] as String?)?.toLowerCase() ?? '';
+                    final String protocol =
+                        (r['protocol'] as String?)?.toLowerCase() ?? '';
+                    final rejections = List<String>.from(
+                      (r['rejections'] as Iterable?) ?? <String>[],
+                    );
+
+                    if (_searchQuery.isNotEmpty) {
+                      final q = _searchQuery.toLowerCase();
+                      if (!title.contains(q) && !indexer.contains(q)) {
+                        return false;
+                      }
+                    }
+                    if (_selectedProtocol == 'Torrent' &&
+                        protocol != 'torrent') {
+                      return false;
+                    }
+                    if (_selectedProtocol == 'Usenet' && protocol != 'usenet') {
+                      return false;
+                    }
+                    if (_approvedOnly && rejections.isNotEmpty) return false;
+
+                    return true;
+                  }).toList();
+
+                  // Sort list
+                  filtered.sort((a, b) {
+                    int result = 0;
+                    if (_sortBy == 'Age') {
+                      result = _getAgeMinutes(a).compareTo(_getAgeMinutes(b));
+                    } else if (_sortBy == 'Size') {
+                      final aSize = a['size'] as int? ?? 0;
+                      final bSize = b['size'] as int? ?? 0;
+                      result = aSize.compareTo(bSize);
+                    } else if (_sortBy == 'Seeders') {
+                      final aSeeders = a['seeders'] as int? ?? 0;
+                      final bSeeders = b['seeders'] as int? ?? 0;
+                      result = bSeeders.compareTo(aSeeders);
+                    }
+                    return _sortAscending ? result : -result;
+                  });
+
+                  if (filtered.isEmpty) {
+                    return const EmptyView(
+                      icon: Icons.search_off,
+                      title: 'No releases found',
+                      message:
+                          'Try modifying your filter settings or search query.',
+                    );
+                  }
+
+                  return ListView.builder(
+                    padding: const EdgeInsets.symmetric(horizontal: Insets.md),
+                    itemCount: filtered.length,
+                    itemBuilder: (context, index) {
+                      final r = filtered[index];
+                      final title =
+                          (r['title'] as String?) ?? 'Unknown release';
+                      final indexer =
+                          (r['indexer'] as String?) ?? 'Unknown Indexer';
+                      final sizeBytes = r['size'] as int? ?? 0;
+                      final seeders = r['seeders'] as int? ?? 0;
+                      final leechers = r['leechers'] as int? ?? 0;
+                      final protocol =
+                          (r['protocol'] as String?)?.toLowerCase() ??
+                              'torrent';
+                      final rejections = List<String>.from(
+                        (r['rejections'] as Iterable?) ?? <String>[],
+                      );
+                      final isApproved = rejections.isEmpty;
+                      final guid = (r['guid'] as String?) ?? title;
+                      final isDownloading = _downloadingMap[guid] ?? false;
+
+                      // Extract quality
+                      final Map<String, dynamic>? qualityMap =
+                          r['quality'] as Map<String, dynamic>?;
+                      final Map<String, dynamic>? qualityInner =
+                          qualityMap?['quality'] as Map<String, dynamic>?;
+                      final String qualityName =
+                          (qualityInner?['name'] as String?) ?? 'SD';
+
+                      // Extract languages
+                      final List<dynamic>? langs =
+                          r['languages'] as List<dynamic>?;
+                      final String langText = langs != null && langs.isNotEmpty
+                          ? langs
+                              .map((dynamic l) {
+                                final Map<String, dynamic> map =
+                                    l as Map<String, dynamic>;
+                                return (map['name'] as String?) ?? '';
+                              })
+                              .where((s) => s.isNotEmpty)
+                              .join(', ')
+                          : '';
+
+                      return Card(
+                        margin: const EdgeInsets.only(bottom: Insets.sm),
+                        clipBehavior: Clip.antiAlias,
+                        color: theme.colorScheme.surfaceContainerLow,
+                        elevation: 0,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(Radii.md),
+                          side: BorderSide(
+                            color:
+                                colors.outlineVariant.withValues(alpha: 0.25),
+                          ),
+                        ),
+                        child: ExpansionTile(
+                          shape: const Border(),
+                          title: Padding(
+                            padding: const EdgeInsets.only(top: 8.0),
+                            child: Text(
+                              title,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                          subtitle: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const SizedBox(height: 6),
+                              Row(
+                                children: [
+                                  // Quality badge
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 6,
+                                      vertical: 2,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: colors.primaryContainer
+                                          .withValues(alpha: 0.4),
+                                      borderRadius:
+                                          BorderRadius.circular(Radii.sm),
+                                    ),
+                                    child: Text(
+                                      qualityName,
+                                      style:
+                                          theme.textTheme.labelSmall?.copyWith(
+                                        color: colors.onPrimaryContainer,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                  if (langText.isNotEmpty) ...[
+                                    const SizedBox(width: Insets.xs),
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: colors.secondaryContainer
+                                            .withValues(alpha: 0.4),
+                                        borderRadius:
+                                            BorderRadius.circular(Radii.sm),
+                                      ),
+                                      child: Text(
+                                        langText,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: colors.onSecondaryContainer,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  ],
+                                ],
+                              ),
+                              const SizedBox(height: 6),
+                              Row(
+                                children: [
+                                  Icon(
+                                    protocol == 'torrent'
+                                        ? Icons.cloud_download
+                                        : Icons.swap_calls,
+                                    size: 14,
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Expanded(
+                                    child: Text(
+                                      '$indexer • ${_formatSize(sizeBytes)} • ${_formatAge(r)}',
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
+                                        color: theme.colorScheme.outline,
+                                      ),
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                              if (protocol == 'torrent')
+                                Padding(
+                                  padding: const EdgeInsets.only(top: 4.0),
+                                  child: Row(
+                                    children: [
+                                      const Icon(
+                                        Icons.arrow_upward,
+                                        size: 12,
+                                        color: Colors.green,
+                                      ),
+                                      Text(
+                                        ' $seeders',
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: Colors.green,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                      const SizedBox(width: Insets.sm),
+                                      const Icon(
+                                        Icons.arrow_downward,
+                                        size: 12,
+                                        color: Colors.red,
+                                      ),
+                                      Text(
+                                        ' $leechers',
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: Colors.red,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              const SizedBox(height: 6),
+                            ],
+                          ),
+                          trailing: isDownloading
+                              ? const SizedBox(
+                                  width: 24,
+                                  height: 24,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                )
+                              : IconButton(
+                                  icon: Icon(
+                                    isApproved
+                                        ? Icons.download
+                                        : Icons.warning_amber_rounded,
+                                    color: isApproved
+                                        ? colors.primary
+                                        : Colors.orange,
+                                  ),
+                                  onPressed: () => _download(r),
+                                ),
+                          children: [
+                            Padding(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 16.0,
+                                vertical: 8.0,
+                              ),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  if (!isApproved) ...[
+                                    Row(
+                                      children: [
+                                        const Icon(
+                                          Icons.error_outline,
+                                          size: 16,
+                                          color: Colors.red,
+                                        ),
+                                        const SizedBox(width: Insets.xs),
+                                        Text(
+                                          'Rejection Reasons:',
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                            color: colors.error,
+                                            fontWeight: FontWeight.bold,
+                                          ),
+                                        ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 4),
+                                    ...rejections.map(
+                                      (rej) => Padding(
+                                        padding: const EdgeInsets.only(
+                                          bottom: 2.0,
+                                          left: 20.0,
+                                        ),
+                                        child: Text(
+                                          '• $rej',
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(color: colors.error),
+                                        ),
+                                      ),
+                                    ),
+                                    const SizedBox(height: 8),
+                                  ] else
+                                    Row(
+                                      children: [
+                                        const Icon(
+                                          Icons.check_circle_outline,
+                                          size: 16,
+                                          color: Colors.green,
+                                        ),
+                                        const SizedBox(width: Insets.xs),
+                                        Text(
+                                          'Approved for download.',
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(color: Colors.green),
+                                        ),
+                                      ],
+                                    ),
+                                  const SizedBox(height: 4),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    },
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/services/service_sonarr/lib/src/sonarr_settings_form_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_settings_form_screen.dart
@@ -1,0 +1,342 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models/sonarr_series.dart';
+import 'sonarr_providers.dart';
+
+class SonarrSettingsFormScreen extends ConsumerStatefulWidget {
+  const SonarrSettingsFormScreen({
+    required this.instance,
+    required this.series,
+    super.key,
+  });
+
+  final Instance instance;
+  final SonarrSeries series;
+
+  @override
+  ConsumerState<SonarrSettingsFormScreen> createState() =>
+      _SonarrSettingsFormScreenState();
+}
+
+class _SonarrSettingsFormScreenState
+    extends ConsumerState<SonarrSettingsFormScreen> {
+  final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _pathController;
+
+  String _monitorOption = 'all';
+  int? _selectedQualityProfileId;
+  String _seriesType = 'standard';
+  bool _seasonFolder = true;
+  List<int> _selectedTagIds = [];
+
+  bool _saving = false;
+  bool _initialized = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _pathController = TextEditingController();
+  }
+
+  @override
+  void dispose() {
+    _pathController.dispose();
+    super.dispose();
+  }
+
+  void _initializeValues(Map<String, dynamic> rawSeries) {
+    if (_initialized) return;
+    _initialized = true;
+
+    _pathController.text = (rawSeries['path'] as String?) ?? '';
+    _monitorOption = (rawSeries['monitorOption'] as String?) ?? 'all';
+    _selectedQualityProfileId = rawSeries['qualityProfileId'] as int?;
+    _seriesType = (rawSeries['seriesType'] as String?) ?? 'standard';
+    _seasonFolder = (rawSeries['seasonFolder'] as bool?) ?? true;
+    _selectedTagIds =
+        List<int>.from((rawSeries['tags'] as Iterable?) ?? <int>[]);
+  }
+
+  Future<void> _save(Map<String, dynamic> rawSeries) async {
+    if (!_formKey.currentState!.validate()) return;
+    setState(() => _saving = true);
+
+    final api = await ref.read(sonarrApiProvider(widget.instance).future);
+
+    // Mutate the raw series map
+    final Map<String, dynamic> payload = Map<String, dynamic>.from(rawSeries);
+    payload['path'] = _pathController.text.trim();
+    payload['monitored'] = _monitorOption != 'none';
+    payload['monitorOption'] = _monitorOption;
+    payload['qualityProfileId'] = _selectedQualityProfileId;
+    payload['seriesType'] = _seriesType;
+    payload['seasonFolder'] = _seasonFolder;
+    payload['tags'] = _selectedTagIds;
+
+    try {
+      await api.updateSeriesRaw(payload);
+      ref.invalidate(
+          sonarrSeriesByIdProvider((widget.instance, widget.series.id)));
+      ref.invalidate(sonarrSeriesProvider(widget.instance));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Series settings saved successfully!')),
+        );
+        Navigator.pop(context);
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to save settings: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final profilesAsync =
+        ref.watch(sonarrQualityProfilesProvider(widget.instance));
+    final tagsAsync = ref.watch(sonarrTagsProvider(widget.instance));
+
+    // Fetch the raw series metadata asynchronously for the settings form
+    final rawSeriesAsync = ref
+        .watch(sonarrSeriesByIdProvider((widget.instance, widget.series.id)));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Edit Series Settings'),
+        actions: [
+          if (_saving)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 16.0),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          else
+            rawSeriesAsync.maybeWhen(
+              data: (freshSeries) => IconButton(
+                icon: const Icon(Icons.check),
+                onPressed: () async {
+                  final api =
+                      await ref.read(sonarrApiProvider(widget.instance).future);
+                  final rawJson = await api.getSeriesRaw(widget.series.id);
+                  await _save(rawJson);
+                },
+              ),
+              orElse: () => const SizedBox.shrink(),
+            ),
+        ],
+      ),
+      body: rawSeriesAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (err, stack) =>
+            Center(child: Text('Error loading series metadata: $err')),
+        data: (freshSeries) {
+          // Trigger initialization using the loaded SonarrSeries structure
+          return FutureBuilder<Map<String, dynamic>>(
+            future: ref
+                .read(sonarrApiProvider(widget.instance).future)
+                .then((api) => api.getSeriesRaw(widget.series.id)),
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const Center(child: CircularProgressIndicator());
+              }
+              _initializeValues(snapshot.data!);
+
+              return Form(
+                key: _formKey,
+                child: ListView(
+                  padding: const EdgeInsets.all(Insets.md),
+                  children: [
+                    Text(
+                      widget.series.title,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: Insets.md),
+
+                    // Path field
+                    TextFormField(
+                      controller: _pathController,
+                      decoration: const InputDecoration(
+                        labelText: 'Path',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.folder_open),
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Path cannot be empty';
+                        }
+                        return null;
+                      },
+                    ),
+                    const SizedBox(height: Insets.md),
+
+                    // Monitor status dropdown
+                    DropdownButtonFormField<String>(
+                      initialValue: _monitorOption,
+                      decoration: const InputDecoration(
+                        labelText: 'Monitor',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.bookmark_outline),
+                      ),
+                      items: const [
+                        DropdownMenuItem(
+                            value: 'all', child: Text('All Episodes')),
+                        DropdownMenuItem(
+                            value: 'future', child: Text('Future Episodes')),
+                        DropdownMenuItem(
+                            value: 'missing', child: Text('Missing Episodes')),
+                        DropdownMenuItem(
+                            value: 'existing',
+                            child: Text('Existing Episodes')),
+                        DropdownMenuItem(
+                            value: 'firstSeason',
+                            child: Text('First Season Only')),
+                        DropdownMenuItem(
+                            value: 'latestSeason',
+                            child: Text('Latest Season Only')),
+                        DropdownMenuItem(
+                            value: 'none', child: Text('None (Unmonitored)')),
+                      ],
+                      onChanged: (val) {
+                        if (val != null) {
+                          setState(() => _monitorOption = val);
+                        }
+                      },
+                    ),
+                    const SizedBox(height: Insets.md),
+
+                    // Quality Profile dropdown
+                    profilesAsync.when(
+                      loading: () =>
+                          const Center(child: CircularProgressIndicator()),
+                      error: (err, stack) =>
+                          Text('Error loading profiles: $err'),
+                      data: (profiles) {
+                        // Ensure selected profile is valid or select first
+                        if (_selectedQualityProfileId == null &&
+                            profiles.isNotEmpty) {
+                          _selectedQualityProfileId =
+                              profiles.first['id'] as int?;
+                        }
+                        return DropdownButtonFormField<int>(
+                          initialValue: _selectedQualityProfileId,
+                          decoration: const InputDecoration(
+                            labelText: 'Quality Profile',
+                            border: OutlineInputBorder(),
+                            prefixIcon: Icon(Icons.high_quality),
+                          ),
+                          items: profiles.map((p) {
+                            return DropdownMenuItem<int>(
+                              value: p['id'] as int,
+                              child: Text((p['name'] as String?) ?? 'Unknown'),
+                            );
+                          }).toList(),
+                          onChanged: (val) {
+                            setState(() => _selectedQualityProfileId = val);
+                          },
+                        );
+                      },
+                    ),
+                    const SizedBox(height: Insets.md),
+
+                    // Series Type dropdown
+                    DropdownButtonFormField<String>(
+                      initialValue: _seriesType,
+                      decoration: const InputDecoration(
+                        labelText: 'Series Type',
+                        border: OutlineInputBorder(),
+                        prefixIcon: Icon(Icons.tv),
+                      ),
+                      items: const [
+                        DropdownMenuItem(
+                            value: 'standard', child: Text('Standard')),
+                        DropdownMenuItem(value: 'daily', child: Text('Daily')),
+                        DropdownMenuItem(value: 'anime', child: Text('Anime')),
+                      ],
+                      onChanged: (val) {
+                        if (val != null) {
+                          setState(() => _seriesType = val);
+                        }
+                      },
+                    ),
+                    const SizedBox(height: Insets.md),
+
+                    // Season Folder switch
+                    SwitchListTile(
+                      title: const Text('Use Season Folder'),
+                      subtitle: const Text(
+                          'Store files in subfolders for each season'),
+                      value: _seasonFolder,
+                      onChanged: (val) {
+                        setState(() => _seasonFolder = val);
+                      },
+                    ),
+                    const SizedBox(height: Insets.md),
+
+                    // Tags multi-selector section
+                    tagsAsync.when(
+                      loading: () =>
+                          const Center(child: CircularProgressIndicator()),
+                      error: (err, stack) => Text('Error loading tags: $err'),
+                      data: (tags) {
+                        if (tags.isEmpty) {
+                          return const SizedBox.shrink();
+                        }
+                        return Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Tags',
+                              style: theme.textTheme.titleSmall
+                                  ?.copyWith(fontWeight: FontWeight.bold),
+                            ),
+                            const SizedBox(height: Insets.xs),
+                            Wrap(
+                              spacing: Insets.xs,
+                              runSpacing: Insets.xs,
+                              children: tags.map((t) {
+                                final id = t['id'] as int;
+                                final label = (t['label'] as String?) ?? '';
+                                final isSelected = _selectedTagIds.contains(id);
+                                return FilterChip(
+                                  label: Text(label),
+                                  selected: isSelected,
+                                  onSelected: (selected) {
+                                    setState(() {
+                                      if (selected) {
+                                        _selectedTagIds.add(id);
+                                      } else {
+                                        _selectedTagIds.remove(id);
+                                      }
+                                    });
+                                  },
+                                );
+                              }).toList(),
+                            ),
+                          ],
+                        );
+                      },
+                    ),
+                  ],
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/v5.yaml
+++ b/v5.yaml
@@ -1,0 +1,9090 @@
+openapi: 3.0.4
+info:
+  title: Sonarr
+  description: Sonarr API docs - The v5 API docs apply to Sonarr v5 only.
+  license:
+    name: GPL-3.0
+    url: https://github.com/Sonarr/Sonarr/blob/develop/LICENSE
+  version: 5.0.0
+servers:
+  - url: "{protocol}://{hostpath}"
+    variables:
+      protocol:
+        default: http
+        enum:
+          - http
+          - https
+      hostpath:
+        default: localhost:8989
+paths:
+  /api:
+    get:
+      tags:
+        - ApiInfo
+      responses:
+        "200":
+          description: OK
+  /login:
+    post:
+      tags:
+        - Authentication
+      parameters:
+        - name: returnUrl
+          in: query
+          schema:
+            type: string
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+                rememberMe:
+                  type: string
+            encoding:
+              username:
+                style: form
+              password:
+                style: form
+              rememberMe:
+                style: form
+      responses:
+        "200":
+          description: OK
+    get:
+      tags:
+        - StaticResource
+      responses:
+        "200":
+          description: OK
+  /logout:
+    get:
+      tags:
+        - Authentication
+      responses:
+        "200":
+          description: OK
+  /api/v5/autotagging:
+    get:
+      tags:
+        - AutoTagging
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutoTaggingResource"
+    post:
+      tags:
+        - AutoTagging
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutoTaggingResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutoTaggingResource"
+        "404":
+          description: Not Found
+  /api/v5/autotagging/{id}:
+    put:
+      tags:
+        - AutoTagging
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AutoTaggingResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutoTaggingResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - AutoTagging
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - AutoTagging
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AutoTaggingResource"
+        "404":
+          description: Not Found
+  /api/v5/autotagging/schema:
+    get:
+      tags:
+        - AutoTagging
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/AutoTaggingSpecificationSchema"
+  /api/v5/system/backup:
+    get:
+      tags:
+        - Backup
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/BackupResource"
+  /api/v5/system/backup/{id}:
+    delete:
+      tags:
+        - Backup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+  /api/v5/system/backup/restore/{id}:
+    post:
+      tags:
+        - Backup
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+        "404":
+          description: Not Found
+  /api/v5/system/backup/restore/upload:
+    post:
+      tags:
+        - Backup
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema: {}
+  /api/v5/blocklist:
+    get:
+      tags:
+        - Blocklist
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+        - name: seriesIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: protocols
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/DownloadProtocol"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BlocklistResourcePagingResource"
+  /api/v5/blocklist/{id}:
+    delete:
+      tags:
+        - Blocklist
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+  /api/v5/blocklist/bulk:
+    delete:
+      tags:
+        - Blocklist
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlocklistBulkResource"
+          text/json:
+            schema:
+              $ref: "#/components/schemas/BlocklistBulkResource"
+          application/*+json:
+            schema:
+              $ref: "#/components/schemas/BlocklistBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/calendar:
+    get:
+      tags:
+        - Calendar
+      parameters:
+        - name: start
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: end
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: includeUnmonitored
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: includeSpecials
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: tags
+          in: query
+          schema:
+            type: string
+            default: ""
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/CalendarSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EpisodeResource"
+  /api/v5/calendar/{id}:
+    get:
+      tags:
+        - Calendar
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResource"
+        "404":
+          description: Not Found
+  /feed/v5/calendar/sonarr.ics:
+    get:
+      tags:
+        - CalendarFeed
+      parameters:
+        - name: pastDays
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 7
+        - name: futureDays
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 28
+        - name: tags
+          in: query
+          schema:
+            type: string
+            default: ""
+        - name: unmonitored
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: premieresOnly
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: asAllDay
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: includeSpecials
+          in: query
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "204":
+          description: No Content
+  /api/v5/command:
+    post:
+      tags:
+        - Command
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommandResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommandResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - Command
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CommandResource"
+  /api/v5/command/{id}:
+    delete:
+      tags:
+        - Command
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - Command
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CommandResource"
+        "404":
+          description: Not Found
+  /api/v5/connection:
+    get:
+      tags:
+        - Connection
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConnectionResource"
+    post:
+      tags:
+        - Connection
+      parameters:
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionResource"
+        "404":
+          description: Not Found
+  /api/v5/connection/{id}:
+    put:
+      tags:
+        - Connection
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - Connection
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - Connection
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionResource"
+        "404":
+          description: Not Found
+  /api/v5/connection/schema:
+    get:
+      tags:
+        - Connection
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ConnectionResource"
+  /api/v5/connection/test:
+    post:
+      tags:
+        - Connection
+      parameters:
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/connection/testall:
+    post:
+      tags:
+        - Connection
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+  /api/v5/connection/action/{name}:
+    post:
+      tags:
+        - Connection
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionResource"
+      responses:
+        "400":
+          description: Bad Request
+  /api/v5/customfilter:
+    get:
+      tags:
+        - CustomFilter
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CustomFilterResource"
+    post:
+      tags:
+        - CustomFilter
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomFilterResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomFilterResource"
+        "404":
+          description: Not Found
+  /api/v5/customfilter/{id}:
+    put:
+      tags:
+        - CustomFilter
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomFilterResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomFilterResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - CustomFilter
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - CustomFilter
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomFilterResource"
+        "404":
+          description: Not Found
+  /api/v5/customformat:
+    get:
+      tags:
+        - CustomFormat
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CustomFormatResource"
+    post:
+      tags:
+        - CustomFormat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomFormatResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomFormatResource"
+        "404":
+          description: Not Found
+  /api/v5/customformat/{id}:
+    put:
+      tags:
+        - CustomFormat
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomFormatResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomFormatResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - CustomFormat
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - CustomFormat
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CustomFormatResource"
+        "404":
+          description: Not Found
+  /api/v5/customformat/bulk:
+    put:
+      tags:
+        - CustomFormat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomFormatBulkResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CustomFormatResource"
+    delete:
+      tags:
+        - CustomFormat
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CustomFormatBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/customformat/schema:
+    get:
+      tags:
+        - CustomFormat
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/CustomFormatSpecificationSchema"
+  /api/v5/wanted/cutoff:
+    get:
+      tags:
+        - Cutoff
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+        - name: monitored
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: seriesIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: qualityProfileIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: seriesType
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SeriesTypes"
+        - name: seriesTags
+          in: query
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: quality
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/CutoffSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResourcePagingResource"
+  /api/v5/wanted/cutoff/{id}:
+    get:
+      tags:
+        - Cutoff
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResource"
+        "404":
+          description: Not Found
+  /api/v5/delayprofile:
+    post:
+      tags:
+        - DelayProfile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DelayProfileResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelayProfileResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - DelayProfile
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DelayProfileResource"
+  /api/v5/delayprofile/{id}:
+    delete:
+      tags:
+        - DelayProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    put:
+      tags:
+        - DelayProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DelayProfileResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelayProfileResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - DelayProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DelayProfileResource"
+        "404":
+          description: Not Found
+  /api/v5/delayprofile/reorder/{id}:
+    put:
+      tags:
+        - DelayProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: after
+          in: query
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DelayProfileResource"
+  /api/v5/diskspace:
+    get:
+      tags:
+        - DiskSpace
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DiskSpaceResource"
+  /api/v5/downloadclient:
+    get:
+      tags:
+        - DownloadClient
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DownloadClientResource"
+    post:
+      tags:
+        - DownloadClient
+      parameters:
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadClientResource"
+        "404":
+          description: Not Found
+  /api/v5/downloadclient/{id}:
+    put:
+      tags:
+        - DownloadClient
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadClientResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - DownloadClient
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - DownloadClient
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadClientResource"
+        "404":
+          description: Not Found
+  /api/v5/downloadclient/bulk:
+    put:
+      tags:
+        - DownloadClient
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientBulkResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DownloadClientResource"
+        "400":
+          description: Bad Request
+    delete:
+      tags:
+        - DownloadClient
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/downloadclient/schema:
+    get:
+      tags:
+        - DownloadClient
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/DownloadClientResource"
+  /api/v5/downloadclient/test:
+    post:
+      tags:
+        - DownloadClient
+      parameters:
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/downloadclient/testall:
+    post:
+      tags:
+        - DownloadClient
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+  /api/v5/downloadclient/action/{name}:
+    post:
+      tags:
+        - DownloadClient
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientResource"
+      responses:
+        "400":
+          description: Bad Request
+  /api/v5/settings/downloadclient:
+    get:
+      tags:
+        - DownloadClientSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadClientSettingsResource"
+  /api/v5/settings/downloadclient/{id}:
+    put:
+      tags:
+        - DownloadClientSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DownloadClientSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadClientSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - DownloadClientSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DownloadClientSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/episode:
+    get:
+      tags:
+        - Episode
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: seasonNumber
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: episodeIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: episodeFileId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/EpisodeSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EpisodeResource"
+        "400":
+          description: Bad Request
+  /api/v5/episode/{id}:
+    put:
+      tags:
+        - Episode
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EpisodeResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResource"
+    get:
+      tags:
+        - Episode
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResource"
+        "404":
+          description: Not Found
+  /api/v5/episode/monitor:
+    put:
+      tags:
+        - Episode
+      parameters:
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/EpisodeSubresource"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EpisodesMonitoredResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EpisodeResource"
+  /api/v5/episodefile:
+    get:
+      tags:
+        - EpisodeFile
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: episodeFileIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EpisodeFileResource"
+        "400":
+          description: Bad Request
+  /api/v5/episodefile/{id}:
+    put:
+      tags:
+        - EpisodeFile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EpisodeFileResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeFileResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - EpisodeFile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - EpisodeFile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeFileResource"
+        "404":
+          description: Not Found
+  /api/v5/episodefile/bulk:
+    delete:
+      tags:
+        - EpisodeFile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EpisodeFileListResource"
+      responses:
+        "204":
+          description: No Content
+    put:
+      tags:
+        - EpisodeFile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/EpisodeFileResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/EpisodeFileResource"
+  /api/v5/filesystem:
+    get:
+      tags:
+        - FileSystem
+      parameters:
+        - name: path
+          in: query
+          schema:
+            type: string
+        - name: includeFiles
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: allowFoldersWithoutTrailingSlashes
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FileSystemResult"
+  /api/v5/filesystem/type:
+    get:
+      tags:
+        - FileSystem
+      parameters:
+        - name: path
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+  /api/v5/filesystem/mediafiles:
+    get:
+      tags:
+        - FileSystem
+      parameters:
+        - name: path
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items: {}
+  /api/v5/settings/general/{id}:
+    put:
+      tags:
+        - GeneralSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/GeneralSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - GeneralSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/settings/general:
+    get:
+      tags:
+        - GeneralSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralSettingsResource"
+  /api/v5/health:
+    get:
+      tags:
+        - Health
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HealthResource"
+  /api/v5/history:
+    get:
+      tags:
+        - History
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+        - name: eventType
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: episodeId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: downloadId
+          in: query
+          schema:
+            type: string
+        - name: seriesIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: languages
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: quality
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/HistorySubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/HistoryResourcePagingResource"
+  /api/v5/history/since:
+    get:
+      tags:
+        - History
+      parameters:
+        - name: date
+          in: query
+          schema:
+            type: string
+            format: date-time
+        - name: eventType
+          in: query
+          schema:
+            $ref: "#/components/schemas/EpisodeHistoryEventType"
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/HistorySubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HistoryResource"
+  /api/v5/history/series:
+    get:
+      tags:
+        - History
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: eventType
+          in: query
+          schema:
+            $ref: "#/components/schemas/EpisodeHistoryEventType"
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/HistorySubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HistoryResource"
+  /api/v5/history/season:
+    get:
+      tags:
+        - History
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: seasonNumber
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: eventType
+          in: query
+          schema:
+            $ref: "#/components/schemas/EpisodeHistoryEventType"
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/HistorySubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HistoryResource"
+  /api/v5/history/episode:
+    get:
+      tags:
+        - History
+      parameters:
+        - name: episodeId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: eventType
+          in: query
+          schema:
+            $ref: "#/components/schemas/EpisodeHistoryEventType"
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/HistorySubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/HistoryResource"
+  /api/v5/history/failed/{id}:
+    post:
+      tags:
+        - History
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+  /api/v5/importlist:
+    get:
+      tags:
+        - ImportList
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ImportListResource"
+    post:
+      tags:
+        - ImportList
+      parameters:
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListResource"
+        "404":
+          description: Not Found
+  /api/v5/importlist/{id}:
+    put:
+      tags:
+        - ImportList
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - ImportList
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - ImportList
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListResource"
+        "404":
+          description: Not Found
+  /api/v5/importlist/bulk:
+    put:
+      tags:
+        - ImportList
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListBulkResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ImportListResource"
+        "400":
+          description: Bad Request
+    delete:
+      tags:
+        - ImportList
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/importlist/schema:
+    get:
+      tags:
+        - ImportList
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ImportListResource"
+  /api/v5/importlist/test:
+    post:
+      tags:
+        - ImportList
+      parameters:
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/importlist/testall:
+    post:
+      tags:
+        - ImportList
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+  /api/v5/importlist/action/{name}:
+    post:
+      tags:
+        - ImportList
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListResource"
+      responses:
+        "400":
+          description: Bad Request
+  /api/v5/importlistexclusion:
+    get:
+      tags:
+        - ImportListExclusion
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListExclusionResourcePagingResource"
+    post:
+      tags:
+        - ImportListExclusion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListExclusionResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListExclusionResource"
+        "404":
+          description: Not Found
+  /api/v5/importlistexclusion/{id}:
+    put:
+      tags:
+        - ImportListExclusion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListExclusionResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListExclusionResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - ImportListExclusion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - ImportListExclusion
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListExclusionResource"
+        "404":
+          description: Not Found
+  /api/v5/importlistexclusion/bulk:
+    delete:
+      tags:
+        - ImportListExclusion
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListExclusionBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/settings/importlist:
+    get:
+      tags:
+        - ImportListSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListSettingsResource"
+  /api/v5/settings/importlist/{id}:
+    put:
+      tags:
+        - ImportListSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ImportListSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - ImportListSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ImportListSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/indexer:
+    get:
+      tags:
+        - Indexer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IndexerResource"
+    post:
+      tags:
+        - Indexer
+      parameters:
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexerResource"
+        "404":
+          description: Not Found
+  /api/v5/indexer/{id}:
+    put:
+      tags:
+        - Indexer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexerResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - Indexer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - Indexer
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexerResource"
+        "404":
+          description: Not Found
+  /api/v5/indexer/bulk:
+    put:
+      tags:
+        - Indexer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerBulkResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IndexerResource"
+        "400":
+          description: Bad Request
+    delete:
+      tags:
+        - Indexer
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/indexer/schema:
+    get:
+      tags:
+        - Indexer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IndexerResource"
+  /api/v5/indexer/test:
+    post:
+      tags:
+        - Indexer
+      parameters:
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/indexer/testall:
+    post:
+      tags:
+        - Indexer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+  /api/v5/indexer/action/{name}:
+    post:
+      tags:
+        - Indexer
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerResource"
+      responses:
+        "400":
+          description: Bad Request
+  /api/v5/indexerflag:
+    get:
+      tags:
+        - IndexerFlag
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/IndexerFlagResource"
+  /api/v5/settings/indexer:
+    get:
+      tags:
+        - IndexerSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexerSettingsResource"
+  /api/v5/settings/indexer/{id}:
+    put:
+      tags:
+        - IndexerSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IndexerSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexerSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - IndexerSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IndexerSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/language:
+    get:
+      tags:
+        - Language
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LanguageResource"
+  /api/v5/language/{id}:
+    get:
+      tags:
+        - Language
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LanguageResource"
+        "404":
+          description: Not Found
+  /api/v5/localization:
+    get:
+      tags:
+        - Localization
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocalizationResource"
+  /api/v5/localization/language:
+    get:
+      tags:
+        - Localization
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocalizationLanguageResource"
+  /api/v5/localization/{id}:
+    get:
+      tags:
+        - Localization
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LocalizationResource"
+        "404":
+          description: Not Found
+  /api/v5/log:
+    get:
+      tags:
+        - Log
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+        - name: level
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LogResourcePagingResource"
+  /api/v5/log/file:
+    get:
+      tags:
+        - LogFile
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LogFileResource"
+  /api/v5/log/file/{filename}:
+    get:
+      tags:
+        - LogFile
+      parameters:
+        - name: filename
+          in: path
+          required: true
+          schema:
+            pattern: "[-.a-zA-Z0-9]+?\\.txt"
+            type: string
+      responses:
+        "404":
+          description: Not Found
+  /api/v5/manualimport:
+    get:
+      tags:
+        - ManualImport
+      parameters:
+        - name: folder
+          in: query
+          schema:
+            type: string
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: seasonNumber
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: downloadIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+        - name: filterExistingFiles
+          in: query
+          schema:
+            type: boolean
+            default: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ManualImportResource"
+    post:
+      tags:
+        - ManualImport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/ManualImportReprocessResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ManualImportResource"
+        "400":
+          description: Bad Request
+  /api/v5/settings/mediamanagement:
+    get:
+      tags:
+        - MediaManagementSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MediaManagementSettingsResource"
+  /api/v5/settings/mediamanagement/{id}:
+    put:
+      tags:
+        - MediaManagementSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MediaManagementSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MediaManagementSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - MediaManagementSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MediaManagementSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/metadata:
+    get:
+      tags:
+        - Metadata
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/MetadataResource"
+    post:
+      tags:
+        - Metadata
+      parameters:
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetadataResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetadataResource"
+        "404":
+          description: Not Found
+  /api/v5/metadata/{id}:
+    put:
+      tags:
+        - Metadata
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: skipTesting
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetadataResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetadataResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - Metadata
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - Metadata
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MetadataResource"
+        "404":
+          description: Not Found
+  /api/v5/metadata/schema:
+    get:
+      tags:
+        - Metadata
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/MetadataResource"
+  /api/v5/metadata/test:
+    post:
+      tags:
+        - Metadata
+      parameters:
+        - name: skipValidation
+          in: query
+          schema:
+            $ref: "#/components/schemas/SkipValidation"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetadataResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/metadata/testall:
+    post:
+      tags:
+        - Metadata
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+        "400":
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderTestAllResult"
+  /api/v5/metadata/action/{name}:
+    post:
+      tags:
+        - Metadata
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MetadataResource"
+      responses:
+        "400":
+          description: Bad Request
+  /api/v5/wanted/missing:
+    get:
+      tags:
+        - Missing
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+        - name: monitored
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: includeSpecials
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: seriesIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: qualityProfileIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: seriesType
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SeriesTypes"
+        - name: seriesTags
+          in: query
+          schema:
+            uniqueItems: true
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/MissingSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResourcePagingResource"
+  /api/v5/wanted/missing/{id}:
+    get:
+      tags:
+        - Missing
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EpisodeResource"
+        "404":
+          description: Not Found
+  /api/v5/settings/naming:
+    get:
+      tags:
+        - NamingSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NamingSettingsResource"
+  /api/v5/settings/naming/{id}:
+    put:
+      tags:
+        - NamingSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/NamingSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NamingSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - NamingSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NamingSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/settings/naming/examples:
+    get:
+      tags:
+        - NamingSettings
+      parameters:
+        - name: renameEpisodes
+          in: query
+          schema:
+            type: boolean
+        - name: replaceIllegalCharacters
+          in: query
+          schema:
+            type: boolean
+        - name: colonReplacementFormat
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: customColonReplacementFormat
+          in: query
+          schema:
+            type: string
+        - name: multiEpisodeStyle
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: standardEpisodeFormat
+          in: query
+          schema:
+            type: string
+        - name: dailyEpisodeFormat
+          in: query
+          schema:
+            type: string
+        - name: animeEpisodeFormat
+          in: query
+          schema:
+            type: string
+        - name: seriesFolderFormat
+          in: query
+          schema:
+            type: string
+        - name: seasonFolderFormat
+          in: query
+          schema:
+            type: string
+        - name: specialsFolderFormat
+          in: query
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: resourceName
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/NamingExampleResource"
+  /api/v5/parse:
+    get:
+      tags:
+        - Parse
+      parameters:
+        - name: title
+          in: query
+          schema:
+            type: string
+        - name: path
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ParseResource"
+  /ping:
+    get:
+      tags:
+        - Ping
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PingResource"
+    head:
+      tags:
+        - Ping
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PingResource"
+  /api/v5/qualitydefinition/{id}:
+    put:
+      tags:
+        - QualityDefinition
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QualityDefinitionResource"
+          text/json:
+            schema:
+              $ref: "#/components/schemas/QualityDefinitionResource"
+          application/*+json:
+            schema:
+              $ref: "#/components/schemas/QualityDefinitionResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityDefinitionResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - QualityDefinition
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityDefinitionResource"
+        "404":
+          description: Not Found
+  /api/v5/qualitydefinition:
+    get:
+      tags:
+        - QualityDefinition
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/QualityDefinitionResource"
+    put:
+      tags:
+        - QualityDefinition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/QualityDefinitionResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/QualityDefinitionResource"
+  /api/v5/qualityprofile:
+    post:
+      tags:
+        - QualityProfile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QualityProfileResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityProfileResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - QualityProfile
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/QualityProfileResource"
+  /api/v5/qualityprofile/{id}:
+    delete:
+      tags:
+        - QualityProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    put:
+      tags:
+        - QualityProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QualityProfileResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityProfileResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - QualityProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityProfileResource"
+        "404":
+          description: Not Found
+  /api/v5/qualityprofile/schema:
+    get:
+      tags:
+        - QualityProfileSchema
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QualityProfileResource"
+  /api/v5/queue/{id}:
+    delete:
+      tags:
+        - Queue
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: message
+          in: query
+          schema:
+            type: string
+        - name: removeFromClient
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: blocklist
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipRedownload
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: changeCategory
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+  /api/v5/queue/bulk:
+    delete:
+      tags:
+        - Queue
+      parameters:
+        - name: message
+          in: query
+          schema:
+            type: string
+        - name: removeFromClient
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: blocklist
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: skipRedownload
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: changeCategory
+          in: query
+          schema:
+            type: boolean
+            default: false
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueueBulkResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/queue:
+    get:
+      tags:
+        - Queue
+      parameters:
+        - name: page
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 1
+        - name: pageSize
+          in: query
+          schema:
+            type: integer
+            format: int32
+            default: 10
+        - name: sortKey
+          in: query
+          schema:
+            type: string
+        - name: sortDirection
+          in: query
+          schema:
+            $ref: "#/components/schemas/SortDirection"
+        - name: includeUnknownSeriesItems
+          in: query
+          schema:
+            type: boolean
+            default: true
+        - name: seriesIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: protocol
+          in: query
+          schema:
+            $ref: "#/components/schemas/DownloadProtocol"
+        - name: languages
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: quality
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: status
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/QueueStatus"
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/QueueSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueueResourcePagingResource"
+  /api/v5/queue/grab/{id}:
+    post:
+      tags:
+        - QueueAction
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+  /api/v5/queue/grab/bulk:
+    post:
+      tags:
+        - QueueAction
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueueBulkResource"
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+  /api/v5/queue/details:
+    get:
+      tags:
+        - QueueDetails
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: episodeIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/QueueSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/QueueResource"
+  /api/v5/queue/status:
+    get:
+      tags:
+        - QueueStatus
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueueStatusResource"
+  /api/v5/release:
+    post:
+      tags:
+        - Release
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReleaseGrabResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseGrabResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - Release
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: episodeId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: seasonNumber
+          in: query
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReleaseResource"
+        "400":
+          description: Bad Request
+  /api/v5/releaseprofile:
+    post:
+      tags:
+        - ReleaseProfile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReleaseProfileResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseProfileResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - ReleaseProfile
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ReleaseProfileResource"
+  /api/v5/releaseprofile/{id}:
+    delete:
+      tags:
+        - ReleaseProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    put:
+      tags:
+        - ReleaseProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReleaseProfileResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseProfileResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - ReleaseProfile
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseProfileResource"
+        "404":
+          description: Not Found
+  /api/v5/release/push:
+    post:
+      tags:
+        - ReleasePush
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReleasePushResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleaseResource"
+        "400":
+          description: Bad Request
+  /api/v5/release/push/{id}:
+    get:
+      tags:
+        - ReleasePush
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ReleasePushResource"
+        "404":
+          description: Not Found
+  /api/v5/remotepathmapping:
+    post:
+      tags:
+        - RemotePathMapping
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemotePathMappingResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RemotePathMappingResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - RemotePathMapping
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RemotePathMappingResource"
+  /api/v5/remotepathmapping/{id}:
+    delete:
+      tags:
+        - RemotePathMapping
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    put:
+      tags:
+        - RemotePathMapping
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RemotePathMappingResource"
+          text/json:
+            schema:
+              $ref: "#/components/schemas/RemotePathMappingResource"
+          application/*+json:
+            schema:
+              $ref: "#/components/schemas/RemotePathMappingResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RemotePathMappingResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - RemotePathMapping
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RemotePathMappingResource"
+        "404":
+          description: Not Found
+  /api/v5/rename:
+    get:
+      tags:
+        - RenameEpisode
+      parameters:
+        - name: seriesId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: seasonNumber
+          in: query
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RenameEpisodeResource"
+  /api/v5/rename/bulk:
+    get:
+      tags:
+        - RenameEpisode
+      parameters:
+        - name: seriesIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RenameEpisodeResource"
+        "400":
+          description: Bad Request
+  /api/v5/rootfolder:
+    post:
+      tags:
+        - RootFolder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RootFolderResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RootFolderResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - RootFolder
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/RootFolderResource"
+  /api/v5/rootfolder/{id}:
+    delete:
+      tags:
+        - RootFolder
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - RootFolder
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RootFolderResource"
+        "404":
+          description: Not Found
+  /api/v5/seasonpass:
+    post:
+      tags:
+        - SeasonPass
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeasonPassResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/series:
+    get:
+      tags:
+        - Series
+      parameters:
+        - name: tvdbId
+          in: query
+          schema:
+            type: integer
+            format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SeriesSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SeriesResource"
+    post:
+      tags:
+        - Series
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeriesResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesResource"
+        "404":
+          description: Not Found
+  /api/v5/series/{id}:
+    get:
+      tags:
+        - Series
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: includeSubresources
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SeriesSubresource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesResource"
+        "404":
+          description: Not Found
+    put:
+      tags:
+        - Series
+      parameters:
+        - name: moveFiles
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeriesResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeriesResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - Series
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+        - name: deleteFiles
+          in: query
+          schema:
+            type: boolean
+            default: false
+        - name: addImportListExclusion
+          in: query
+          schema:
+            type: boolean
+            default: false
+      responses:
+        "204":
+          description: No Content
+  /api/v5/series/{id}/season:
+    put:
+      tags:
+        - Series
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeasonResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SeasonResource"
+        "404":
+          description: Not Found
+  /api/v5/series/editor:
+    put:
+      tags:
+        - SeriesEditor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeriesEditorResource"
+          text/json:
+            schema:
+              $ref: "#/components/schemas/SeriesEditorResource"
+          application/*+json:
+            schema:
+              $ref: "#/components/schemas/SeriesEditorResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SeriesResource"
+        "400":
+          description: Bad Request
+    delete:
+      tags:
+        - SeriesEditor
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SeriesEditorResource"
+          text/json:
+            schema:
+              $ref: "#/components/schemas/SeriesEditorResource"
+          application/*+json:
+            schema:
+              $ref: "#/components/schemas/SeriesEditorResource"
+      responses:
+        "204":
+          description: No Content
+  /api/v5/series/{id}/folder:
+    get:
+      tags:
+        - SeriesFolder
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+  /api/v5/series/import:
+    post:
+      tags:
+        - SeriesImport
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/SeriesResource"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SeriesResource"
+  /api/v5/series/lookup:
+    get:
+      tags:
+        - SeriesLookup
+      parameters:
+        - name: term
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/SeriesResource"
+  /content/{path}:
+    get:
+      tags:
+        - StaticResource
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            pattern: ^(?!api/).*
+            type: string
+      responses:
+        "200":
+          description: OK
+  /:
+    get:
+      tags:
+        - StaticResource
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+  /{path}:
+    get:
+      tags:
+        - StaticResource
+      parameters:
+        - name: path
+          in: path
+          required: true
+          schema:
+            pattern: ^(?!(api|feed)/).*
+            type: string
+      responses:
+        "200":
+          description: OK
+  /api/v5/statistics:
+    get:
+      tags:
+        - Statistics
+      parameters:
+        - name: rootFolderPaths
+          in: query
+          schema:
+            type: array
+            items:
+              type: string
+        - name: rootFolderPathsNot
+          in: query
+          schema:
+            type: boolean
+        - name: tagIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: tagIdsNot
+          in: query
+          schema:
+            type: boolean
+        - name: qualityProfileIds
+          in: query
+          schema:
+            type: array
+            items:
+              type: integer
+              format: int32
+        - name: qualityProfileIdsNot
+          in: query
+          schema:
+            type: boolean
+        - name: monitored
+          in: query
+          schema:
+            type: boolean
+        - name: seriesTypes
+          in: query
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/SeriesTypes"
+        - name: seriesTypesNot
+          in: query
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatisticsResource"
+  /api/v5/system/status:
+    get:
+      tags:
+        - System
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SystemResource"
+  /api/v5/system/routes:
+    get:
+      tags:
+        - System
+      responses:
+        "200":
+          description: OK
+  /api/v5/system/routes/duplicate:
+    get:
+      tags:
+        - System
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: array
+                  items:
+                    type: string
+  /api/v5/system/shutdown:
+    post:
+      tags:
+        - System
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+  /api/v5/system/restart:
+    post:
+      tags:
+        - System
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema: {}
+  /api/v5/tag:
+    get:
+      tags:
+        - Tag
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TagResource"
+    post:
+      tags:
+        - Tag
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TagResource"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagResource"
+        "404":
+          description: Not Found
+  /api/v5/tag/{id}:
+    put:
+      tags:
+        - Tag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TagResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagResource"
+        "404":
+          description: Not Found
+    delete:
+      tags:
+        - Tag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "204":
+          description: No Content
+    get:
+      tags:
+        - Tag
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagResource"
+        "404":
+          description: Not Found
+  /api/v5/tag/detail:
+    get:
+      tags:
+        - TagDetails
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TagDetailsResource"
+  /api/v5/tag/detail/{id}:
+    get:
+      tags:
+        - TagDetails
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TagDetailsResource"
+        "404":
+          description: Not Found
+  /api/v5/system/task:
+    get:
+      tags:
+        - Task
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/TaskResource"
+  /api/v5/system/task/{id}:
+    get:
+      tags:
+        - Task
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TaskResource"
+        "404":
+          description: Not Found
+  /api/v5/settings/ui:
+    get:
+      tags:
+        - UiSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UiSettingsResource"
+  /api/v5/settings/ui/{id}:
+    put:
+      tags:
+        - UiSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UiSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UiSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - UiSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UiSettingsResource"
+        "404":
+          description: Not Found
+  /api/v5/update:
+    get:
+      tags:
+        - Update
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/UpdateResource"
+  /api/v5/log/file/update:
+    get:
+      tags:
+        - UpdateLogFile
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/LogFileResource"
+  /api/v5/log/file/update/{filename}:
+    get:
+      tags:
+        - UpdateLogFile
+      parameters:
+        - name: filename
+          in: path
+          required: true
+          schema:
+            pattern: "[-.a-zA-Z0-9]+?\\.txt"
+            type: string
+      responses:
+        "404":
+          description: Not Found
+  /api/v5/settings/update:
+    get:
+      tags:
+        - UpdateSettings
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateSettingsResource"
+  /api/v5/settings/update/{id}:
+    put:
+      tags:
+        - UpdateSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateSettingsResource"
+      responses:
+        "202":
+          description: Accepted
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateSettingsResource"
+        "404":
+          description: Not Found
+    get:
+      tags:
+        - UpdateSettings
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int32
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateSettingsResource"
+        "404":
+          description: Not Found
+components:
+  schemas:
+    AddSeriesOptions:
+      type: object
+      properties:
+        ignoreEpisodesWithFiles:
+          type: boolean
+        ignoreEpisodesWithoutFiles:
+          type: boolean
+        monitor:
+          $ref: "#/components/schemas/MonitorTypes"
+        searchForMissingEpisodes:
+          type: boolean
+        searchForCutoffUnmetEpisodes:
+          type: boolean
+      additionalProperties: false
+    AlternateTitleResource:
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+        seasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        sceneSeasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        sceneOrigin:
+          type: string
+          nullable: true
+        comment:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ApplyTags:
+      enum:
+        - add
+        - remove
+        - replace
+      type: string
+    AuthenticationRequiredType:
+      enum:
+        - enabled
+        - disabledForLocalAddresses
+        - disabledForLocalhost
+      type: string
+    AuthenticationType:
+      enum:
+        - none
+        - basic
+        - forms
+        - external
+      type: string
+    AutoTaggingResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        removeTagsAutomatically:
+          type: boolean
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        specifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/AutoTaggingSpecificationSchema"
+          nullable: true
+      additionalProperties: false
+    AutoTaggingSpecificationSchema:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        negate:
+          type: boolean
+        required:
+          type: boolean
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+      additionalProperties: false
+    BackupResource:
+      required:
+        - name
+        - path
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        path:
+          type: string
+          nullable: true
+        type:
+          $ref: "#/components/schemas/BackupType"
+        size:
+          type: integer
+          format: int64
+        time:
+          type: string
+          format: date-time
+      additionalProperties: false
+    BackupType:
+      enum:
+        - scheduled
+        - manual
+        - update
+      type: string
+    BlocklistBulkResource:
+      required:
+        - ids
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    BlocklistResource:
+      required:
+        - customFormats
+        - episodeIds
+        - languages
+        - quality
+        - series
+        - sourceTitle
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seriesId:
+          type: integer
+          format: int32
+        episodeIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        sourceTitle:
+          type: string
+          nullable: true
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        date:
+          type: string
+          format: date-time
+        protocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        indexer:
+          type: string
+          nullable: true
+        message:
+          type: string
+          nullable: true
+        source:
+          type: string
+          nullable: true
+        series:
+          $ref: "#/components/schemas/SeriesResource"
+      additionalProperties: false
+    BlocklistResourcePagingResource:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sortKey:
+          type: string
+          nullable: true
+        sortDirection:
+          $ref: "#/components/schemas/SortDirection"
+        totalRecords:
+          type: integer
+          format: int32
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/BlocklistResource"
+          nullable: true
+      additionalProperties: false
+    CalendarSubresource:
+      enum:
+        - series
+        - episodeFile
+        - images
+      type: string
+    CertificateValidationType:
+      enum:
+        - enabled
+        - disabledForLocalAddresses
+        - disabled
+      type: string
+    Command:
+      type: object
+      properties:
+        sendUpdatesToClient:
+          type: boolean
+        updateScheduledTask:
+          type: boolean
+          readOnly: true
+        completionMessage:
+          type: string
+          nullable: true
+          readOnly: true
+        requiresDiskAccess:
+          type: boolean
+          readOnly: true
+        isExclusive:
+          type: boolean
+          readOnly: true
+        isLongRunning:
+          type: boolean
+          readOnly: true
+        name:
+          type: string
+          nullable: true
+          readOnly: true
+        lastExecutionTime:
+          type: string
+          format: date-time
+          nullable: true
+        lastStartTime:
+          type: string
+          format: date-time
+          nullable: true
+        trigger:
+          $ref: "#/components/schemas/CommandTrigger"
+        suppressMessages:
+          type: boolean
+        clientUserAgent:
+          type: string
+          nullable: true
+      additionalProperties: false
+    CommandPriority:
+      enum:
+        - normal
+        - high
+        - low
+      type: string
+    CommandResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        commandName:
+          type: string
+          nullable: true
+        message:
+          type: string
+          nullable: true
+        body:
+          $ref: "#/components/schemas/Command"
+        priority:
+          $ref: "#/components/schemas/CommandPriority"
+        status:
+          $ref: "#/components/schemas/CommandStatus"
+        result:
+          $ref: "#/components/schemas/CommandResult"
+        queued:
+          type: string
+          format: date-time
+        started:
+          type: string
+          format: date-time
+          nullable: true
+        ended:
+          type: string
+          format: date-time
+          nullable: true
+        duration:
+          type: string
+          format: date-span
+          nullable: true
+        exception:
+          type: string
+          nullable: true
+        trigger:
+          $ref: "#/components/schemas/CommandTrigger"
+        clientUserAgent:
+          type: string
+          nullable: true
+        stateChangeTime:
+          type: string
+          format: date-time
+          nullable: true
+        sendUpdatesToClient:
+          type: boolean
+        updateScheduledTask:
+          type: boolean
+        lastExecutionTime:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    CommandResult:
+      enum:
+        - unknown
+        - successful
+        - unsuccessful
+        - indeterminate
+      type: string
+    CommandStatus:
+      enum:
+        - queued
+        - started
+        - completed
+        - failed
+        - aborted
+        - cancelled
+        - orphaned
+      type: string
+    CommandTrigger:
+      enum:
+        - unspecified
+        - manual
+        - scheduled
+      type: string
+    ConnectionResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        configContract:
+          type: string
+          nullable: true
+        infoLink:
+          type: string
+          nullable: true
+        message:
+          $ref: "#/components/schemas/ProviderMessage"
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        presets:
+          type: array
+          items:
+            $ref: "#/components/schemas/ConnectionResource"
+          nullable: true
+        link:
+          type: string
+          nullable: true
+        onGrab:
+          type: boolean
+        onDownload:
+          type: boolean
+        onUpgrade:
+          type: boolean
+        onImportComplete:
+          type: boolean
+        onRename:
+          type: boolean
+        onSeriesAdd:
+          type: boolean
+        onSeriesDelete:
+          type: boolean
+        onEpisodeFileDelete:
+          type: boolean
+        onEpisodeFileDeleteForUpgrade:
+          type: boolean
+        onHealthIssue:
+          type: boolean
+        includeHealthWarnings:
+          type: boolean
+        onHealthRestored:
+          type: boolean
+        onApplicationUpdate:
+          type: boolean
+        onManualInteractionRequired:
+          type: boolean
+        supportsOnGrab:
+          type: boolean
+        supportsOnDownload:
+          type: boolean
+        supportsOnUpgrade:
+          type: boolean
+        supportsOnImportComplete:
+          type: boolean
+        supportsOnRename:
+          type: boolean
+        supportsOnSeriesAdd:
+          type: boolean
+        supportsOnSeriesDelete:
+          type: boolean
+        supportsOnEpisodeFileDelete:
+          type: boolean
+        supportsOnEpisodeFileDeleteForUpgrade:
+          type: boolean
+        supportsOnHealthIssue:
+          type: boolean
+        supportsOnHealthRestored:
+          type: boolean
+        supportsOnApplicationUpdate:
+          type: boolean
+        supportsOnManualInteractionRequired:
+          type: boolean
+        testCommand:
+          type: string
+          nullable: true
+      additionalProperties: false
+    CustomFilterResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        type:
+          type: string
+          nullable: true
+        label:
+          type: string
+          nullable: true
+        filters:
+          type: array
+          items:
+            type: object
+            additionalProperties: {}
+          nullable: true
+      additionalProperties: false
+    CustomFormatBulkResource:
+      type: object
+      properties:
+        ids:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        includeCustomFormatWhenRenaming:
+          type: boolean
+          nullable: true
+      additionalProperties: false
+    CustomFormatResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        includeCustomFormatWhenRenaming:
+          type: boolean
+          nullable: true
+        specifications:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatSpecificationSchema"
+          nullable: true
+      additionalProperties: false
+    CustomFormatSpecificationSchema:
+      required:
+        - fields
+        - implementation
+        - implementationName
+        - infoLink
+        - name
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        infoLink:
+          type: string
+          nullable: true
+        negate:
+          type: boolean
+        required:
+          type: boolean
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+        presets:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatSpecificationSchema"
+          nullable: true
+      additionalProperties: false
+    CutoffSubresource:
+      enum:
+        - series
+        - episodeFile
+        - images
+      type: string
+    DatabaseType:
+      enum:
+        - sqLite
+        - postgreSQL
+      type: string
+    DelayProfileResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        enableUsenet:
+          type: boolean
+        enableTorrent:
+          type: boolean
+        preferredProtocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        usenetDelay:
+          type: integer
+          format: int32
+        torrentDelay:
+          type: integer
+          format: int32
+        bypassIfHighestQuality:
+          type: boolean
+        bypassIfAboveCustomFormatScore:
+          type: boolean
+        minimumCustomFormatScore:
+          type: integer
+          format: int32
+        order:
+          type: integer
+          format: int32
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    DiskSpaceResource:
+      required:
+        - label
+        - path
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        path:
+          type: string
+          nullable: true
+        label:
+          type: string
+          nullable: true
+        freeSpace:
+          type: integer
+          format: int64
+        totalSpace:
+          type: integer
+          format: int64
+      additionalProperties: false
+    DownloadClientBulkResource:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        applyTags:
+          $ref: "#/components/schemas/ApplyTags"
+        enable:
+          type: boolean
+          nullable: true
+        priority:
+          type: integer
+          format: int32
+          nullable: true
+        removeCompletedDownloads:
+          type: boolean
+          nullable: true
+        removeFailedDownloads:
+          type: boolean
+          nullable: true
+      additionalProperties: false
+    DownloadClientResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        configContract:
+          type: string
+          nullable: true
+        infoLink:
+          type: string
+          nullable: true
+        message:
+          $ref: "#/components/schemas/ProviderMessage"
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        presets:
+          type: array
+          items:
+            $ref: "#/components/schemas/DownloadClientResource"
+          nullable: true
+        enable:
+          type: boolean
+        protocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        priority:
+          type: integer
+          format: int32
+        removeCompletedDownloads:
+          type: boolean
+        removeFailedDownloads:
+          type: boolean
+      additionalProperties: false
+    DownloadClientSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        downloadClientWorkingFolders:
+          type: string
+          nullable: true
+        enableCompletedDownloadHandling:
+          type: boolean
+        autoRedownloadFailed:
+          type: boolean
+        autoRedownloadFailedFromInteractiveSearch:
+          type: boolean
+      additionalProperties: false
+    DownloadProtocol:
+      enum:
+        - unknown
+        - usenet
+        - torrent
+      type: string
+    DownloadRejectionReason:
+      enum:
+        - unknown
+        - unknownSeries
+        - unknownEpisode
+        - matchesAnotherSeries
+        - unableToParse
+        - error
+        - decisionError
+        - minimumAgeDelay
+        - minimumAgeDelayPushed
+        - seriesNotMonitored
+        - episodeNotMonitored
+        - historyRecentCutoffMet
+        - historyCdhDisabledCutoffMet
+        - historyHigherPreference
+        - historyHigherRevision
+        - historyCutoffMet
+        - historyCustomFormatCutoffMet
+        - historyCustomFormatScore
+        - historyCustomFormatScoreIncrement
+        - historyUpgradesNotAllowed
+        - noMatchingTag
+        - propersDisabled
+        - properForOldFile
+        - wrongEpisode
+        - wrongSeason
+        - wrongSeries
+        - fullSeason
+        - unknownRuntime
+        - belowMinimumSize
+        - aboveMaximumSize
+        - alreadyImportedSameHash
+        - alreadyImportedSameName
+        - unknownReleaseGroup
+        - releaseGroupDoesNotMatch
+        - indexerDisabled
+        - blocklisted
+        - customFormatMinimumScore
+        - minimumFreeSpace
+        - fullSeasonNotAired
+        - maximumSizeExceeded
+        - minimumAge
+        - maximumAge
+        - multiSeason
+        - sample
+        - protocolDisabled
+        - qualityNotWanted
+        - qualityUpgradesDisabled
+        - queueHigherPreference
+        - queueHigherRevision
+        - queueCutoffMet
+        - queueCustomFormatCutoffMet
+        - queueCustomFormatScore
+        - queueCustomFormatScoreIncrement
+        - queueUpgradesNotAllowed
+        - queuePropersDisabled
+        - raw
+        - mustContainMissing
+        - mustNotContainPresent
+        - repackDisabled
+        - repackUnknownReleaseGroup
+        - repackReleaseGroupDoesNotMatch
+        - existingFileHasMoreEpisodes
+        - ambiguousNumbering
+        - notSeasonPack
+        - splitEpisode
+        - minimumSeeders
+        - diskHigherPreference
+        - diskHigherRevision
+        - diskCutoffMet
+        - diskCustomFormatCutoffMet
+        - diskCustomFormatScore
+        - diskCustomFormatScoreIncrement
+        - diskUpgradesNotAllowed
+        - diskNotUpgrade
+        - beforeAirDate
+      type: string
+    DownloadRejectionResource:
+      type: object
+      properties:
+        message:
+          type: string
+          nullable: true
+        reason:
+          $ref: "#/components/schemas/DownloadRejectionReason"
+        type:
+          $ref: "#/components/schemas/RejectionType"
+      additionalProperties: false
+    EpisodeFileListResource:
+      type: object
+      properties:
+        episodeFileIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    EpisodeFileResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seriesId:
+          type: integer
+          format: int32
+        seasonNumber:
+          type: integer
+          format: int32
+        relativePath:
+          type: string
+          nullable: true
+        path:
+          type: string
+          nullable: true
+        size:
+          type: integer
+          format: int64
+        dateAdded:
+          type: string
+          format: date-time
+        sceneName:
+          type: string
+          nullable: true
+        releaseGroup:
+          type: string
+          nullable: true
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+        indexerFlags:
+          type: integer
+          format: int32
+          nullable: true
+        releaseType:
+          $ref: "#/components/schemas/ReleaseType"
+        mediaInfo:
+          $ref: "#/components/schemas/MediaInfoResource"
+        qualityCutoffNotMet:
+          type: boolean
+      additionalProperties: false
+    EpisodeHistoryEventType:
+      enum:
+        - unknown
+        - grabbed
+        - seriesFolderImported
+        - downloadFolderImported
+        - downloadFailed
+        - episodeFileDeleted
+        - episodeFileRenamed
+        - downloadIgnored
+      type: string
+    EpisodeResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seriesId:
+          type: integer
+          format: int32
+        tvdbId:
+          type: integer
+          format: int32
+        episodeFileId:
+          type: integer
+          format: int32
+        seasonNumber:
+          type: integer
+          format: int32
+        episodeNumber:
+          type: integer
+          format: int32
+        title:
+          type: string
+          nullable: true
+        airDate:
+          type: string
+          nullable: true
+        airDateUtc:
+          type: string
+          format: date-time
+          nullable: true
+        lastSearchTime:
+          type: string
+          format: date-time
+          nullable: true
+        runtime:
+          type: integer
+          format: int32
+        finaleType:
+          type: string
+          nullable: true
+        overview:
+          type: string
+          nullable: true
+        episodeFile:
+          $ref: "#/components/schemas/EpisodeFileResource"
+        hasFile:
+          type: boolean
+        monitored:
+          type: boolean
+        absoluteEpisodeNumber:
+          type: integer
+          format: int32
+          nullable: true
+        sceneAbsoluteEpisodeNumber:
+          type: integer
+          format: int32
+          nullable: true
+        sceneEpisodeNumber:
+          type: integer
+          format: int32
+          nullable: true
+        sceneSeasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        unverifiedSceneNumbering:
+          type: boolean
+        endTime:
+          type: string
+          format: date-time
+          nullable: true
+        grabDate:
+          type: string
+          format: date-time
+          nullable: true
+        series:
+          $ref: "#/components/schemas/SeriesResource"
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaCover"
+          nullable: true
+      additionalProperties: false
+    EpisodeResourcePagingResource:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sortKey:
+          type: string
+          nullable: true
+        sortDirection:
+          $ref: "#/components/schemas/SortDirection"
+        totalRecords:
+          type: integer
+          format: int32
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpisodeResource"
+          nullable: true
+      additionalProperties: false
+    EpisodeSubresource:
+      enum:
+        - series
+        - episodeFile
+        - images
+      type: string
+    EpisodeTitleRequiredType:
+      enum:
+        - always
+        - bulkSeasonReleases
+        - never
+      type: string
+    EpisodesMonitoredResource:
+      required:
+        - episodeIds
+      type: object
+      properties:
+        episodeIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        monitored:
+          type: boolean
+      additionalProperties: false
+    Field:
+      type: object
+      properties:
+        order:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        label:
+          type: string
+          nullable: true
+        unit:
+          type: string
+          nullable: true
+        helpText:
+          type: string
+          nullable: true
+        helpTextWarning:
+          type: string
+          nullable: true
+        helpLink:
+          type: string
+          nullable: true
+        value:
+          nullable: true
+        type:
+          type: string
+          nullable: true
+        advanced:
+          type: boolean
+        selectOptions:
+          type: array
+          items:
+            $ref: "#/components/schemas/SelectOption"
+          nullable: true
+        selectOptionsProviderAction:
+          type: string
+          nullable: true
+        section:
+          type: string
+          nullable: true
+        hidden:
+          type: string
+          nullable: true
+        privacy:
+          $ref: "#/components/schemas/PrivacyLevel"
+        placeholder:
+          type: string
+          nullable: true
+        isFloat:
+          type: boolean
+      additionalProperties: false
+    FileDateType:
+      enum:
+        - none
+        - localAirDate
+        - utcAirDate
+      type: string
+    FileSystemEntityType:
+      enum:
+        - parent
+        - drive
+        - folder
+        - file
+      type: string
+    FileSystemModel:
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/FileSystemEntityType"
+        name:
+          type: string
+          nullable: true
+        path:
+          type: string
+          nullable: true
+        extension:
+          type: string
+          nullable: true
+        size:
+          type: integer
+          format: int64
+        lastModified:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    FileSystemResult:
+      type: object
+      properties:
+        parent:
+          type: string
+          nullable: true
+        directories:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileSystemModel"
+          nullable: true
+        files:
+          type: array
+          items:
+            $ref: "#/components/schemas/FileSystemModel"
+          nullable: true
+      additionalProperties: false
+    GeneralSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        bindAddress:
+          type: string
+          nullable: true
+        port:
+          type: integer
+          format: int32
+        sslPort:
+          type: integer
+          format: int32
+        enableSsl:
+          type: boolean
+        launchBrowser:
+          type: boolean
+        authenticationMethod:
+          $ref: "#/components/schemas/AuthenticationType"
+        authenticationRequired:
+          $ref: "#/components/schemas/AuthenticationRequiredType"
+        analyticsEnabled:
+          type: boolean
+        username:
+          type: string
+          nullable: true
+        password:
+          type: string
+          nullable: true
+        passwordConfirmation:
+          type: string
+          nullable: true
+        logLevel:
+          type: string
+          nullable: true
+        logSizeLimit:
+          type: integer
+          format: int32
+        consoleLogLevel:
+          type: string
+          nullable: true
+        branch:
+          type: string
+          nullable: true
+        apiKey:
+          type: string
+          nullable: true
+        sslCertPath:
+          type: string
+          nullable: true
+        sslKeyPath:
+          type: string
+          nullable: true
+        sslCertPassword:
+          type: string
+          nullable: true
+        urlBase:
+          type: string
+          nullable: true
+        instanceName:
+          type: string
+          nullable: true
+        applicationUrl:
+          type: string
+          nullable: true
+        updateAutomatically:
+          type: boolean
+        updateMechanism:
+          $ref: "#/components/schemas/UpdateMechanism"
+        updateScriptPath:
+          type: string
+          nullable: true
+        proxyEnabled:
+          type: boolean
+        proxyType:
+          $ref: "#/components/schemas/ProxyType"
+        proxyHostname:
+          type: string
+          nullable: true
+        proxyPort:
+          type: integer
+          format: int32
+        proxyUsername:
+          type: string
+          nullable: true
+        proxyPassword:
+          type: string
+          nullable: true
+        proxyBypassFilter:
+          type: string
+          nullable: true
+        proxyBypassLocalAddresses:
+          type: boolean
+        certificateValidation:
+          $ref: "#/components/schemas/CertificateValidationType"
+        backupFolder:
+          type: string
+          nullable: true
+        backupInterval:
+          type: integer
+          format: int32
+        backupRetention:
+          type: integer
+          format: int32
+      additionalProperties: false
+    HealthCheckReason:
+      enum:
+        - appDataLocation
+        - downloadClientCheckNoneAvailable
+        - downloadClientCheckUnableToCommunicate
+        - downloadClientRemovesCompletedDownloads
+        - downloadClientRootFolder
+        - downloadClientSorting
+        - downloadClientStatusAllClients
+        - downloadClientStatusSingleClient
+        - importListRootFolderMissing
+        - importListRootFolderMultipleMissing
+        - importListStatusAllUnavailable
+        - importListStatusUnavailable
+        - importMechanismEnableCompletedDownloadHandlingIfPossible
+        - importMechanismEnableCompletedDownloadHandlingIfPossibleMultiComputer
+        - importMechanismHandlingDisabled
+        - indexerDownloadClient
+        - indexerJackettAll
+        - indexerLongTermStatusAllUnavailable
+        - indexerLongTermStatusUnavailable
+        - indexerRssNoIndexersAvailable
+        - indexerRssNoIndexersEnabled
+        - indexerSearchNoAutomatic
+        - indexerSearchNoAvailableIndexers
+        - indexerSearchNoInteractive
+        - indexerStatusAllUnavailable
+        - indexerStatusUnavailable
+        - minimumApiKeyLength
+        - mountSeries
+        - notificationStatusAll
+        - notificationStatusSingle
+        - package
+        - proxyBadRequest
+        - proxyFailed
+        - proxyResolveIp
+        - recycleBinUnableToWrite
+        - remotePathMappingBadDockerPath
+        - remotePathMappingDockerFolderMissing
+        - remotePathMappingDownloadPermissionsEpisode
+        - remotePathMappingFileRemoved
+        - remotePathMappingFilesBadDockerPath
+        - remotePathMappingFilesGenericPermissions
+        - remotePathMappingFilesLocalWrongOSPath
+        - remotePathMappingFilesWrongOSPath
+        - remotePathMappingFolderPermissions
+        - remotePathMappingGenericPermissions
+        - remotePathMappingImportEpisodeFailed
+        - remotePathMappingLocalFolderMissing
+        - remotePathMappingLocalWrongOSPath
+        - remotePathMappingRemoteDownloadClient
+        - remotePathMappingWrongOSPath
+        - removedSeriesMultiple
+        - removedSeriesSingle
+        - rootFolderEmpty
+        - rootFolderMissing
+        - rootFolderMultipleMissing
+        - serverNotification
+        - systemTime
+        - updateAvailable
+        - updateStartupNotWritable
+        - updateStartupTranslocation
+        - updateUiNotWritable
+      type: string
+    HealthCheckResult:
+      enum:
+        - ok
+        - notice
+        - warning
+        - error
+      type: string
+    HealthResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        source:
+          type: string
+          nullable: true
+        type:
+          $ref: "#/components/schemas/HealthCheckResult"
+        reason:
+          $ref: "#/components/schemas/HealthCheckReason"
+        message:
+          type: string
+          nullable: true
+        wikiUrl:
+          type: string
+          nullable: true
+      additionalProperties: false
+    HistoryResource:
+      required:
+        - customFormats
+        - data
+        - languages
+        - quality
+        - sourceTitle
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        episodeId:
+          type: integer
+          format: int32
+        seriesId:
+          type: integer
+          format: int32
+        sourceTitle:
+          type: string
+          nullable: true
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+        qualityCutoffNotMet:
+          type: boolean
+        date:
+          type: string
+          format: date-time
+        downloadId:
+          type: string
+          nullable: true
+        eventType:
+          $ref: "#/components/schemas/EpisodeHistoryEventType"
+        data:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+        episode:
+          $ref: "#/components/schemas/EpisodeResource"
+        series:
+          $ref: "#/components/schemas/SeriesResource"
+      additionalProperties: false
+    HistoryResourcePagingResource:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sortKey:
+          type: string
+          nullable: true
+        sortDirection:
+          $ref: "#/components/schemas/SortDirection"
+        totalRecords:
+          type: integer
+          format: int32
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/HistoryResource"
+          nullable: true
+      additionalProperties: false
+    HistorySubresource:
+      enum:
+        - series
+        - episode
+      type: string
+    ImportListBulkResource:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        applyTags:
+          $ref: "#/components/schemas/ApplyTags"
+        enableAutomaticAdd:
+          type: boolean
+          nullable: true
+        rootFolderPath:
+          type: string
+          nullable: true
+        qualityProfileId:
+          type: integer
+          format: int32
+          nullable: true
+      additionalProperties: false
+    ImportListExclusionBulkResource:
+      required:
+        - ids
+      type: object
+      properties:
+        ids:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    ImportListExclusionResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        tvdbId:
+          type: integer
+          format: int32
+        title:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ImportListExclusionResourcePagingResource:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sortKey:
+          type: string
+          nullable: true
+        sortDirection:
+          $ref: "#/components/schemas/SortDirection"
+        totalRecords:
+          type: integer
+          format: int32
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportListExclusionResource"
+          nullable: true
+      additionalProperties: false
+    ImportListResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        configContract:
+          type: string
+          nullable: true
+        infoLink:
+          type: string
+          nullable: true
+        message:
+          $ref: "#/components/schemas/ProviderMessage"
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        presets:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportListResource"
+          nullable: true
+        enableAutomaticAdd:
+          type: boolean
+        searchForMissingEpisodes:
+          type: boolean
+        shouldMonitor:
+          $ref: "#/components/schemas/MonitorTypes"
+        monitorNewItems:
+          $ref: "#/components/schemas/NewItemMonitorTypes"
+        rootFolderPath:
+          type: string
+          nullable: true
+        qualityProfileId:
+          type: integer
+          format: int32
+        seriesType:
+          $ref: "#/components/schemas/SeriesTypes"
+        seasonFolder:
+          type: boolean
+        listType:
+          $ref: "#/components/schemas/ImportListType"
+        listOrder:
+          type: integer
+          format: int32
+        minRefreshInterval:
+          type: string
+          format: date-span
+      additionalProperties: false
+    ImportListSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        listSyncLevel:
+          $ref: "#/components/schemas/ListSyncLevelType"
+        listSyncTag:
+          type: integer
+          format: int32
+      additionalProperties: false
+    ImportListType:
+      enum:
+        - program
+        - plex
+        - trakt
+        - simkl
+        - other
+        - advanced
+      type: string
+    ImportRejectionReason:
+      enum:
+        - unknown
+        - fileLocked
+        - unknownSeries
+        - dangerousFile
+        - executableFile
+        - userRejectedExtension
+        - archiveFile
+        - seriesFolder
+        - invalidFilePath
+        - unsupportedExtension
+        - partialSeason
+        - seasonExtra
+        - invalidSeasonOrEpisode
+        - unableToParse
+        - error
+        - decisionError
+        - noEpisodes
+        - missingAbsoluteEpisodeNumber
+        - episodeAlreadyImported
+        - titleMissing
+        - titleTba
+        - minimumFreeSpace
+        - fullSeason
+        - noAudio
+        - episodeUnexpected
+        - episodeNotFoundInRelease
+        - sample
+        - sampleIndeterminate
+        - unpacking
+        - existingFileHasMoreEpisodes
+        - splitEpisode
+        - unverifiedSceneMapping
+        - notQualityUpgrade
+        - notRevisionUpgrade
+        - notCustomFormatUpgrade
+        - notCustomFormatUpgradeAfterRename
+        - multiSeason
+      type: string
+    ImportRejectionResource:
+      type: object
+      properties:
+        reason:
+          $ref: "#/components/schemas/ImportRejectionReason"
+        message:
+          type: string
+          nullable: true
+        type:
+          $ref: "#/components/schemas/RejectionType"
+      additionalProperties: false
+    IndexerBulkResource:
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        applyTags:
+          $ref: "#/components/schemas/ApplyTags"
+        enableRss:
+          type: boolean
+          nullable: true
+        enableAutomaticSearch:
+          type: boolean
+          nullable: true
+        enableInteractiveSearch:
+          type: boolean
+          nullable: true
+        priority:
+          type: integer
+          format: int32
+          nullable: true
+        seasonSearchMaximumSingleEpisodeAge:
+          type: integer
+          format: int32
+          nullable: true
+      additionalProperties: false
+    IndexerFlagResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        nameLower:
+          type: string
+          nullable: true
+          readOnly: true
+      additionalProperties: false
+    IndexerResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        configContract:
+          type: string
+          nullable: true
+        infoLink:
+          type: string
+          nullable: true
+        message:
+          $ref: "#/components/schemas/ProviderMessage"
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        presets:
+          type: array
+          items:
+            $ref: "#/components/schemas/IndexerResource"
+          nullable: true
+        enableRss:
+          type: boolean
+        enableAutomaticSearch:
+          type: boolean
+        enableInteractiveSearch:
+          type: boolean
+        supportsRss:
+          type: boolean
+        supportsSearch:
+          type: boolean
+        protocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        priority:
+          type: integer
+          format: int32
+        seasonSearchMaximumSingleEpisodeAge:
+          type: integer
+          format: int32
+        downloadClientId:
+          type: integer
+          format: int32
+      additionalProperties: false
+    IndexerSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        minimumAge:
+          type: integer
+          format: int32
+        retention:
+          type: integer
+          format: int32
+        maximumSize:
+          type: integer
+          format: int32
+        rssSyncInterval:
+          type: integer
+          format: int32
+      additionalProperties: false
+    Language:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+      additionalProperties: false
+    LanguageResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        nameLower:
+          type: string
+          nullable: true
+          readOnly: true
+      additionalProperties: false
+    ListSyncLevelType:
+      enum:
+        - disabled
+        - logOnly
+        - keepAndUnmonitor
+        - keepAndTag
+      type: string
+    LocalizationLanguageResource:
+      type: object
+      properties:
+        identifier:
+          type: string
+          nullable: true
+      additionalProperties: false
+    LocalizationResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        strings:
+          type: object
+          additionalProperties:
+            type: string
+          nullable: true
+      additionalProperties: false
+    LogFileResource:
+      required:
+        - contentsUrl
+        - downloadUrl
+        - filename
+        - lastWriteTime
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        filename:
+          type: string
+          nullable: true
+        lastWriteTime:
+          type: string
+          format: date-time
+        contentsUrl:
+          type: string
+          nullable: true
+        downloadUrl:
+          type: string
+          nullable: true
+      additionalProperties: false
+    LogResource:
+      required:
+        - level
+        - logger
+        - message
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        time:
+          type: string
+          format: date-time
+        exception:
+          type: string
+          nullable: true
+        exceptionType:
+          type: string
+          nullable: true
+        level:
+          type: string
+          nullable: true
+        logger:
+          type: string
+          nullable: true
+        message:
+          type: string
+          nullable: true
+      additionalProperties: false
+    LogResourcePagingResource:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sortKey:
+          type: string
+          nullable: true
+        sortDirection:
+          $ref: "#/components/schemas/SortDirection"
+        totalRecords:
+          type: integer
+          format: int32
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/LogResource"
+          nullable: true
+      additionalProperties: false
+    ManualImportReprocessResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        path:
+          type: string
+          nullable: true
+        relativePath:
+          type: string
+          nullable: true
+        seriesId:
+          type: integer
+          format: int32
+        seasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        episodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpisodeResource"
+          nullable: true
+        episodeIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        releaseGroup:
+          type: string
+          nullable: true
+        downloadId:
+          type: string
+          nullable: true
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+        indexerFlags:
+          type: integer
+          format: int32
+        releaseType:
+          $ref: "#/components/schemas/ReleaseType"
+        rejections:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportRejectionResource"
+          nullable: true
+      additionalProperties: false
+    ManualImportResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        path:
+          type: string
+          nullable: true
+        relativePath:
+          type: string
+          nullable: true
+        folderName:
+          type: string
+          nullable: true
+        name:
+          type: string
+          nullable: true
+        size:
+          type: integer
+          format: int64
+        series:
+          $ref: "#/components/schemas/SeriesResource"
+        seasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        episodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpisodeResource"
+          nullable: true
+        episodeFileId:
+          type: integer
+          format: int32
+          nullable: true
+        releaseGroup:
+          type: string
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        qualityWeight:
+          type: integer
+          format: int32
+        downloadId:
+          type: string
+          nullable: true
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+        indexerFlags:
+          type: integer
+          format: int32
+        releaseType:
+          $ref: "#/components/schemas/ReleaseType"
+        rejections:
+          type: array
+          items:
+            $ref: "#/components/schemas/ImportRejectionResource"
+          nullable: true
+      additionalProperties: false
+    MediaCover:
+      type: object
+      properties:
+        coverType:
+          $ref: "#/components/schemas/MediaCoverTypes"
+        url:
+          type: string
+          nullable: true
+        remoteUrl:
+          type: string
+          nullable: true
+      additionalProperties: false
+    MediaCoverTypes:
+      enum:
+        - unknown
+        - poster
+        - banner
+        - fanart
+        - screenshot
+        - headshot
+        - clearlogo
+      type: string
+    MediaInfoAudioStreamResource:
+      type: object
+      properties:
+        language:
+          type: string
+          nullable: true
+        codec:
+          type: string
+          nullable: true
+        codecId:
+          type: string
+          nullable: true
+        profile:
+          type: string
+          nullable: true
+        bitrate:
+          type: integer
+          format: int64
+        channels:
+          type: number
+          format: double
+        channelPositions:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+      additionalProperties: false
+    MediaInfoResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        videoBitDepth:
+          type: integer
+          format: int32
+        videoBitrate:
+          type: integer
+          format: int64
+        videoCodec:
+          type: string
+          nullable: true
+        videoFps:
+          type: number
+          format: double
+        videoDynamicRange:
+          type: string
+          nullable: true
+        videoDynamicRangeType:
+          type: string
+          nullable: true
+        resolution:
+          type: string
+          nullable: true
+        runTime:
+          type: string
+          nullable: true
+        scanType:
+          type: string
+          nullable: true
+        audioStreams:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaInfoAudioStreamResource"
+          nullable: true
+        subtitleStreams:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaInfoSubtitleStreamResource"
+          nullable: true
+      additionalProperties: false
+    MediaInfoSubtitleStreamResource:
+      type: object
+      properties:
+        language:
+          type: string
+          nullable: true
+        format:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        forced:
+          type: boolean
+          nullable: true
+        hearingImpaired:
+          type: boolean
+          nullable: true
+      additionalProperties: false
+    MediaManagementSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        autoUnmonitorPreviouslyDownloadedEpisodes:
+          type: boolean
+        recycleBin:
+          type: string
+          nullable: true
+        recycleBinCleanupDays:
+          type: integer
+          format: int32
+        downloadPropersAndRepacks:
+          $ref: "#/components/schemas/ProperDownloadTypes"
+        createEmptySeriesFolders:
+          type: boolean
+        deleteEmptyFolders:
+          type: boolean
+        fileDate:
+          $ref: "#/components/schemas/FileDateType"
+        rescanAfterRefresh:
+          $ref: "#/components/schemas/RescanAfterRefreshType"
+        setPermissionsLinux:
+          type: boolean
+        chmodFolder:
+          type: string
+          nullable: true
+        chownGroup:
+          type: string
+          nullable: true
+        episodeTitleRequired:
+          $ref: "#/components/schemas/EpisodeTitleRequiredType"
+        skipFreeSpaceCheckWhenImporting:
+          type: boolean
+        minimumFreeSpaceWhenImporting:
+          type: integer
+          format: int32
+        copyUsingHardlinks:
+          type: boolean
+        useScriptImport:
+          type: boolean
+        scriptImportPath:
+          type: string
+          nullable: true
+        importExtraFiles:
+          type: boolean
+        extraFileExtensions:
+          type: string
+          nullable: true
+        enableMediaInfo:
+          type: boolean
+        userRejectedExtensions:
+          type: string
+          nullable: true
+        seasonPackUpgrade:
+          $ref: "#/components/schemas/SeasonPackUpgradeType"
+        seasonPackUpgradeThreshold:
+          type: number
+          format: double
+      additionalProperties: false
+    MetadataResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        fields:
+          type: array
+          items:
+            $ref: "#/components/schemas/Field"
+          nullable: true
+        implementationName:
+          type: string
+          nullable: true
+        implementation:
+          type: string
+          nullable: true
+        configContract:
+          type: string
+          nullable: true
+        infoLink:
+          type: string
+          nullable: true
+        message:
+          $ref: "#/components/schemas/ProviderMessage"
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        presets:
+          type: array
+          items:
+            $ref: "#/components/schemas/MetadataResource"
+          nullable: true
+        enable:
+          type: boolean
+      additionalProperties: false
+    MissingSubresource:
+      enum:
+        - series
+        - images
+      type: string
+    MonitorTypes:
+      enum:
+        - unknown
+        - all
+        - future
+        - missing
+        - existing
+        - firstSeason
+        - lastSeason
+        - latestSeason
+        - pilot
+        - recent
+        - monitorSpecials
+        - unmonitorSpecials
+        - none
+        - skip
+      type: string
+    MonitoringOptionsResource:
+      type: object
+      properties:
+        monitor:
+          $ref: "#/components/schemas/MonitorTypes"
+      additionalProperties: false
+    NamingExampleResource:
+      type: object
+      properties:
+        singleEpisodeExample:
+          type: string
+          nullable: true
+        multiEpisodeExample:
+          type: string
+          nullable: true
+        dailyEpisodeExample:
+          type: string
+          nullable: true
+        animeEpisodeExample:
+          type: string
+          nullable: true
+        animeMultiEpisodeExample:
+          type: string
+          nullable: true
+        seriesFolderExample:
+          type: string
+          nullable: true
+        seasonFolderExample:
+          type: string
+          nullable: true
+        specialsFolderExample:
+          type: string
+          nullable: true
+      additionalProperties: false
+    NamingSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        renameEpisodes:
+          type: boolean
+        replaceIllegalCharacters:
+          type: boolean
+        colonReplacementFormat:
+          type: integer
+          format: int32
+        customColonReplacementFormat:
+          type: string
+          nullable: true
+        multiEpisodeStyle:
+          type: integer
+          format: int32
+        standardEpisodeFormat:
+          type: string
+          nullable: true
+        dailyEpisodeFormat:
+          type: string
+          nullable: true
+        animeEpisodeFormat:
+          type: string
+          nullable: true
+        seriesFolderFormat:
+          type: string
+          nullable: true
+        seasonFolderFormat:
+          type: string
+          nullable: true
+        specialsFolderFormat:
+          type: string
+          nullable: true
+      additionalProperties: false
+    NewItemMonitorTypes:
+      enum:
+        - all
+        - none
+      type: string
+    OverrideReleaseResource:
+      type: object
+      properties:
+        seriesId:
+          type: integer
+          format: int32
+          nullable: true
+        episodeIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        downloadClientId:
+          type: integer
+          format: int32
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+      additionalProperties: false
+    ParseResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        title:
+          type: string
+          nullable: true
+        parsedEpisodeInfo:
+          $ref: "#/components/schemas/ParsedEpisodeInfo"
+        series:
+          $ref: "#/components/schemas/SeriesResource"
+        episodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpisodeResource"
+          nullable: true
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+      additionalProperties: false
+    ParsedEpisodeInfo:
+      type: object
+      properties:
+        releaseTitle:
+          type: string
+          nullable: true
+        seriesTitle:
+          type: string
+          nullable: true
+        seriesTitleInfo:
+          $ref: "#/components/schemas/SeriesTitleInfo"
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        seasonNumber:
+          type: integer
+          format: int32
+        episodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        absoluteEpisodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        specialAbsoluteEpisodeNumbers:
+          type: array
+          items:
+            type: number
+            format: double
+          nullable: true
+        airDate:
+          type: string
+          nullable: true
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        fullSeason:
+          type: boolean
+        isPartialSeason:
+          type: boolean
+        isMultiSeason:
+          type: boolean
+        isSeasonExtra:
+          type: boolean
+        isSplitEpisode:
+          type: boolean
+        isMiniSeries:
+          type: boolean
+        special:
+          type: boolean
+        releaseGroup:
+          type: string
+          nullable: true
+        releaseHash:
+          type: string
+          nullable: true
+        seasonPart:
+          type: integer
+          format: int32
+        releaseTokens:
+          type: string
+          nullable: true
+        dailyPart:
+          type: integer
+          format: int32
+          nullable: true
+        isDaily:
+          type: boolean
+          readOnly: true
+        isAbsoluteNumbering:
+          type: boolean
+          readOnly: true
+        isPossibleSpecialEpisode:
+          type: boolean
+          readOnly: true
+        isPossibleSceneSeasonSpecial:
+          type: boolean
+          readOnly: true
+        releaseType:
+          $ref: "#/components/schemas/ReleaseType"
+      additionalProperties: false
+    ParsedEpisodeInfoResource:
+      type: object
+      properties:
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        releaseGroup:
+          type: string
+          nullable: true
+        releaseHash:
+          type: string
+          nullable: true
+        fullSeason:
+          type: boolean
+        seasonNumber:
+          type: integer
+          format: int32
+        airDate:
+          type: string
+          nullable: true
+        seriesTitle:
+          type: string
+          nullable: true
+        episodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        absoluteEpisodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        isDaily:
+          type: boolean
+        isAbsoluteNumbering:
+          type: boolean
+        isPossibleSpecialEpisode:
+          type: boolean
+        special:
+          type: boolean
+      additionalProperties: false
+    PingResource:
+      type: object
+      properties:
+        status:
+          type: string
+          nullable: true
+      additionalProperties: false
+    PrivacyLevel:
+      enum:
+        - normal
+        - password
+        - apiKey
+        - userName
+      type: string
+    ProfileFormatItemResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        format:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        score:
+          type: integer
+          format: int32
+      additionalProperties: false
+    ProperDownloadTypes:
+      enum:
+        - preferAndUpgrade
+        - doNotUpgrade
+        - doNotPrefer
+      type: string
+    ProviderMessage:
+      type: object
+      properties:
+        message:
+          type: string
+          nullable: true
+        type:
+          $ref: "#/components/schemas/ProviderMessageType"
+      additionalProperties: false
+    ProviderMessageType:
+      enum:
+        - info
+        - warning
+        - error
+      type: string
+    ProviderTestAllResult:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        isValid:
+          type: boolean
+          readOnly: true
+        validationFailures:
+          type: array
+          items:
+            $ref: "#/components/schemas/ValidationFailure"
+          nullable: true
+      additionalProperties: false
+    ProxyType:
+      enum:
+        - http
+        - socks4
+        - socks5
+      type: string
+    Quality:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        source:
+          $ref: "#/components/schemas/QualitySource"
+        resolution:
+          type: integer
+          format: int32
+      additionalProperties: false
+    QualityDefinitionResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        quality:
+          $ref: "#/components/schemas/Quality"
+        title:
+          type: string
+          nullable: true
+        weight:
+          type: integer
+          format: int32
+      additionalProperties: false
+    QualityModel:
+      type: object
+      properties:
+        quality:
+          $ref: "#/components/schemas/Quality"
+        revision:
+          $ref: "#/components/schemas/Revision"
+      additionalProperties: false
+    QualityProfileQualityItemResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/Quality"
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityProfileQualityItemResource"
+          nullable: true
+        allowed:
+          type: boolean
+        minSize:
+          type: number
+          format: double
+          nullable: true
+        maxSize:
+          type: number
+          format: double
+          nullable: true
+        preferredSize:
+          type: number
+          format: double
+          nullable: true
+      additionalProperties: false
+    QualityProfileResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        upgradeAllowed:
+          type: boolean
+        cutoff:
+          type: integer
+          format: int32
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityProfileQualityItemResource"
+          nullable: true
+        minFormatScore:
+          type: integer
+          format: int32
+        cutoffFormatScore:
+          type: integer
+          format: int32
+        minUpgradeFormatScore:
+          type: integer
+          format: int32
+        formatItems:
+          type: array
+          items:
+            $ref: "#/components/schemas/ProfileFormatItemResource"
+          nullable: true
+      additionalProperties: false
+    QualityProfileStatisticsResource:
+      required:
+        - name
+      type: object
+      properties:
+        qualityProfileId:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        seriesCount:
+          type: integer
+          format: int32
+        episodeFileCount:
+          type: integer
+          format: int32
+        sizeOnDisk:
+          type: integer
+          format: int64
+      additionalProperties: false
+    QualitySource:
+      enum:
+        - unknown
+        - television
+        - televisionRaw
+        - web
+        - webRip
+        - dvd
+        - bluray
+        - blurayRaw
+      type: string
+    QualityStatisticsResource:
+      required:
+        - quality
+      type: object
+      properties:
+        quality:
+          $ref: "#/components/schemas/Quality"
+        episodeFileCount:
+          type: integer
+          format: int32
+        sizeOnDisk:
+          type: integer
+          format: int64
+      additionalProperties: false
+    QueueBulkResource:
+      required:
+        - ids
+      type: object
+      properties:
+        ids:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    QueueResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seriesId:
+          type: integer
+          format: int32
+          nullable: true
+        episodeIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        seasonNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        series:
+          $ref: "#/components/schemas/SeriesResource"
+        episodes:
+          type: array
+          items:
+            $ref: "#/components/schemas/EpisodeResource"
+          nullable: true
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        quality:
+          $ref: "#/components/schemas/QualityModel"
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+        size:
+          type: number
+          format: double
+        title:
+          type: string
+          nullable: true
+        sizeLeft:
+          type: number
+          format: double
+        timeLeft:
+          type: string
+          format: date-span
+          nullable: true
+        estimatedCompletionTime:
+          type: string
+          format: date-time
+          nullable: true
+        added:
+          type: string
+          format: date-time
+          nullable: true
+        status:
+          $ref: "#/components/schemas/QueueStatus"
+        trackedDownloadStatus:
+          $ref: "#/components/schemas/TrackedDownloadStatus"
+        trackedDownloadState:
+          $ref: "#/components/schemas/TrackedDownloadState"
+        statusMessages:
+          type: array
+          items:
+            $ref: "#/components/schemas/TrackedDownloadStatusMessage"
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+        downloadId:
+          type: string
+          nullable: true
+        protocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        downloadClient:
+          type: string
+          nullable: true
+        downloadClientHasPostImportCategory:
+          type: boolean
+        indexer:
+          type: string
+          nullable: true
+        outputPath:
+          type: string
+          nullable: true
+        episodesWithFilesCount:
+          type: integer
+          format: int32
+        isFullSeason:
+          type: boolean
+      additionalProperties: false
+    QueueResourcePagingResource:
+      type: object
+      properties:
+        page:
+          type: integer
+          format: int32
+        pageSize:
+          type: integer
+          format: int32
+        sortKey:
+          type: string
+          nullable: true
+        sortDirection:
+          $ref: "#/components/schemas/SortDirection"
+        totalRecords:
+          type: integer
+          format: int32
+        records:
+          type: array
+          items:
+            $ref: "#/components/schemas/QueueResource"
+          nullable: true
+      additionalProperties: false
+    QueueStatus:
+      enum:
+        - unknown
+        - queued
+        - paused
+        - downloading
+        - completed
+        - failed
+        - warning
+        - delay
+        - downloadClientUnavailable
+        - fallback
+      type: string
+    QueueStatusResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        totalCount:
+          type: integer
+          format: int32
+        count:
+          type: integer
+          format: int32
+        unknownCount:
+          type: integer
+          format: int32
+        errors:
+          type: boolean
+        warnings:
+          type: boolean
+        unknownErrors:
+          type: boolean
+        unknownWarnings:
+          type: boolean
+      additionalProperties: false
+    QueueSubresource:
+      enum:
+        - series
+        - episodes
+      type: string
+    Ratings:
+      type: object
+      properties:
+        votes:
+          type: integer
+          format: int32
+        value:
+          type: number
+          format: double
+      additionalProperties: false
+    RejectionType:
+      enum:
+        - permanent
+        - temporary
+      type: string
+    ReleaseDecisionResource:
+      type: object
+      properties:
+        approved:
+          type: boolean
+        temporarilyRejected:
+          type: boolean
+        rejected:
+          type: boolean
+        rejections:
+          type: array
+          items:
+            $ref: "#/components/schemas/DownloadRejectionResource"
+          nullable: true
+      additionalProperties: false
+    ReleaseEpisodeResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seasonNumber:
+          type: integer
+          format: int32
+        episodeNumber:
+          type: integer
+          format: int32
+        absoluteEpisodeNumber:
+          type: integer
+          format: int32
+          nullable: true
+        title:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ReleaseGrabResource:
+      required:
+        - guid
+        - indexerId
+      type: object
+      properties:
+        guid:
+          type: string
+          nullable: true
+        indexerId:
+          type: integer
+          format: int32
+        override:
+          $ref: "#/components/schemas/OverrideReleaseResource"
+        searchInfo:
+          $ref: "#/components/schemas/SearchInfoResource"
+      additionalProperties: false
+    ReleaseHistoryResource:
+      type: object
+      properties:
+        grabbed:
+          type: string
+          format: date-time
+          nullable: true
+        failed:
+          type: string
+          format: date-time
+          nullable: true
+      additionalProperties: false
+    ReleaseInfoResource:
+      type: object
+      properties:
+        guid:
+          type: string
+          nullable: true
+        age:
+          type: integer
+          format: int32
+        ageHours:
+          type: number
+          format: double
+        ageMinutes:
+          type: number
+          format: double
+        size:
+          type: integer
+          format: int64
+        indexerId:
+          type: integer
+          format: int32
+        indexer:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        tvdbId:
+          type: integer
+          format: int32
+        tvRageId:
+          type: integer
+          format: int32
+        imdbId:
+          type: string
+          nullable: true
+        publishDate:
+          type: string
+          format: date-time
+        commentUrl:
+          type: string
+          nullable: true
+        downloadUrl:
+          type: string
+          nullable: true
+        infoUrl:
+          type: string
+          nullable: true
+        magnetUrl:
+          type: string
+          nullable: true
+        infoHash:
+          type: string
+          nullable: true
+        seeders:
+          type: integer
+          format: int32
+          nullable: true
+        leechers:
+          type: integer
+          format: int32
+          nullable: true
+        protocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        indexerFlags:
+          type: integer
+          format: int32
+      additionalProperties: false
+    ReleaseProfileResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        enabled:
+          type: boolean
+        required:
+          type: array
+          items:
+            type: string
+          nullable: true
+        ignored:
+          type: array
+          items:
+            type: string
+          nullable: true
+        airDateRestriction:
+          type: boolean
+        airDateGracePeriod:
+          type: integer
+          format: int32
+        indexerIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        excludedTags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    ReleasePushResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        guid:
+          type: string
+          nullable: true
+        size:
+          type: integer
+          format: int64
+        indexerId:
+          type: integer
+          format: int32
+        indexer:
+          type: string
+          nullable: true
+        title:
+          type: string
+          nullable: true
+        tvdbId:
+          type: integer
+          format: int32
+        tvRageId:
+          type: integer
+          format: int32
+        imdbId:
+          type: string
+          nullable: true
+        rejections:
+          type: array
+          items:
+            type: string
+          nullable: true
+        publishDate:
+          type: string
+          format: date-time
+        commentUrl:
+          type: string
+          nullable: true
+        downloadUrl:
+          type: string
+          nullable: true
+        infoUrl:
+          type: string
+          nullable: true
+        magnetUrl:
+          type: string
+          nullable: true
+        infoHash:
+          type: string
+          nullable: true
+        seeders:
+          type: integer
+          format: int32
+          nullable: true
+        leechers:
+          type: integer
+          format: int32
+          nullable: true
+        protocol:
+          $ref: "#/components/schemas/DownloadProtocol"
+        indexerFlags:
+          type: integer
+          format: int32
+        downloadClientId:
+          type: integer
+          format: int32
+          nullable: true
+        downloadClientName:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ReleaseResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        parsedInfo:
+          $ref: "#/components/schemas/ParsedEpisodeInfoResource"
+        release:
+          $ref: "#/components/schemas/ReleaseInfoResource"
+        decision:
+          $ref: "#/components/schemas/ReleaseDecisionResource"
+        history:
+          $ref: "#/components/schemas/ReleaseHistoryResource"
+        qualityWeight:
+          type: integer
+          format: int32
+        languages:
+          type: array
+          items:
+            $ref: "#/components/schemas/Language"
+          nullable: true
+        mappedSeasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        mappedEpisodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        mappedAbsoluteEpisodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        mappedSeriesId:
+          type: integer
+          format: int32
+          nullable: true
+        mappedEpisodeInfo:
+          type: array
+          items:
+            $ref: "#/components/schemas/ReleaseEpisodeResource"
+          nullable: true
+        episodeRequested:
+          type: boolean
+        downloadAllowed:
+          type: boolean
+        releaseWeight:
+          type: integer
+          format: int32
+        customFormats:
+          type: array
+          items:
+            $ref: "#/components/schemas/CustomFormatResource"
+          nullable: true
+        customFormatScore:
+          type: integer
+          format: int32
+        sceneMapping:
+          $ref: "#/components/schemas/AlternateTitleResource"
+      additionalProperties: false
+    ReleaseType:
+      enum:
+        - unknown
+        - singleEpisode
+        - multiEpisode
+        - seasonPack
+      type: string
+    RemotePathMappingResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        host:
+          type: string
+          nullable: true
+        remotePath:
+          type: string
+          nullable: true
+        localPath:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RenameEpisodeResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seriesId:
+          type: integer
+          format: int32
+        seasonNumber:
+          type: integer
+          format: int32
+        episodeNumbers:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        episodeFileId:
+          type: integer
+          format: int32
+        existingPath:
+          type: string
+          nullable: true
+        newPath:
+          type: string
+          nullable: true
+      additionalProperties: false
+    RescanAfterRefreshType:
+      enum:
+        - always
+        - afterManual
+        - never
+      type: string
+    Revision:
+      type: object
+      properties:
+        version:
+          type: integer
+          format: int32
+        real:
+          type: integer
+          format: int32
+        isRepack:
+          type: boolean
+      additionalProperties: false
+    RootFolderResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        path:
+          type: string
+          nullable: true
+        accessible:
+          type: boolean
+        isEmpty:
+          type: boolean
+        freeSpace:
+          type: integer
+          format: int64
+          nullable: true
+        totalSpace:
+          type: integer
+          format: int64
+          nullable: true
+        unmappedFolders:
+          type: array
+          items:
+            $ref: "#/components/schemas/UnmappedFolder"
+          nullable: true
+      additionalProperties: false
+    RuntimeMode:
+      enum:
+        - console
+        - service
+        - tray
+      type: string
+    SearchInfoResource:
+      type: object
+      properties:
+        seriesId:
+          type: integer
+          format: int32
+          nullable: true
+        seasonNumber:
+          type: integer
+          format: int32
+          nullable: true
+        episodeId:
+          type: integer
+          format: int32
+          nullable: true
+      additionalProperties: false
+    SeasonPackUpgradeType:
+      enum:
+        - all
+        - threshold
+        - any
+      type: string
+    SeasonPassResource:
+      type: object
+      properties:
+        series:
+          type: array
+          items:
+            $ref: "#/components/schemas/SeasonPassSeriesResource"
+          nullable: true
+        monitoringOptions:
+          $ref: "#/components/schemas/MonitoringOptionsResource"
+      additionalProperties: false
+    SeasonPassSeriesResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        monitored:
+          type: boolean
+          nullable: true
+        seasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/SeasonResource"
+          nullable: true
+      additionalProperties: false
+    SeasonResource:
+      type: object
+      properties:
+        seasonNumber:
+          type: integer
+          format: int32
+        monitored:
+          type: boolean
+        statistics:
+          $ref: "#/components/schemas/SeasonStatisticsResource"
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaCover"
+          nullable: true
+      additionalProperties: false
+    SeasonStatisticsResource:
+      type: object
+      properties:
+        nextAiring:
+          type: string
+          format: date-time
+          nullable: true
+        previousAiring:
+          type: string
+          format: date-time
+          nullable: true
+        episodeFileCount:
+          type: integer
+          format: int32
+        episodeCount:
+          type: integer
+          format: int32
+        totalEpisodeCount:
+          type: integer
+          format: int32
+        monitoredEpisodeCount:
+          type: integer
+          format: int32
+        sizeOnDisk:
+          type: integer
+          format: int64
+        releaseGroups:
+          type: array
+          items:
+            type: string
+          nullable: true
+        releaseTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/ReleaseType"
+          nullable: true
+        episodeFileQualities:
+          type: array
+          items:
+            $ref: "#/components/schemas/Quality"
+          nullable: true
+        percentOfEpisodes:
+          type: number
+          format: double
+          readOnly: true
+      additionalProperties: false
+    SelectOption:
+      type: object
+      properties:
+        value:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        order:
+          type: integer
+          format: int32
+        hint:
+          type: string
+          nullable: true
+      additionalProperties: false
+    SeriesEditorResource:
+      type: object
+      properties:
+        seriesIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        monitored:
+          type: boolean
+          nullable: true
+        monitorNewItems:
+          $ref: "#/components/schemas/NewItemMonitorTypes"
+        qualityProfileId:
+          type: integer
+          format: int32
+          nullable: true
+        seriesType:
+          $ref: "#/components/schemas/SeriesTypes"
+        seasonFolder:
+          type: boolean
+          nullable: true
+        rootFolderPath:
+          type: string
+          nullable: true
+        tags:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        applyTags:
+          $ref: "#/components/schemas/ApplyTags"
+        moveFiles:
+          type: boolean
+        deleteFiles:
+          type: boolean
+        addImportListExclusion:
+          type: boolean
+      additionalProperties: false
+    SeriesResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        title:
+          type: string
+          nullable: true
+        alternateTitles:
+          type: array
+          items:
+            $ref: "#/components/schemas/AlternateTitleResource"
+          nullable: true
+        sortTitle:
+          type: string
+          nullable: true
+        status:
+          $ref: "#/components/schemas/SeriesStatusType"
+        ended:
+          type: boolean
+          readOnly: true
+        profileName:
+          type: string
+          nullable: true
+        overview:
+          type: string
+          nullable: true
+        nextAiring:
+          type: string
+          format: date-time
+          nullable: true
+        previousAiring:
+          type: string
+          format: date-time
+          nullable: true
+        network:
+          type: string
+          nullable: true
+        airTime:
+          type: string
+          nullable: true
+        images:
+          type: array
+          items:
+            $ref: "#/components/schemas/MediaCover"
+          nullable: true
+        originalLanguage:
+          $ref: "#/components/schemas/Language"
+        remotePoster:
+          type: string
+          nullable: true
+        seasons:
+          type: array
+          items:
+            $ref: "#/components/schemas/SeasonResource"
+          nullable: true
+        year:
+          type: integer
+          format: int32
+        path:
+          type: string
+          nullable: true
+        qualityProfileId:
+          type: integer
+          format: int32
+        seasonFolder:
+          type: boolean
+        monitored:
+          type: boolean
+        monitorNewItems:
+          $ref: "#/components/schemas/NewItemMonitorTypes"
+        useSceneNumbering:
+          type: boolean
+        runtime:
+          type: integer
+          format: int32
+        tvdbId:
+          type: integer
+          format: int32
+        tvRageId:
+          type: integer
+          format: int32
+        tvMazeId:
+          type: integer
+          format: int32
+        tmdbId:
+          type: integer
+          format: int32
+        malIds:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        aniListIds:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        firstAired:
+          type: string
+          format: date-time
+          nullable: true
+        lastAired:
+          type: string
+          format: date-time
+          nullable: true
+        seriesType:
+          $ref: "#/components/schemas/SeriesTypes"
+        cleanTitle:
+          type: string
+          nullable: true
+        imdbId:
+          type: string
+          nullable: true
+        titleSlug:
+          type: string
+          nullable: true
+        rootFolderPath:
+          type: string
+          nullable: true
+        folder:
+          type: string
+          nullable: true
+        certification:
+          type: string
+          nullable: true
+        genres:
+          type: array
+          items:
+            type: string
+          nullable: true
+        originalCountry:
+          type: string
+          nullable: true
+        tags:
+          uniqueItems: true
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        added:
+          type: string
+          format: date-time
+        addOptions:
+          $ref: "#/components/schemas/AddSeriesOptions"
+        ratings:
+          $ref: "#/components/schemas/Ratings"
+        statistics:
+          $ref: "#/components/schemas/SeriesStatisticsResource"
+        episodesChanged:
+          type: boolean
+          nullable: true
+      additionalProperties: false
+    SeriesStatisticsResource:
+      type: object
+      properties:
+        seasonCount:
+          type: integer
+          format: int32
+        episodeFileCount:
+          type: integer
+          format: int32
+        episodeCount:
+          type: integer
+          format: int32
+        totalEpisodeCount:
+          type: integer
+          format: int32
+        monitoredEpisodeCount:
+          type: integer
+          format: int32
+        sizeOnDisk:
+          type: integer
+          format: int64
+        releaseGroups:
+          type: array
+          items:
+            type: string
+          nullable: true
+        releaseTypes:
+          type: array
+          items:
+            $ref: "#/components/schemas/ReleaseType"
+          nullable: true
+        episodeFileQualities:
+          type: array
+          items:
+            $ref: "#/components/schemas/Quality"
+          nullable: true
+        percentOfEpisodes:
+          type: number
+          format: double
+          readOnly: true
+      additionalProperties: false
+    SeriesStatusType:
+      enum:
+        - continuing
+        - ended
+        - upcoming
+        - deleted
+      type: string
+    SeriesSubresource:
+      enum:
+        - seasonImages
+      type: string
+    SeriesTitleInfo:
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+        titleWithoutYear:
+          type: string
+          nullable: true
+        year:
+          type: integer
+          format: int32
+        allTitles:
+          type: array
+          items:
+            type: string
+          nullable: true
+      additionalProperties: false
+    SeriesTypes:
+      enum:
+        - standard
+        - daily
+        - anime
+      type: string
+    Severity:
+      enum:
+        - error
+        - warning
+        - info
+      type: string
+    SkipValidation:
+      enum:
+        - none
+        - warnings
+        - all
+      type: string
+    SortDirection:
+      enum:
+        - default
+        - ascending
+        - descending
+      type: string
+    StatisticsResource:
+      required:
+        - qualityProfileStatistics
+        - qualityStatistics
+        - tagStatistics
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        seriesCount:
+          type: integer
+          format: int32
+        monitoredSeriesCount:
+          type: integer
+          format: int32
+        completedSeriesCount:
+          type: integer
+          format: int32
+        continuingSeriesCount:
+          type: integer
+          format: int32
+        endedSeriesCount:
+          type: integer
+          format: int32
+        upcomingSeriesCount:
+          type: integer
+          format: int32
+        deletedSeriesCount:
+          type: integer
+          format: int32
+        standardSeriesCount:
+          type: integer
+          format: int32
+        dailySeriesCount:
+          type: integer
+          format: int32
+        animeSeriesCount:
+          type: integer
+          format: int32
+        seasonCount:
+          type: integer
+          format: int32
+        completedSeasonCount:
+          type: integer
+          format: int32
+        totalEpisodeCount:
+          type: integer
+          format: int32
+        monitoredEpisodeCount:
+          type: integer
+          format: int32
+        downloadedEpisodeCount:
+          type: integer
+          format: int32
+        missingEpisodeCount:
+          type: integer
+          format: int32
+        unairedEpisodeCount:
+          type: integer
+          format: int32
+        episodeFileCount:
+          type: integer
+          format: int32
+        sizeOnDisk:
+          type: integer
+          format: int64
+        qualityProfileStatistics:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityProfileStatisticsResource"
+          nullable: true
+        qualityStatistics:
+          type: array
+          items:
+            $ref: "#/components/schemas/QualityStatisticsResource"
+          nullable: true
+        tagStatistics:
+          type: array
+          items:
+            $ref: "#/components/schemas/TagStatisticsResource"
+          nullable: true
+      additionalProperties: false
+    SystemResource:
+      required:
+        - appData
+        - appName
+        - branch
+        - databaseVersion
+        - instanceName
+        - osName
+        - osVersion
+        - packageAuthor
+        - packageUpdateMechanismMessage
+        - packageVersion
+        - runtimeName
+        - runtimeVersion
+        - startupPath
+        - urlBase
+        - version
+      type: object
+      properties:
+        appName:
+          type: string
+          nullable: true
+        instanceName:
+          type: string
+          nullable: true
+        version:
+          type: string
+          nullable: true
+        buildTime:
+          type: string
+          format: date-time
+        isDebug:
+          type: boolean
+        isProduction:
+          type: boolean
+        isAdmin:
+          type: boolean
+        isUserInteractive:
+          type: boolean
+        startupPath:
+          type: string
+          nullable: true
+        appData:
+          type: string
+          nullable: true
+        osName:
+          type: string
+          nullable: true
+        osVersion:
+          type: string
+          nullable: true
+        isNetCore:
+          type: boolean
+        isLinux:
+          type: boolean
+        isOsx:
+          type: boolean
+        isWindows:
+          type: boolean
+        isDocker:
+          type: boolean
+        mode:
+          $ref: "#/components/schemas/RuntimeMode"
+        branch:
+          type: string
+          nullable: true
+        authentication:
+          $ref: "#/components/schemas/AuthenticationType"
+        migrationVersion:
+          type: integer
+          format: int32
+        urlBase:
+          type: string
+          nullable: true
+        runtimeVersion:
+          type: string
+          nullable: true
+        runtimeName:
+          type: string
+          nullable: true
+        startTime:
+          type: string
+          format: date-time
+        packageVersion:
+          type: string
+          nullable: true
+        packageAuthor:
+          type: string
+          nullable: true
+        packageUpdateMechanism:
+          $ref: "#/components/schemas/UpdateMechanism"
+        packageUpdateMechanismMessage:
+          type: string
+          nullable: true
+        databaseVersion:
+          type: string
+          nullable: true
+        databaseType:
+          $ref: "#/components/schemas/DatabaseType"
+      additionalProperties: false
+    TagDetailsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        label:
+          type: string
+          nullable: true
+        delayProfileIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        importListIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        notificationIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        restrictionIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        excludedReleaseProfileIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        indexerIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        downloadClientIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        autoTagIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+        seriesIds:
+          type: array
+          items:
+            type: integer
+            format: int32
+          nullable: true
+      additionalProperties: false
+    TagResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        label:
+          type: string
+          nullable: true
+      additionalProperties: false
+    TagStatisticsResource:
+      required:
+        - label
+      type: object
+      properties:
+        tagId:
+          type: integer
+          format: int32
+        label:
+          type: string
+          nullable: true
+        seriesCount:
+          type: integer
+          format: int32
+        episodeFileCount:
+          type: integer
+          format: int32
+        sizeOnDisk:
+          type: integer
+          format: int64
+      additionalProperties: false
+    TaskResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        name:
+          type: string
+          nullable: true
+        taskName:
+          type: string
+          nullable: true
+        interval:
+          type: integer
+          format: int32
+        lastExecution:
+          type: string
+          format: date-time
+        lastStartTime:
+          type: string
+          format: date-time
+        nextExecution:
+          type: string
+          format: date-time
+        lastDuration:
+          type: string
+          format: date-span
+      additionalProperties: false
+    TrackedDownloadState:
+      enum:
+        - downloading
+        - importBlocked
+        - importPending
+        - importing
+        - imported
+        - failedPending
+        - failed
+        - ignored
+      type: string
+    TrackedDownloadStatus:
+      enum:
+        - ok
+        - warning
+        - error
+      type: string
+    TrackedDownloadStatusMessage:
+      type: object
+      properties:
+        title:
+          type: string
+          nullable: true
+        messages:
+          type: array
+          items:
+            type: string
+          nullable: true
+      additionalProperties: false
+    UiSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        firstDayOfWeek:
+          type: integer
+          format: int32
+        calendarWeekColumnHeader:
+          type: string
+          nullable: true
+        shortDateFormat:
+          type: string
+          nullable: true
+        longDateFormat:
+          type: string
+          nullable: true
+        timeFormat:
+          type: string
+          nullable: true
+        timeZone:
+          type: string
+          nullable: true
+        showRelativeDates:
+          type: boolean
+        enableColorImpairedMode:
+          type: boolean
+        theme:
+          type: string
+          nullable: true
+        uiLanguage:
+          type: integer
+          format: int32
+      additionalProperties: false
+    UnmappedFolder:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        path:
+          type: string
+          nullable: true
+        relativePath:
+          type: string
+          nullable: true
+      additionalProperties: false
+    UpdateChanges:
+      type: object
+      properties:
+        new:
+          type: array
+          items:
+            type: string
+          nullable: true
+        fixed:
+          type: array
+          items:
+            type: string
+          nullable: true
+      additionalProperties: false
+    UpdateMechanism:
+      enum:
+        - builtIn
+        - script
+        - external
+        - apt
+        - docker
+      type: string
+    UpdateResource:
+      required:
+        - branch
+        - changes
+        - fileName
+        - hash
+        - url
+        - version
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        version:
+          type: string
+          nullable: true
+        branch:
+          type: string
+          nullable: true
+        releaseDate:
+          type: string
+          format: date-time
+        fileName:
+          type: string
+          nullable: true
+        url:
+          type: string
+          nullable: true
+        installed:
+          type: boolean
+        installedOn:
+          type: string
+          format: date-time
+          nullable: true
+        installable:
+          type: boolean
+        latest:
+          type: boolean
+        changes:
+          $ref: "#/components/schemas/UpdateChanges"
+        hash:
+          type: string
+          nullable: true
+      additionalProperties: false
+    UpdateSettingsResource:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int32
+        branch:
+          type: string
+          nullable: true
+        updateAutomatically:
+          type: boolean
+        updateMechanism:
+          $ref: "#/components/schemas/UpdateMechanism"
+        updateScriptPath:
+          type: string
+          nullable: true
+      additionalProperties: false
+    ValidationFailure:
+      type: object
+      properties:
+        propertyName:
+          type: string
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+        attemptedValue:
+          nullable: true
+        customState:
+          nullable: true
+        severity:
+          $ref: "#/components/schemas/Severity"
+        errorCode:
+          type: string
+          nullable: true
+        formattedMessageArguments:
+          type: array
+          items: {}
+          nullable: true
+          deprecated: true
+        formattedMessagePlaceholderValues:
+          type: object
+          additionalProperties:
+            nullable: true
+          nullable: true
+      additionalProperties: false
+  securitySchemes:
+    X-Api-Key:
+      type: apiKey
+      description: Apikey passed as header
+      name: X-Api-Key
+      in: header
+    apikey:
+      type: apiKey
+      description: Apikey passed as query parameter
+      name: apikey
+      in: query
+security:
+  - X-Api-Key: []
+  - apikey: []
+tags:
+  - name: ApiInfo
+  - name: Authentication
+  - name: StaticResource
+  - name: AutoTagging
+  - name: Backup
+  - name: Blocklist
+  - name: Calendar
+  - name: CalendarFeed
+  - name: Command
+  - name: Connection
+  - name: CustomFilter
+  - name: CustomFormat
+  - name: Cutoff
+  - name: DelayProfile
+  - name: DiskSpace
+  - name: DownloadClient
+  - name: DownloadClientSettings
+  - name: Episode
+  - name: EpisodeFile
+  - name: FileSystem
+  - name: GeneralSettings
+  - name: Health
+  - name: History
+  - name: ImportList
+  - name: ImportListExclusion
+  - name: ImportListSettings
+  - name: Indexer
+  - name: IndexerFlag
+  - name: IndexerSettings
+  - name: Language
+  - name: Localization
+  - name: Log
+  - name: LogFile
+  - name: ManualImport
+  - name: MediaManagementSettings
+  - name: Metadata
+  - name: Missing
+  - name: NamingSettings
+  - name: Parse
+  - name: Ping
+  - name: QualityDefinition
+  - name: QualityProfile
+  - name: QualityProfileSchema
+  - name: Queue
+  - name: QueueAction
+  - name: QueueDetails
+  - name: QueueStatus
+  - name: Release
+  - name: ReleaseProfile
+  - name: ReleasePush
+  - name: RemotePathMapping
+  - name: RenameEpisode
+  - name: RootFolder
+  - name: SeasonPass
+  - name: Series
+  - name: SeriesEditor
+  - name: SeriesFolder
+  - name: SeriesImport
+  - name: SeriesLookup
+  - name: Statistics
+  - name: System
+  - name: Tag
+  - name: TagDetails
+  - name: Task
+  - name: UiSettings
+  - name: Update
+  - name: UpdateLogFile
+  - name: UpdateSettings


### PR DESCRIPTION
This PR introduces the second phase of the Sonarr redesign on top of the clean upstream history. It implements the Material 3 Expressive layout for the series detail screen, integrates the RefreshSeries command into pull-to-refresh, adds interactive season release searches, and serves high-quality banners.