### PR TITLE
feat(sonarr): implement sort/filter, disk sizes, direct instance editing, and navigation drawer overlay improvements

### DIFF
--- a/app/lib/src/router.dart
+++ b/app/lib/src/router.dart
@@ -1,4 +1,6 @@
 import 'package:core_router/core_router.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_models/core_models.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
@@ -28,7 +30,16 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((Ref ref) {
           GoRouterState state,
           StatefulNavigationShell shell,
         ) =>
-            ScaffoldWithNavBar(navigationShell: shell),
+            Consumer(
+              builder: (BuildContext context, WidgetRef ref, Widget? child) {
+                final List<Instance> instances = ref.watch(activeInstancesProvider);
+                final Profile? profile = ref.watch(activeProfileProvider);
+                return ScaffoldWithNavBar(
+                  navigationShell: shell,
+                  drawer: ServicesDrawer(instances: instances, profile: profile),
+                );
+              },
+            ),
         branches: <StatefulShellBranch>[
           StatefulShellBranch(
             routes: <RouteBase>[

--- a/app/lib/src/screens/activity_screen.dart
+++ b/app/lib/src/screens/activity_screen.dart
@@ -9,7 +9,19 @@ class ActivityScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Activity')),
+      appBar: AppBar(
+        leading: Builder(
+          builder: (BuildContext context) {
+            return IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () {
+                openDrawer(context);
+              },
+            );
+          },
+        ),
+        title: const Text('Activity'),
+      ),
       body: const EmptyView(
         icon: Icons.swap_vert_outlined,
         title: 'Activity coming soon',

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -307,7 +307,19 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
 
     if (!hasCalendarServices) {
       return Scaffold(
-        appBar: AppBar(title: const Text('Calendar')),
+        appBar: AppBar(
+          leading: Builder(
+            builder: (BuildContext context) {
+              return IconButton(
+                icon: const Icon(Icons.menu),
+                onPressed: () {
+                  openDrawer(context);
+                },
+              );
+            },
+          ),
+          title: const Text('Calendar'),
+        ),
         body: const EmptyView(
           icon: Icons.calendar_today_outlined,
           title: 'No calendar services',
@@ -319,6 +331,16 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
 
     return Scaffold(
       appBar: AppBar(
+        leading: Builder(
+          builder: (BuildContext context) {
+            return IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () {
+                openDrawer(context);
+              },
+            );
+          },
+        ),
         title: const Text('Calendar'),
       ),
       body: M3RefreshIndicator(

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -22,13 +22,18 @@ class DashboardScreen extends ConsumerWidget {
 
     return Scaffold(
       appBar: AppBar(
+        leading: Builder(
+          builder: (BuildContext context) {
+            return IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () {
+                openDrawer(context);
+              },
+            );
+          },
+        ),
         title: Text(profile == null ? 'Atrium' : profile.name),
       ),
-      drawer: ServicesDrawer(instances: instances, profile: profile),
-      // Wide left-edge drag zone so the sidebar opens with a swipe from well
-      // inside the screen, clear of Android's system back-gesture strip - no
-      // need to hit the hamburger.
-      drawerEdgeDragWidth: MediaQuery.sizeOf(context).width * 0.5,
       body: instances.isEmpty
           ? EmptyView(
               icon: Icons.dns_outlined,
@@ -349,6 +354,51 @@ class _HealthAwareTile extends ConsumerWidget {
         final GoRouter router = GoRouter.of(context);
         Navigator.of(context).pop();
         router.go(AtriumRoutes.servicePath(instance.kind.name, instance.id));
+      },
+      onLongPress: () {
+        showModalBottomSheet<void>(
+          context: context,
+          showDragHandle: true,
+          builder: (BuildContext sheetContext) {
+            return SafeArea(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  ListTile(
+                    leading: const Icon(Icons.open_in_new),
+                    title: const Text('Open service'),
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      final GoRouter router = GoRouter.of(context);
+                      Navigator.of(context).pop();
+                      router.go(
+                        AtriumRoutes.servicePath(
+                          instance.kind.name,
+                          instance.id,
+                        ),
+                      );
+                    },
+                  ),
+                  ListTile(
+                    leading: const Icon(Icons.edit),
+                    title: const Text('Edit connection settings'),
+                    onTap: () {
+                      Navigator.pop(sheetContext);
+                      final GoRouter router = GoRouter.of(context);
+                      Navigator.of(context).pop();
+                      router.goNamed(
+                        AtriumRoutes.editInstanceName,
+                        pathParameters: <String, String>{
+                          'instanceId': instance.id,
+                        },
+                      );
+                    },
+                  ),
+                ],
+              ),
+            );
+          },
+        );
       },
     );
   }

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -18,7 +18,19 @@ class SettingsScreen extends ConsumerWidget {
         ref.read(preferencesProvider.notifier);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Settings')),
+      appBar: AppBar(
+        leading: Builder(
+          builder: (BuildContext context) {
+            return IconButton(
+              icon: const Icon(Icons.menu),
+              onPressed: () {
+                openDrawer(context);
+              },
+            );
+          },
+        ),
+        title: const Text('Settings'),
+      ),
       body: ListView(
         children: <Widget>[
           const _SectionHeader('Appearance'),

--- a/packages/core_networking/lib/src/network_exception.dart
+++ b/packages/core_networking/lib/src/network_exception.dart
@@ -23,7 +23,7 @@ sealed class NetworkException implements Exception {
       DioExceptionType.cancel =>
         const NetworkCancelledException('Request was cancelled.'),
       DioExceptionType.badResponse => _fromBadResponse(e),
-      DioExceptionType.unknown =>
+      DioExceptionType.unknown || _ =>
         NetworkUnknownException(e.message ?? 'Unknown network error.'),
     };
   }

--- a/packages/core_router/lib/src/scaffold_with_nav_bar.dart
+++ b/packages/core_router/lib/src/scaffold_with_nav_bar.dart
@@ -7,14 +7,21 @@ import 'package:go_router/go_router.dart';
 /// navigation stack (tapping away from a deep screen and back returns you
 /// where you were). Used as the builder for a `StatefulShellRoute`.
 class ScaffoldWithNavBar extends StatelessWidget {
-  const ScaffoldWithNavBar({required this.navigationShell, super.key});
+  const ScaffoldWithNavBar({
+    required this.navigationShell,
+    this.drawer,
+    super.key,
+  });
 
   final StatefulNavigationShell navigationShell;
+  final Widget? drawer;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: navigationShell,
+      drawer: drawer,
+      drawerEdgeDragWidth: drawer != null ? MediaQuery.sizeOf(context).width * 0.5 : null,
       bottomNavigationBar: NavigationBar(
         selectedIndex: navigationShell.currentIndex,
         onDestinationSelected: _onTap,

--- a/packages/core_ui/lib/src/navigation.dart
+++ b/packages/core_ui/lib/src/navigation.dart
@@ -17,3 +17,14 @@ Future<T?> pushScreen<T>(BuildContext context, Widget screen) =>
     Navigator.of(context, rootNavigator: true).push<T>(
       MaterialPageRoute<T>(builder: (_) => screen),
     );
+
+/// Finds the nearest ancestor ScaffoldState that has a drawer, and opens it.
+/// Used in multi-Scaffold nesting (e.g. inner screen Scaffold nested inside
+/// an outer bottom nav Scaffold that owns the drawer).
+void openDrawer(BuildContext context) {
+  ScaffoldState? scaffold = Scaffold.maybeOf(context);
+  while (scaffold != null && !scaffold.hasDrawer) {
+    scaffold = scaffold.context.findAncestorStateOfType<ScaffoldState>();
+  }
+  scaffold?.openDrawer();
+}

--- a/packages/core_ui/lib/src/widgets/service_tile.dart
+++ b/packages/core_ui/lib/src/widgets/service_tile.dart
@@ -13,6 +13,7 @@ class ServiceTile extends StatelessWidget {
     this.health = Health.unknown,
     this.subtitle,
     this.onTap,
+    this.onLongPress,
     super.key,
   });
 
@@ -23,6 +24,7 @@ class ServiceTile extends StatelessWidget {
   /// e.g., a queue count or "3 missing".
   final String? subtitle;
   final VoidCallback? onTap;
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -46,6 +48,7 @@ class ServiceTile extends StatelessWidget {
         subtitle: Text(subtitle ?? instance.kind.tagline),
         trailing: StatusChip(health: health, compact: true),
         onTap: onTap,
+        onLongPress: onLongPress,
       ),
     );
   }

--- a/services/service_sonarr/lib/src/home/manual_import_dialog.dart
+++ b/services/service_sonarr/lib/src/home/manual_import_dialog.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
 import 'package:core_ui/core_ui.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -81,23 +83,59 @@ class __ManualImportSetupDialogState
       return;
     }
 
+    final CancelToken cancelToken = CancelToken();
+
     // Show loading overlay
     final NavigatorState nav = Navigator.of(context, rootNavigator: true);
     unawaited(showDialog<void>(
       context: context,
       barrierDismissible: false,
-      builder: (BuildContext context) => const PopScope<Object?>(
+      builder: (BuildContext dialogContext) => PopScope<Object?>(
         canPop: false,
         child: Center(
           child: Card(
+            margin: const EdgeInsets.symmetric(horizontal: 32),
             child: Padding(
-              padding: EdgeInsets.all(24.0),
+              padding: const EdgeInsets.all(24.0),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  ExpressiveProgressIndicator(),
-                  SizedBox(height: 16),
-                  Text('Scanning folder contents...'),
+                  const ExpressiveProgressIndicator(),
+                  const SizedBox(height: 16),
+                  const Text('Scanning folder contents...'),
+                  const SizedBox(height: 24),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: <Widget>[
+                      TextButton(
+                        onPressed: () async {
+                          final bool? confirm = await showDialog<bool>(
+                            context: dialogContext,
+                            builder: (BuildContext confirmContext) => AlertDialog(
+                              title: const Text('Cancel Scan?'),
+                              content: const Text(
+                                'Are you sure you want to stop scanning this folder?',
+                              ),
+                              actions: <Widget>[
+                                TextButton(
+                                  onPressed: () => Navigator.pop(confirmContext, false),
+                                  child: const Text('No'),
+                                ),
+                                TextButton(
+                                  onPressed: () => Navigator.pop(confirmContext, true),
+                                  child: const Text('Yes, Cancel'),
+                                ),
+                              ],
+                            ),
+                          );
+                          if (confirm == true) {
+                            cancelToken.cancel('user_cancelled');
+                          }
+                        },
+                        child: const Text('Cancel'),
+                      ),
+                    ],
+                  ),
                 ],
               ),
             ),
@@ -115,6 +153,7 @@ class __ManualImportSetupDialogState
       scanResults = await api.getManualImport(
         folder: folder,
         filterExistingFiles: filterExisting,
+        cancelToken: cancelToken,
       );
     } catch (e) {
       error = e;
@@ -124,9 +163,15 @@ class __ManualImportSetupDialogState
 
     if (!mounted) return;
     if (error != null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Scan failed: $error')),
-      );
+      if (error is NetworkCancelledException) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Scan cancelled.')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Scan failed: $error')),
+        );
+      }
       return;
     }
 
@@ -525,13 +570,51 @@ class __ManualImportMappingScreenState
   final Set<String> _selectedPaths = <String>{};
   bool _importing = false;
 
+  bool _isVideoFile(Map<String, dynamic> f) {
+    final String? path = (f['path'] as String?)?.toLowerCase();
+    if (path == null) return false;
+
+    // TypeScript definition files are never videos
+    if (path.endsWith('.d.ts')) return false;
+
+    // Standard video extensions supported by Sonarr / Radarr / typical players
+    const Set<String> videoExtensions = <String>{
+      '.mkv',
+      '.mp4',
+      '.avi',
+      '.m4v',
+      '.mov',
+      '.wmv',
+      '.mpg',
+      '.mpeg',
+      '.flv',
+      '.webm',
+      '.ts',
+    };
+
+    final bool hasVideoExtension = videoExtensions.any(path.endsWith);
+    if (!hasVideoExtension) return false;
+
+    // If it's a .ts file, ensure it's not a tiny TypeScript file.
+    // Real video .ts files are typically at least 1MB (1,048,576 bytes).
+    if (path.endsWith('.ts')) {
+      final int size = (f['size'] as num?)?.toInt() ?? 0;
+      if (size < 1024 * 1024) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
   @override
   void initState() {
     super.initState();
-    // Copy the items locally so they are mutable
-    _files = List<dynamic>.from(
+    // Copy the items locally so they are mutable, filtering out non-video files
+    final List<Map<String, dynamic>> rawFiles = List<Map<String, dynamic>>.from(
       widget.initialFiles.map((dynamic f) => Map<String, dynamic>.from(f as Map)),
     );
+    _files = rawFiles.where(_isVideoFile).toList();
 
     // Auto-select items that are parsed successfully and have no rejections
     for (final f in _files.cast<Map<String, dynamic>>()) {

--- a/services/service_sonarr/lib/src/home/series_tab.dart
+++ b/services/service_sonarr/lib/src/home/series_tab.dart
@@ -133,20 +133,42 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                 sonarrActiveTabBarIndexProvider(widget.instance),
               ) ==
               0
-          ? FloatingActionButton.extended(
-              shape: const StadiumBorder(),
-              backgroundColor: theme.colorScheme.primaryContainer,
-              foregroundColor: theme.colorScheme.onPrimaryContainer,
-              onPressed: () {
-                Navigator.of(context, rootNavigator: true).push(
-                  FadePageRoute<void>(
-                    builder: (BuildContext context) =>
-                        SonarrAddSeriesSearchScreen(instance: widget.instance),
-                  ),
-                );
-              },
-              icon: const Icon(Icons.add),
-              label: const Text('Add Series'),
+          ? Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: <Widget>[
+                FloatingActionButton.small(
+                  heroTag: 'sonarr_sort_filter_fab',
+                  backgroundColor: theme.colorScheme.secondaryContainer,
+                  foregroundColor: theme.colorScheme.onSecondaryContainer,
+                  onPressed: () {
+                    showModalBottomSheet<void>(
+                      context: context,
+                      showDragHandle: true,
+                      builder: (BuildContext context) =>
+                          _SortFilterBottomSheet(instance: widget.instance),
+                    );
+                  },
+                  child: const Icon(Icons.tune),
+                ),
+                const SizedBox(height: 12),
+                FloatingActionButton.extended(
+                  heroTag: 'sonarr_add_series_fab',
+                  shape: const StadiumBorder(),
+                  backgroundColor: theme.colorScheme.primaryContainer,
+                  foregroundColor: theme.colorScheme.onPrimaryContainer,
+                  onPressed: () {
+                    Navigator.of(context, rootNavigator: true).push(
+                      FadePageRoute<void>(
+                        builder: (BuildContext context) =>
+                            SonarrAddSeriesSearchScreen(instance: widget.instance),
+                      ),
+                    );
+                  },
+                  icon: const Icon(Icons.add),
+                  label: const Text('Add Series'),
+                ),
+              ],
             )
           : null,
       body: GestureDetector(
@@ -185,7 +207,7 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                         : IconButton(
                             icon: const Icon(Icons.menu),
                             onPressed: () {
-                              Scaffold.of(context).openDrawer();
+                              openDrawer(context);
                             },
                           ),
                     title: isSelecting
@@ -538,9 +560,11 @@ class _SeriesCard extends StatelessWidget {
   }
 
   String _subtitle() {
+    final int sizeOnDisk = series.statistics?.sizeOnDisk ?? 0;
     final List<String> parts = <String>[
       if (series.year != null) '${series.year}',
       if (series.status != null) series.status!,
+      if (sizeOnDisk > 0) _formatSize(sizeOnDisk),
     ];
     return parts.join(' • ');
   }
@@ -740,10 +764,12 @@ class _SeriesBannerCard extends ConsumerWidget {
   }
 
   String _metaText() {
+    final int sizeOnDisk = series.statistics?.sizeOnDisk ?? 0;
     final List<String> parts = <String>[
       if (series.year != null) '${series.year}',
       if (series.network != null && series.network!.isNotEmpty) series.network!,
       if (series.status != null && series.status!.isNotEmpty) series.status!,
+      if (sizeOnDisk > 0) _formatSize(sizeOnDisk),
     ];
     return parts.join(' • ');
   }
@@ -1141,5 +1167,146 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
       ],
     );
   }
+}
+
+class _SortFilterBottomSheet extends ConsumerWidget {
+  const _SortFilterBottomSheet({required this.instance});
+
+  final Instance instance;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
+    final sortField = ref.watch(sonarrSeriesSortFieldProvider(instance));
+    final sortAscending = ref.watch(sonarrSeriesSortAscendingProvider(instance));
+    final filter = ref.watch(sonarrSeriesFilterProvider(instance));
+
+    return SafeArea(
+      child: SingleChildScrollView(
+        child: Padding(
+          padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              Text(
+                'Filter',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: SonarrSeriesFilter.values.map((f) {
+                  final label = switch (f) {
+                    SonarrSeriesFilter.all => 'All',
+                    SonarrSeriesFilter.monitoredOnly => 'Monitored Only',
+                    SonarrSeriesFilter.unmonitoredOnly => 'Unmonitored Only',
+                    SonarrSeriesFilter.continuingOnly => 'Continuing Only',
+                    SonarrSeriesFilter.endedOnly => 'Ended Only',
+                    SonarrSeriesFilter.missingEpisodes => 'Missing Episodes',
+                  };
+                  final selected = filter == f;
+                  return ChoiceChip(
+                    label: Text(label),
+                    selected: selected,
+                    onSelected: (val) {
+                      if (val) {
+                        ref
+                            .read(sonarrSeriesFilterProvider(instance).notifier)
+                            .state = f;
+                      }
+                    },
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Sort By',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              Wrap(
+                spacing: 8,
+                runSpacing: 4,
+                children: SonarrSeriesSortField.values.map((field) {
+                  final label = switch (field) {
+                    SonarrSeriesSortField.monitoredStatus => 'Monitored/Status',
+                    SonarrSeriesSortField.title => 'Title',
+                    SonarrSeriesSortField.network => 'Network',
+                    SonarrSeriesSortField.nextAiring => 'Next Airing',
+                    SonarrSeriesSortField.previousAiring => 'Previous Airing',
+                    SonarrSeriesSortField.added => 'Added',
+                    SonarrSeriesSortField.seasons => 'Seasons',
+                    SonarrSeriesSortField.episodes => 'Episodes',
+                    SonarrSeriesSortField.episodeCount => 'Episode Count',
+                    SonarrSeriesSortField.sizeOnDisk => 'Size on Disk',
+                  };
+                  final selected = sortField == field;
+                  return ChoiceChip(
+                    label: Text(label),
+                    selected: selected,
+                    onSelected: (val) {
+                      if (val) {
+                        ref
+                            .read(sonarrSeriesSortFieldProvider(instance).notifier)
+                            .state = field;
+                      }
+                    },
+                  );
+                }).toList(),
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'Order',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              const SizedBox(height: 8),
+              SegmentedButton<bool>(
+                segments: const <ButtonSegment<bool>>[
+                  ButtonSegment<bool>(
+                    value: true,
+                    label: Text('Ascending'),
+                    icon: Icon(Icons.arrow_upward),
+                  ),
+                  ButtonSegment<bool>(
+                    value: false,
+                    label: Text('Descending'),
+                    icon: Icon(Icons.arrow_downward),
+                  ),
+                ],
+                selected: {sortAscending},
+                onSelectionChanged: (val) {
+                  ref
+                      .read(sonarrSeriesSortAscendingProvider(instance).notifier)
+                      .state = val.first;
+                },
+              ),
+              const SizedBox(height: 16),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+String _formatSize(int bytes) {
+  if (bytes <= 0) return '0 B';
+  const List<String> suffixes = <String>['B', 'KB', 'MB', 'GB', 'TB'];
+  int i = 0;
+  double dBytes = bytes.toDouble();
+  while (dBytes >= 1024 && i < suffixes.length - 1) {
+    dBytes /= 1024;
+    i++;
+  }
+  return '${dBytes.toStringAsFixed(1)} ${suffixes[i]}';
 }
 

--- a/services/service_sonarr/lib/src/home/settings_tab.dart
+++ b/services/service_sonarr/lib/src/home/settings_tab.dart
@@ -1,6 +1,8 @@
 import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 
 import 'settings/connect_settings_screen.dart';
 import 'settings/download_clients_screen.dart';
@@ -111,6 +113,20 @@ class SettingsTab extends StatelessWidget {
             subtitle: 'Manage label identifiers for categories, series, and profiles.',
             icon: Icons.label_outline,
             screen: TagsSettingsScreen(instance: instance),
+          ),
+          _buildSettingsCard(
+            context: context,
+            title: 'Connection Settings',
+            subtitle: 'Edit connection URL, API Key, and label for this Sonarr instance in Atrium.',
+            icon: Icons.key_outlined,
+            onTap: () {
+              context.pushNamed(
+                AtriumRoutes.editInstanceName,
+                pathParameters: <String, String>{
+                  'instanceId': instance.id,
+                },
+              );
+            },
           ),
           const SizedBox(height: Insets.md),
 

--- a/services/service_sonarr/lib/src/models/sonarr_series.dart
+++ b/services/service_sonarr/lib/src/models/sonarr_series.dart
@@ -26,6 +26,7 @@ abstract class SonarrSeries with _$SonarrSeries {
     String? previousAiring,
     int? tvdbId,
     String? titleSlug,
+    String? added,
   }) = _SonarrSeries;
 
   factory SonarrSeries.fromJson(Map<String, dynamic> json) =>

--- a/services/service_sonarr/lib/src/series_detail_screen.dart
+++ b/services/service_sonarr/lib/src/series_detail_screen.dart
@@ -46,7 +46,7 @@ class SeriesDetailScreen extends ConsumerWidget {
 // Main body
 // ---------------------------------------------------------------------------
 
-class _SeriesDetailBody extends ConsumerWidget {
+class _SeriesDetailBody extends ConsumerStatefulWidget {
   const _SeriesDetailBody({
     required this.instance,
     required this.series,
@@ -57,12 +57,19 @@ class _SeriesDetailBody extends ConsumerWidget {
   final SonarrSeries series;
   final AsyncValue<List<SonarrEpisode>> episodesAsync;
 
-  Future<void> _refresh(BuildContext context, WidgetRef ref) async {
+  @override
+  ConsumerState<_SeriesDetailBody> createState() => _SeriesDetailBodyState();
+}
+
+class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
+  int? _selectedSeasonFilter;
+
+  Future<void> _refresh(BuildContext context) async {
     try {
-      final api = await ref.read(sonarrApiProvider(instance).future);
+      final api = await ref.read(sonarrApiProvider(widget.instance).future);
       await api.runCommand(<String, dynamic>{
         'name': 'RefreshSeries',
-        'seriesId': series.id,
+        'seriesId': widget.series.id,
       });
     } catch (e) {
       if (context.mounted) {
@@ -71,48 +78,98 @@ class _SeriesDetailBody extends ConsumerWidget {
         );
       }
     } finally {
-      _invalidateProviders(ref);
+      _invalidateProviders();
     }
   }
 
-  void _invalidateProviders(WidgetRef ref) {
-    ref.invalidate(sonarrSeriesByIdProvider((instance, series.id)));
-    ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
-    ref.invalidate(sonarrSeriesProvider(instance));
+  void _invalidateProviders() {
+    ref.invalidate(sonarrSeriesByIdProvider((widget.instance, widget.series.id)));
+    ref.invalidate(sonarrEpisodesProvider((widget.instance, widget.series.id)));
+    ref.invalidate(sonarrSeriesProvider(widget.instance));
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
-    final SonarrApi? api = ref.watch(sonarrApiProvider(instance)).value;
+    final SonarrApi? api = ref.watch(sonarrApiProvider(widget.instance)).value;
 
-    final SonarrImage? poster = series.images
+    final SonarrImage? poster = widget.series.images
         .firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
     final String? posterUrl =
         poster == null ? null : api?.posterUrl(poster, width: 500);
 
-    final int downloadedCount = series.statistics?.episodeFileCount ?? 0;
-    final int totalEpisodes = series.statistics?.episodeCount ?? 0;
+    final SonarrImage? fanart = widget.series.images
+        .firstWhereOrNull((SonarrImage i) => i.coverType == 'fanart');
+    final String? fanartUrl =
+        fanart == null ? null : api?.posterUrl(fanart, width: 1080);
+
+    final int downloadedCount = widget.series.statistics?.episodeFileCount ?? 0;
+    final int totalEpisodes = widget.series.statistics?.episodeCount ?? 0;
 
     return M3RefreshIndicator(
-      onRefresh: () => _refresh(context, ref),
+      onRefresh: () => _refresh(context),
       child: CustomScrollView(
         slivers: <Widget>[
           // -- AppBar --
           SliverAppBar(
+            expandedHeight: 250,
             pinned: true,
-            title: Text(
-              series.title,
-              style: const TextStyle(fontWeight: FontWeight.w600),
+            stretch: true,
+            backgroundColor: cs.surface,
+            surfaceTintColor: cs.surfaceTint,
+            leading: Center(
+              child: Container(
+                width: 38,
+                height: 38,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: Colors.black.withValues(alpha: 0.35),
+                ),
+                child: IconButton(
+                  icon: const Icon(Icons.arrow_back, size: 20, color: Colors.white),
+                  onPressed: () => Navigator.maybePop(context),
+                  padding: EdgeInsets.zero,
+                ),
+              ),
             ),
             actions: <Widget>[
-              _OverflowMenu(
-                instance: instance,
-                series: series,
-                onRefreshed: () => _invalidateProviders(ref),
+              Center(
+                child: Container(
+                  width: 38,
+                  height: 38,
+                  margin: const EdgeInsets.only(right: 16),
+                  decoration: BoxDecoration(
+                    shape: BoxShape.circle,
+                    color: Colors.black.withValues(alpha: 0.35),
+                  ),
+                  child: _OverflowMenu(
+                    instance: widget.instance,
+                    series: widget.series,
+                    onRefreshed: _invalidateProviders,
+                  ),
+                ),
               ),
             ],
+            flexibleSpace: FlexibleSpaceBar(
+              centerTitle: false,
+              titlePadding: const EdgeInsetsDirectional.only(
+                start: 56,
+                bottom: 16,
+                end: 16,
+              ),
+              title: Text(
+                widget.series.title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: TextStyle(
+                  fontWeight: FontWeight.w600,
+                  fontSize: 18,
+                  color: cs.onSurface,
+                ),
+              ),
+              background: _Backdrop(fanartUrl: fanartUrl),
+            ),
           ),
 
           // -- Content --
@@ -127,7 +184,7 @@ class _SeriesDetailBody extends ConsumerWidget {
               children: <Widget>[
                 // Hero info card
                 _HeroInfoCard(
-                  series: series,
+                  series: widget.series,
                   posterUrl: posterUrl,
                 ),
 
@@ -137,25 +194,25 @@ class _SeriesDetailBody extends ConsumerWidget {
                 _StatsCard(
                   downloadedCount: downloadedCount,
                   totalEpisodes: totalEpisodes,
-                  sizeOnDisk: series.statistics?.sizeOnDisk ?? 0,
+                  sizeOnDisk: widget.series.statistics?.sizeOnDisk ?? 0,
                 ),
 
                 const SizedBox(height: Insets.lg),
 
                 // Action buttons row
                 _ActionsRow(
-                  instance: instance,
-                  series: series,
-                  onRefreshed: () => _invalidateProviders(ref),
+                  instance: widget.instance,
+                  series: widget.series,
+                  onRefreshed: _invalidateProviders,
                 ),
 
                 // Genre chips
-                if (series.genres.isNotEmpty) ...<Widget>[
+                if (widget.series.genres.isNotEmpty) ...<Widget>[
                   const SizedBox(height: Insets.lg),
                   Wrap(
                     spacing: Insets.sm,
                     runSpacing: Insets.sm,
-                    children: series.genres
+                    children: widget.series.genres
                         .map(
                           (String g) => Chip(
                             label: Text(g),
@@ -174,17 +231,17 @@ class _SeriesDetailBody extends ConsumerWidget {
                 ],
 
                 // Overview
-                if (series.overview != null &&
-                    series.overview!.isNotEmpty) ...<Widget>[
+                if (widget.series.overview != null &&
+                    widget.series.overview!.isNotEmpty) ...<Widget>[
                   const SizedBox(height: Insets.lg),
-                  _OverviewSection(overview: series.overview!),
+                  _OverviewSection(overview: widget.series.overview!),
                 ],
 
                 // Info section (path, next airing)
-                if (series.path != null ||
-                    series.nextAiring != null) ...<Widget>[
+                if (widget.series.path != null ||
+                    widget.series.nextAiring != null) ...<Widget>[
                   const SizedBox(height: Insets.lg),
-                  _InfoSection(series: series),
+                  _InfoSection(series: widget.series),
                 ],
 
                 const SizedBox(height: Insets.xl),
@@ -198,9 +255,56 @@ class _SeriesDetailBody extends ConsumerWidget {
                 const SizedBox(height: Insets.md),
 
                 // Episodes content
-                ...episodesAsync.when(
-                  data: (List<SonarrEpisode> episodes) =>
-                      _buildSeasonCards(context, ref, episodes),
+                ...widget.episodesAsync.when(
+                  data: (List<SonarrEpisode> episodes) {
+                    final Map<int, List<SonarrEpisode>> episodesBySeason =
+                        groupBy(episodes, (e) => e.seasonNumber);
+                    final List<int> sortedSeasons = episodesBySeason.keys.toList()
+                      ..sort((a, b) => b.compareTo(a)); // newest first
+
+                    return [
+                      if (sortedSeasons.isNotEmpty) ...[
+                        SingleChildScrollView(
+                          scrollDirection: Axis.horizontal,
+                          padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+                          child: Row(
+                            children: [
+                              ChoiceChip(
+                                label: const Text('All'),
+                                selected: _selectedSeasonFilter == null,
+                                onSelected: (selected) {
+                                  if (selected) {
+                                    setState(() {
+                                      _selectedSeasonFilter = null;
+                                    });
+                                  }
+                                },
+                              ),
+                              ...sortedSeasons.map((seasonNum) {
+                                final label = seasonNum == 0 ? 'Specials' : 'Season $seasonNum';
+                                return Padding(
+                                  padding: const EdgeInsets.only(left: Insets.xs),
+                                  child: ChoiceChip(
+                                    label: Text(label),
+                                    selected: _selectedSeasonFilter == seasonNum,
+                                    onSelected: (selected) {
+                                      if (selected) {
+                                        setState(() {
+                                          _selectedSeasonFilter = seasonNum;
+                                        });
+                                      }
+                                    },
+                                  ),
+                                );
+                              }),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: Insets.md),
+                      ],
+                      ..._buildSeasonCards(context, episodesBySeason, sortedSeasons),
+                    ];
+                  },
                   loading: () => <Widget>[
                     const Center(
                       child: Padding(
@@ -226,7 +330,7 @@ class _SeriesDetailBody extends ConsumerWidget {
                             const SizedBox(height: Insets.sm),
                             FilledButton.tonal(
                               onPressed: () => ref.invalidate(
-                                sonarrEpisodesProvider((instance, series.id)),
+                                sonarrEpisodesProvider((widget.instance, widget.series.id)),
                               ),
                               child: const Text('Retry'),
                             ),
@@ -246,31 +350,30 @@ class _SeriesDetailBody extends ConsumerWidget {
 
   List<Widget> _buildSeasonCards(
     BuildContext context,
-    WidgetRef ref,
-    List<SonarrEpisode> episodes,
+    Map<int, List<SonarrEpisode>> episodesBySeason,
+    List<int> sortedSeasons,
   ) {
-    final Map<int, List<SonarrEpisode>> episodesBySeason =
-        groupBy(episodes, (e) => e.seasonNumber);
-    final List<int> sortedSeasons = episodesBySeason.keys.toList()
-      ..sort((a, b) => b.compareTo(a)); // newest first
+    final List<int> visibleSeasons = _selectedSeasonFilter != null
+        ? [_selectedSeasonFilter!]
+        : sortedSeasons;
 
-    return sortedSeasons.map((int seasonNum) {
+    return visibleSeasons.map((int seasonNum) {
       final List<SonarrEpisode> seasonEpisodes = episodesBySeason[seasonNum]!
         ..sort((a, b) => b.episodeNumber.compareTo(a.episodeNumber));
 
       // Get per-season stats from the series model if available
-      final SonarrSeason? seasonMeta =
-          series.seasons.firstWhereOrNull((s) => s.seasonNumber == seasonNum);
+      final SonarrSeason? seasonMeta = widget.series.seasons
+          .firstWhereOrNull((s) => s.seasonNumber == seasonNum);
 
       return Padding(
         padding: const EdgeInsets.only(bottom: Insets.md),
         child: _SeasonCard(
-          instance: instance,
-          series: series,
+          instance: widget.instance,
+          series: widget.series,
           seasonNumber: seasonNum,
           episodes: seasonEpisodes,
           seasonMeta: seasonMeta,
-          onRefreshed: () => _refresh(context, ref),
+          onRefreshed: () => _refresh(context),
         ),
       );
     }).toList();
@@ -362,16 +465,6 @@ class _HeroInfoCard extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                // Title
-                Text(
-                  series.title,
-                  style: theme.textTheme.titleLarge
-                      ?.copyWith(fontWeight: FontWeight.bold),
-                  maxLines: 3,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                const SizedBox(height: Insets.sm),
-
                 // Info chips row
                 Wrap(
                   spacing: Insets.xs,
@@ -515,7 +608,7 @@ class _ActionsRow extends ConsumerWidget {
                     'Monitored',
                     style: TextStyle(fontWeight: FontWeight.bold),
                   ),
-                  onPressed: () => _showMonitorSeriesDialog(context, ref),
+                  onPressed: () => _toggleMonitored(context, ref),
                 )
               : OutlinedButton.icon(
                   style: OutlinedButton.styleFrom(
@@ -525,7 +618,7 @@ class _ActionsRow extends ConsumerWidget {
                   ),
                   icon: const Icon(Icons.bookmark_border, size: 20),
                   label: const Text('Unmonitored'),
-                  onPressed: () => _showMonitorSeriesDialog(context, ref),
+                  onPressed: () => _toggleMonitored(context, ref),
                 ),
         ),
 
@@ -550,118 +643,31 @@ class _ActionsRow extends ConsumerWidget {
     );
   }
 
-  void _showMonitorSeriesDialog(BuildContext context, WidgetRef ref) {
-    final theme = Theme.of(context);
-    String selectedType = series.monitored ? 'all' : 'none';
-
-    final Map<String, String> options = {
-      'all': 'All Episodes',
-      'future': 'Future Episodes',
-      'missing': 'Missing Episodes',
-      'existing': 'Existing Episodes',
-      'firstSeason': 'First Season',
-      'lastSeason': 'Last Season',
-      'pilot': 'Pilot Episode',
-      'recent': 'Recent Episodes',
-      'monitorSpecials': 'Monitor Specials',
-      'unmonitorSpecials': 'Unmonitor Specials',
-      'none': 'None (Unmonitor All)',
-    };
-
-    showDialog<void>(
-      context: context,
-      builder: (BuildContext context) {
-        return StatefulBuilder(
-          builder: (BuildContext context, StateSetter setState) {
-            return AlertDialog(
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(28),
-              ),
-              title: Text(
-                'Monitor Series',
-                style: theme.textTheme.titleLarge?.copyWith(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-              content: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  Text(
-                    'Choose which episodes of "${series.title}" should be monitored by Sonarr:',
-                    style: theme.textTheme.bodyMedium,
-                  ),
-                  const SizedBox(height: 20),
-                  DropdownButtonFormField<String>(
-                    initialValue: selectedType,
-                    decoration: InputDecoration(
-                      labelText: 'Monitoring',
-                      border: OutlineInputBorder(
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      contentPadding: const EdgeInsets.symmetric(
-                        horizontal: 16,
-                        vertical: 12,
-                      ),
-                    ),
-                    items: options.entries.map((e) {
-                      return DropdownMenuItem<String>(
-                        value: e.key,
-                        child: Text(e.value),
-                      );
-                    }).toList(),
-                    onChanged: (String? val) {
-                      if (val != null) {
-                        setState(() {
-                          selectedType = val;
-                        });
-                      }
-                    },
-                  ),
-                ],
-              ),
-              actions: <Widget>[
-                TextButton(
-                  onPressed: () => Navigator.of(context).pop(),
-                  child: const Text('Cancel'),
-                ),
-                FilledButton(
-                  onPressed: () async {
-                    Navigator.of(context).pop();
-                    try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
-                      await api.updateSeasonPass(
-                        seriesIds: [series.id],
-                        monitorType: selectedType,
-                      );
-                      onRefreshed();
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(
-                            content: Text(
-                              selectedType == 'none'
-                                  ? 'Series unmonitored.'
-                                  : 'Series monitoring updated to ${options[selectedType]}.',
-                            ),
-                          ),
-                        );
-                      }
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Failed to update monitoring: $e')),
-                        );
-                      }
-                    }
-                  },
-                  child: const Text('Save'),
-                ),
-              ],
-            );
-          },
+  Future<void> _toggleMonitored(BuildContext context, WidgetRef ref) async {
+    try {
+      final api = await ref.read(sonarrApiProvider(instance).future);
+      final raw = await api.getSeriesRaw(series.id);
+      raw['monitored'] = !series.monitored;
+      await api.updateSeriesRaw(raw);
+      onRefreshed();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              !series.monitored
+                  ? 'Series monitored.'
+                  : 'Series unmonitored.',
+            ),
+          ),
         );
-      },
-    );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to update monitoring: $e')),
+        );
+      }
+    }
   }
 
   Future<void> _searchSeries(BuildContext context, WidgetRef ref) async {
@@ -909,6 +915,14 @@ class _SeasonCardState extends ConsumerState<_SeasonCard> {
     final double progress = total > 0 ? downloaded / total : 0.0;
     final bool isMonitored = widget.seasonMeta?.monitored ?? false;
 
+    final double seasonSizeBytes = widget.episodes
+        .where((e) => e.hasFile)
+        .map((e) => (e.episodeFile?['size'] as num?)?.toDouble() ?? 0.0)
+        .sum;
+    final String seasonSizeStr = seasonSizeBytes > 0
+        ? ' • ${_formatSize(seasonSizeBytes.toInt())}'
+        : '';
+
     return AnimatedContainer(
       duration: const Duration(milliseconds: 200),
       decoration: BoxDecoration(
@@ -983,7 +997,7 @@ class _SeasonCardState extends ConsumerState<_SeasonCard> {
                             ),
                             const SizedBox(width: Insets.sm),
                             Text(
-                              '$downloaded/$total',
+                              '$downloaded/$total$seasonSizeStr',
                               style: theme.textTheme.labelSmall?.copyWith(
                                 color: cs.outline,
                               ),
@@ -993,35 +1007,6 @@ class _SeasonCardState extends ConsumerState<_SeasonCard> {
                       ],
                     ),
                   ),
-
-                  // Search season (automatic)
-                  IconButton(
-                    icon: const Icon(Icons.search, size: 20),
-                    tooltip: 'Automatic Search',
-                    onPressed: () =>
-                        _searchSeason(context, widget.seasonNumber),
-                    visualDensity: VisualDensity.compact,
-                  ),
-
-                  // Search season (interactive)
-                  IconButton(
-                    icon: const Icon(Icons.person_search, size: 20),
-                    tooltip: 'Interactive Search',
-                    onPressed: () => _openSeasonInteractiveSearch(
-                      context,
-                      widget.seasonNumber,
-                    ),
-                    visualDensity: VisualDensity.compact,
-                  ),
-
-                  // Delete season files
-                  if (downloaded > 0)
-                    IconButton(
-                      icon: Icon(Icons.delete_outline, color: cs.error, size: 20),
-                      tooltip: 'Delete Season Files',
-                      onPressed: () => _confirmDeleteSeasonFiles(context),
-                      visualDensity: VisualDensity.compact,
-                    ),
 
                   // Expand indicator
                   AnimatedRotation(
@@ -1039,6 +1024,60 @@ class _SeasonCardState extends ConsumerState<_SeasonCard> {
             firstChild: const SizedBox(width: double.infinity, height: 0),
             secondChild: Column(
               children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Insets.md,
+                    vertical: Insets.xs,
+                  ),
+                  child: Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.search, size: 16),
+                          label: const Text(
+                            'Search',
+                            style: TextStyle(fontSize: 12),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          onPressed: () =>
+                              _searchSeason(context, widget.seasonNumber),
+                        ),
+                      ),
+                      const SizedBox(width: Insets.xs),
+                      Expanded(
+                        child: TextButton.icon(
+                          icon: const Icon(Icons.person_search, size: 16),
+                          label: const Text(
+                            'Interactive',
+                            style: TextStyle(fontSize: 12),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          onPressed: () => _openSeasonInteractiveSearch(
+                            context,
+                            widget.seasonNumber,
+                          ),
+                        ),
+                      ),
+                      if (downloaded > 0) ...[
+                        const SizedBox(width: Insets.xs),
+                        Expanded(
+                          child: TextButton.icon(
+                            icon: Icon(Icons.delete_outline, color: cs.error, size: 16),
+                            label: Text(
+                              'Delete',
+                              style: TextStyle(color: cs.error, fontSize: 12),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            onPressed: () => _confirmDeleteSeasonFiles(context),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
                 Divider(
                   height: 1,
                   color: cs.outlineVariant.withValues(alpha: 0.3),
@@ -1237,235 +1276,381 @@ class _EpisodeRow extends ConsumerWidget {
   final SonarrSeries series;
   final SonarrEpisode episode;
 
+  Future<void> _toggleEpisodeMonitored(BuildContext context, WidgetRef ref) async {
+    try {
+      final api = await ref.read(sonarrApiProvider(instance).future);
+      final updated = episode.copyWith(monitored: !episode.monitored);
+      await api.updateEpisode(updated.toJson());
+      ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to update: $e')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
 
-    final Color statusColor =
-        episode.hasFile ? cs.tertiary : cs.outlineVariant;
+    final bool isDownloaded = episode.hasFile;
+    final bool isMonitored = episode.monitored;
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(
-        horizontal: Insets.lg,
-        vertical: Insets.sm,
+    bool isFuture = false;
+    if (episode.airDateUtc != null && episode.airDateUtc!.isNotEmpty) {
+      final DateTime? airDate = DateTime.tryParse(episode.airDateUtc!);
+      if (airDate != null && airDate.isAfter(DateTime.now())) {
+        isFuture = true;
+      }
+    }
+
+    Color badgeBorderColor;
+    Color badgeBgColor;
+    Color badgeTextColor;
+
+    if (isDownloaded) {
+      badgeBorderColor = cs.tertiary;
+      badgeBgColor = cs.tertiary.withValues(alpha: 0.15);
+      badgeTextColor = cs.tertiary;
+    } else if (!isMonitored) {
+      badgeBorderColor = cs.outlineVariant;
+      badgeBgColor = cs.surfaceContainerHighest.withValues(alpha: 0.4);
+      badgeTextColor = cs.outline;
+    } else if (isFuture) {
+      badgeBorderColor = cs.primary;
+      badgeBgColor = cs.primary.withValues(alpha: 0.08);
+      badgeTextColor = cs.primary;
+    } else {
+      // Missing & Monitored
+      badgeBorderColor = cs.error;
+      badgeBgColor = cs.error.withValues(alpha: 0.1);
+      badgeTextColor = cs.error;
+    }
+
+    final Map<String, dynamic>? fileMap = episode.episodeFile;
+    final Map<String, dynamic>? qualityObj = fileMap?['quality'] as Map<String, dynamic>?;
+    final Map<String, dynamic>? qualityInner = qualityObj?['quality'] as Map<String, dynamic>?;
+    final String? quality = qualityInner?['name'] as String?;
+    final int? sizeBytes = fileMap?['size'] as int?;
+    final String? sizeStr = sizeBytes != null ? _formatSize(sizeBytes) : null;
+
+    final String subtitleText = [
+      if (episode.airDate != null) episode.airDate!,
+      if (quality != null) quality,
+      if (sizeStr != null) sizeStr,
+    ].join(' • ');
+
+    return InkWell(
+      onTap: () => _showEpisodeBottomSheet(
+        context: context,
+        ref: ref,
+        instance: instance,
+        series: series,
+        episode: episode,
       ),
-      child: Row(
-        children: <Widget>[
-          // Episode number circle
-          Container(
-            width: 32,
-            height: 32,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: episode.hasFile
-                  ? cs.tertiary.withValues(alpha: 0.15)
-                  : cs.surfaceContainerHighest,
-              border: Border.all(color: statusColor, width: 1.5),
-            ),
-            child: Center(
-              child: Text(
-                '${episode.episodeNumber}',
-                style: theme.textTheme.labelSmall?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: episode.hasFile ? cs.tertiary : cs.outline,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: Insets.lg,
+          vertical: Insets.sm,
+        ),
+        child: Row(
+          children: <Widget>[
+            // Episode number circle
+            Container(
+              width: 32,
+              height: 32,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: badgeBgColor,
+                border: Border.all(color: badgeBorderColor, width: 1.5),
+              ),
+              child: Center(
+                child: Text(
+                  '${episode.episodeNumber}',
+                  style: theme.textTheme.labelSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: badgeTextColor,
+                  ),
                 ),
               ),
             ),
-          ),
 
-          const SizedBox(width: Insets.md),
+            const SizedBox(width: Insets.md),
 
-          // Title + air date
-          Expanded(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Text(
-                  episode.title,
-                  style: theme.textTheme.bodyMedium?.copyWith(
-                    fontWeight: FontWeight.w500,
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
-                ),
-                if (episode.airDate != null)
+            // Title + air date
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
                   Text(
-                    episode.airDate!,
+                    episode.title,
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  Text(
+                    subtitleText,
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: cs.outline,
                     ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
                   ),
-              ],
+                ],
+              ),
             ),
-          ),
 
-          // Monitored indicator
-          Icon(
-            episode.monitored ? Icons.bookmark : Icons.bookmark_border,
-            size: 16,
-            color: episode.monitored ? cs.primary : cs.outline,
-          ),
+            // Monitored indicator
+            IconButton(
+              icon: Icon(
+                episode.monitored ? Icons.bookmark : Icons.bookmark_border,
+                size: 20,
+                color: episode.monitored ? cs.primary : cs.outline,
+              ),
+              tooltip: episode.monitored ? 'Unmonitor' : 'Monitor',
+              onPressed: () => _toggleEpisodeMonitored(context, ref),
+              visualDensity: VisualDensity.compact,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
 
-          // Popup menu
-          PopupMenuButton<String>(
-            icon: const Icon(Icons.more_vert, size: 20),
-            padding: EdgeInsets.zero,
-            onSelected: (String action) => _handleAction(context, ref, action),
-            itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-              PopupMenuItem<String>(
-                value: 'monitor',
-                child: ListTile(
-                  leading: Icon(
-                    episode.monitored
-                        ? Icons.bookmark_remove
-                        : Icons.bookmark_add,
+void _showEpisodeBottomSheet({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Instance instance,
+  required SonarrSeries series,
+  required SonarrEpisode episode,
+}) {
+  final ThemeData theme = Theme.of(context);
+  final ColorScheme cs = theme.colorScheme;
+
+  final Map<String, dynamic>? fileMap = episode.episodeFile;
+  final Map<String, dynamic>? qualityObj = fileMap?['quality'] as Map<String, dynamic>?;
+  final Map<String, dynamic>? qualityInner = qualityObj?['quality'] as Map<String, dynamic>?;
+  final String? quality = qualityInner?['name'] as String?;
+  final int? sizeBytes = fileMap?['size'] as int?;
+  final String? sizeStr = sizeBytes != null ? _formatSize(sizeBytes) : null;
+  final String? relativePath = fileMap?['relativePath'] as String?;
+
+  showModalBottomSheet<void>(
+    context: context,
+    showDragHandle: true,
+    builder: (BuildContext context) {
+      return SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(Insets.lg, 0, Insets.lg, Insets.lg),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+              // Title / Header
+              Text(
+                'Season ${episode.seasonNumber}, Episode ${episode.episodeNumber}',
+                style: theme.textTheme.labelSmall?.copyWith(color: cs.outline),
+              ),
+              const SizedBox(height: Insets.xs),
+              Text(
+                episode.title,
+                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: Insets.sm),
+
+              // Air date + File size / Quality row
+              Wrap(
+                spacing: Insets.xs,
+                runSpacing: Insets.xs,
+                children: <Widget>[
+                  if (episode.airDate != null)
+                    _MetaChip(label: 'Aired: ${episode.airDate}'),
+                  if (quality != null) _MetaChip(label: quality),
+                  if (sizeStr != null) _MetaChip(label: sizeStr),
+                  _MetaChip(
+                    label: episode.monitored ? 'Monitored' : 'Unmonitored',
                   ),
-                  title: Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
-                  contentPadding: EdgeInsets.zero,
-                  dense: true,
-                ),
+                ],
               ),
-              const PopupMenuItem<String>(
-                value: 'auto_search',
-                child: ListTile(
-                  leading: Icon(Icons.search),
-                  title: Text('Automatic Search'),
-                  contentPadding: EdgeInsets.zero,
-                  dense: true,
-                ),
+              const SizedBox(height: Insets.md),
+
+              // Synopsis / Overview
+              Text(
+                'Overview',
+                style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
               ),
-              const PopupMenuItem<String>(
-                value: 'manual_search',
-                child: ListTile(
-                  leading: Icon(Icons.manage_search),
-                  title: Text('Interactive Search'),
-                  contentPadding: EdgeInsets.zero,
-                  dense: true,
-                ),
+              const SizedBox(height: Insets.xs),
+              Text(
+                episode.overview != null && episode.overview!.isNotEmpty
+                    ? episode.overview!
+                    : 'No overview available.',
+                style: theme.textTheme.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
               ),
-              if (episode.hasFile && episode.episodeFileId != null)
-                PopupMenuItem<String>(
-                  value: 'delete_file',
-                  child: ListTile(
-                    leading: Icon(Icons.delete_outline, color: cs.error),
-                    title: Text(
-                      'Delete File',
-                      style: TextStyle(color: cs.error),
+              const SizedBox(height: Insets.md),
+
+              // File Path (if downloaded)
+              if (relativePath != null) ...[
+                Text(
+                  'Path',
+                  style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: Insets.xs),
+                Text(
+                  relativePath,
+                  style: theme.textTheme.bodySmall?.copyWith(color: cs.outline),
+                ),
+                const SizedBox(height: Insets.md),
+              ],
+
+              // Action buttons
+              Row(
+                children: <Widget>[
+                  // Monitor/Unmonitor Toggle
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      icon: Icon(
+                        episode.monitored ? Icons.bookmark : Icons.bookmark_border,
+                        size: 18,
+                      ),
+                      label: Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
+                      onPressed: () async {
+                        Navigator.pop(context);
+                        try {
+                          final api = await ref.read(sonarrApiProvider(instance).future);
+                          final updated = episode.copyWith(monitored: !episode.monitored);
+                          await api.updateEpisode(updated.toJson());
+                          ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Failed: $e')),
+                            );
+                          }
+                        }
+                      },
                     ),
-                    contentPadding: EdgeInsets.zero,
-                    dense: true,
                   ),
-                ),
+                ],
+              ),
+              const SizedBox(height: Insets.sm),
+              Row(
+                children: <Widget>[
+                  // Automatic Search
+                  Expanded(
+                    child: FilledButton.icon(
+                      icon: const Icon(Icons.search, size: 18),
+                      label: const Text('Auto Search'),
+                      onPressed: () async {
+                        Navigator.pop(context);
+                        try {
+                          final api = await ref.read(sonarrApiProvider(instance).future);
+                          await api.runCommand(<String, dynamic>{
+                            'name': 'EpisodeSearch',
+                            'episodeIds': <int>[episode.id],
+                          });
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Search queued for episode.')),
+                            );
+                          }
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Failed to queue search: $e')),
+                            );
+                          }
+                        }
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: Insets.sm),
+
+                  // Interactive Search
+                  Expanded(
+                    child: OutlinedButton.icon(
+                      icon: const Icon(Icons.person_search, size: 18),
+                      label: const Text('Interactive'),
+                      onPressed: () {
+                        Navigator.pop(context);
+                        pushScreen<void>(
+                          context,
+                          SonarrReleaseSearchScreen(
+                            instance: instance,
+                            episode: episode,
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+
+                  // Delete file (if has file)
+                  if (episode.hasFile && episode.episodeFileId != null) ...[
+                    const SizedBox(width: Insets.sm),
+                    IconButton.filledTonal(
+                      icon: Icon(Icons.delete_outline, color: cs.error),
+                      onPressed: () async {
+                        Navigator.pop(context);
+                        final confirm = await showDialog<bool>(
+                          context: context,
+                          builder: (context) => AlertDialog(
+                            title: const Text('Delete Episode File'),
+                            content: const Text(
+                              'Are you sure? This will delete the file from disk and cannot be undone.',
+                            ),
+                            actions: <Widget>[
+                              TextButton(
+                                onPressed: () => Navigator.pop(context, false),
+                                  child: const Text('Cancel'),
+                              ),
+                              FilledButton(
+                                style: FilledButton.styleFrom(
+                                  backgroundColor: cs.error,
+                                  foregroundColor: cs.onError,
+                                ),
+                                onPressed: () => Navigator.pop(context, true),
+                                child: const Text('Delete'),
+                              ),
+                            ],
+                          ),
+                        );
+
+                        if (confirm == true) {
+                          try {
+                            final api = await ref.read(sonarrApiProvider(instance).future);
+                            await api.deleteEpisodeFile(episode.episodeFileId!);
+                            ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('File deleted.')),
+                              );
+                            }
+                          } catch (e) {
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Failed to delete: $e')),
+                              );
+                            }
+                          }
+                        }
+                      },
+                    ),
+                  ],
+                ],
+              ),
             ],
           ),
-        ],
-      ),
-    );
-  }
-
-  Future<void> _handleAction(
-    BuildContext context,
-    WidgetRef ref,
-    String action,
-  ) async {
-    switch (action) {
-      case 'monitor':
-        try {
-          final api = await ref.read(sonarrApiProvider(instance).future);
-          final updated = episode.copyWith(monitored: !episode.monitored);
-          await api.updateEpisode(updated.toJson());
-          if (!context.mounted) return;
-          ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
-        } catch (e) {
-          if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Failed: $e')),
-            );
-          }
-        }
-
-      case 'auto_search':
-        try {
-          final api = await ref.read(sonarrApiProvider(instance).future);
-          await api.runCommand(<String, dynamic>{
-            'name': 'EpisodeSearch',
-            'episodeIds': [episode.id],
-          });
-          if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Automatic search queued.')),
-            );
-          }
-        } catch (e) {
-          if (context.mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text('Failed: $e')),
-            );
-          }
-        }
-
-      case 'manual_search':
-        if (context.mounted) {
-          await pushScreen<void>(
-            context,
-            SonarrReleaseSearchScreen(
-              instance: instance,
-              episode: episode,
-            ),
-          );
-        }
-
-      case 'delete_file':
-        if (context.mounted) {
-          await _confirmDeleteFile(context, ref);
-        }
-    }
-  }
-
-  Future<void> _confirmDeleteFile(BuildContext context, WidgetRef ref) async {
-    final confirm = await showDialog<bool>(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Delete Episode File'),
-        content: const Text(
-          'Are you sure? This will delete the file from disk and cannot be undone.',
         ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
-          ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: Theme.of(context).colorScheme.error,
-              foregroundColor: Theme.of(context).colorScheme.onError,
-            ),
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Delete'),
-          ),
-        ],
       ),
     );
-
-    if (confirm == true && episode.episodeFileId != null) {
-      try {
-        final api = await ref.read(sonarrApiProvider(instance).future);
-        await api.deleteEpisodeFile(episode.episodeFileId!);
-        if (!context.mounted) return;
-        ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('File deleted.')),
-        );
-      } catch (e) {
-        if (context.mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Failed to delete: $e')),
-          );
-        }
-      }
-    }
-  }
+  },
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -1486,6 +1671,7 @@ class _OverflowMenu extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return PopupMenuButton<String>(
+      icon: const Icon(Icons.more_vert, color: Colors.white),
       onSelected: (String value) => _handleAction(context, ref, value),
       itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
         const PopupMenuItem<String>(
@@ -1501,6 +1687,14 @@ class _OverflowMenu extends ConsumerWidget {
           child: ListTile(
             leading: Icon(Icons.drive_file_rename_outline),
             title: Text('Rename Files'),
+            contentPadding: EdgeInsets.zero,
+          ),
+        ),
+        const PopupMenuItem<String>(
+          value: 'monitoring_options',
+          child: ListTile(
+            leading: Icon(Icons.settings_suggest_outlined),
+            title: Text('Monitoring Options'),
             contentPadding: EdgeInsets.zero,
           ),
         ),
@@ -1541,6 +1735,15 @@ class _OverflowMenu extends ConsumerWidget {
             instance: instance,
             seriesId: series.id,
           ),
+        );
+
+      case 'monitoring_options':
+        _showMonitorSeriesDialog(
+          context: context,
+          ref: ref,
+          instance: instance,
+          series: series,
+          onRefreshed: onRefreshed,
         );
 
       case 'delete':
@@ -1614,6 +1817,126 @@ class _OverflowMenu extends ConsumerWidget {
   }
 }
 
+void _showMonitorSeriesDialog({
+  required BuildContext context,
+  required WidgetRef ref,
+  required Instance instance,
+  required SonarrSeries series,
+  required VoidCallback onRefreshed,
+}) {
+  final theme = Theme.of(context);
+  String selectedType = series.monitored ? 'all' : 'none';
+
+  final Map<String, String> options = {
+    'all': 'All Episodes',
+    'future': 'Future Episodes',
+    'missing': 'Missing Episodes',
+    'existing': 'Existing Episodes',
+    'firstSeason': 'First Season',
+    'lastSeason': 'Last Season',
+    'pilot': 'Pilot Episode',
+    'recent': 'Recent Episodes',
+    'monitorSpecials': 'Monitor Specials',
+    'unmonitorSpecials': 'Unmonitor Specials',
+    'none': 'None (Unmonitor All)',
+  };
+
+  showDialog<void>(
+    context: context,
+    builder: (BuildContext context) {
+      return StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          return AlertDialog(
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(28),
+            ),
+            title: Text(
+              'Monitor Series',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Choose which episodes of "${series.title}" should be monitored by Sonarr:',
+                  style: theme.textTheme.bodyMedium,
+                ),
+                const SizedBox(height: 20),
+                DropdownButtonFormField<String>(
+                  initialValue: selectedType,
+                  decoration: InputDecoration(
+                    labelText: 'Monitoring',
+                    border: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    contentPadding: const EdgeInsets.symmetric(
+                      horizontal: 16,
+                      vertical: 12,
+                    ),
+                  ),
+                  items: options.entries.map((e) {
+                    return DropdownMenuItem<String>(
+                      value: e.key,
+                      child: Text(e.value),
+                    );
+                  }).toList(),
+                  onChanged: (String? val) {
+                    if (val != null) {
+                      setState(() {
+                        selectedType = val;
+                      });
+                    }
+                  },
+                ),
+              ],
+            ),
+            actions: <Widget>[
+              TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: const Text('Cancel'),
+              ),
+              FilledButton(
+                onPressed: () async {
+                  Navigator.of(context).pop();
+                  try {
+                    final api = await ref.read(sonarrApiProvider(instance).future);
+                    await api.updateSeasonPass(
+                      seriesIds: [series.id],
+                      monitorType: selectedType,
+                    );
+                    onRefreshed();
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(
+                            selectedType == 'none'
+                                ? 'Series unmonitored.'
+                                : 'Series monitoring updated to ${options[selectedType]}.',
+                          ),
+                        ),
+                      );
+                    }
+                  } catch (e) {
+                    if (context.mounted) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Failed to update monitoring: $e')),
+                      );
+                    }
+                  }
+                },
+                child: const Text('Save'),
+              ),
+            ],
+          );
+        },
+      );
+    },
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Small reusable widgets
 // ---------------------------------------------------------------------------
@@ -1654,7 +1977,7 @@ class _StatusPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final bool isContinuing = status?.toLowerCase() == 'continuing';
-    final Color tint = isContinuing ? Colors.green : theme.colorScheme.outline;
+    final Color tint = isContinuing ? theme.colorScheme.tertiary : theme.colorScheme.outline;
     final String label = status ?? 'Unknown';
 
     return Container(
@@ -1702,4 +2025,59 @@ String _formatSize(int bytes) {
     i++;
   }
   return '${size.toStringAsFixed(1)} ${suffixes[i]}';
+}
+
+class _Backdrop extends StatelessWidget {
+  const _Backdrop({required this.fanartUrl});
+
+  final String? fanartUrl;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    return Stack(
+      fit: StackFit.expand,
+      children: <Widget>[
+        if (fanartUrl != null)
+          CachedNetworkImage(
+            imageUrl: fanartUrl!,
+            fit: BoxFit.cover,
+            memCacheWidth: 1080,
+            errorWidget: (_, __, ___) =>
+                ColoredBox(color: cs.surfaceContainerHigh),
+          )
+        else
+          ColoredBox(color: cs.surfaceContainerHigh),
+        // Top-down dark scrim for status bar and action icons contrast
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: <Color>[
+                Colors.black.withValues(alpha: 0.45),
+                Colors.transparent,
+              ],
+              stops: const <double>[0.0, 0.45],
+            ),
+          ),
+        ),
+        // Scrim so the title stays legible and the image melts into the surface.
+        DecoratedBox(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: <Color>[
+                cs.surface.withValues(alpha: 0.0),
+                cs.surface.withValues(alpha: 0.6),
+                cs.surface,
+              ],
+              stops: const <double>[0.3, 0.75, 1.0],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
 }

--- a/services/service_sonarr/lib/src/sonarr_api.dart
+++ b/services/service_sonarr/lib/src/sonarr_api.dart
@@ -234,6 +234,9 @@ class SonarrApi {
       final Response<dynamic> resp = await _dio.get<dynamic>(
         '$_base/release',
         queryParameters: qParams,
+        options: Options(
+          receiveTimeout: Duration.zero,
+        ),
       );
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
@@ -246,6 +249,20 @@ class SonarrApi {
   Future<void> downloadRelease(Map<String, dynamic> release) async {
     try {
       await _dio.post<dynamic>('$_base/release', data: release);
+    } on DioException catch (e) {
+      throw NetworkException.fromDio(e);
+    }
+  }
+
+  Future<List<Map<String, dynamic>>> getEpisodeFiles(int seriesId) async {
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>(
+        '$_base/episodefile',
+        queryParameters: <String, dynamic>{'seriesId': seriesId},
+      );
+      return (resp.data as List<dynamic>)
+          .map((dynamic e) => e as Map<String, dynamic>)
+          .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -658,6 +675,7 @@ class SonarrApi {
   Future<List<dynamic>> getManualImport({
     required String folder,
     bool filterExistingFiles = false,
+    CancelToken? cancelToken,
   }) async {
     try {
       final Response<dynamic> resp = await _dio.get<dynamic>(
@@ -666,6 +684,10 @@ class SonarrApi {
           'folder': folder,
           'filterExistingFiles': filterExistingFiles,
         },
+        cancelToken: cancelToken,
+        options: Options(
+          receiveTimeout: const Duration(seconds: 180),
+        ),
       );
       return resp.data as List<dynamic>;
     } on DioException catch (e) {

--- a/services/service_sonarr/lib/src/sonarr_home.dart
+++ b/services/service_sonarr/lib/src/sonarr_home.dart
@@ -97,13 +97,15 @@ class SonarrHome extends ConsumerWidget {
       drawer: drawer,
       body: NotificationListener<UserScrollNotification>(
         onNotification: (UserScrollNotification notification) {
-          final ScrollDirection direction = notification.direction;
-          if (direction == ScrollDirection.reverse) {
-            ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
-                false;
-          } else if (direction == ScrollDirection.forward) {
-            ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
-                true;
+          if (notification.metrics.axis == Axis.vertical) {
+            final ScrollDirection direction = notification.direction;
+            if (direction == ScrollDirection.reverse) {
+              ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
+                  false;
+            } else if (direction == ScrollDirection.forward) {
+              ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
+                  true;
+            }
           }
           return false;
         },

--- a/services/service_sonarr/lib/src/sonarr_providers.dart
+++ b/services/service_sonarr/lib/src/sonarr_providers.dart
@@ -54,11 +54,53 @@ final sonarrSeriesByIdProvider =
 });
 
 /// Active layout view mode for the series tab (grid or list).
+/// Active layout view mode for the series tab (grid or list).
 enum SonarrViewMode { grid, list }
+
+/// Sorting fields supported by the Sonarr Series tab.
+enum SonarrSeriesSortField {
+  monitoredStatus,
+  title,
+  network,
+  nextAiring,
+  previousAiring,
+  added,
+  seasons,
+  episodes,
+  episodeCount,
+  sizeOnDisk,
+}
+
+/// Filter settings supported by the Sonarr Series tab.
+enum SonarrSeriesFilter {
+  all,
+  monitoredOnly,
+  unmonitoredOnly,
+  continuingOnly,
+  endedOnly,
+  missingEpisodes,
+}
 
 /// Persistent view mode preference for Sonarr series.
 final sonarrViewModeProvider = StateProvider.family<SonarrViewMode, Instance>(
   (ref, instance) => SonarrViewMode.grid,
+);
+
+/// Sort field preference for Sonarr series.
+final sonarrSeriesSortFieldProvider =
+    StateProvider.family<SonarrSeriesSortField, Instance>(
+  (ref, instance) => SonarrSeriesSortField.title,
+);
+
+/// Sort direction preference for Sonarr series.
+final sonarrSeriesSortAscendingProvider = StateProvider.family<bool, Instance>(
+  (ref, instance) => true,
+);
+
+/// Active filter setting for Sonarr series.
+final sonarrSeriesFilterProvider =
+    StateProvider.family<SonarrSeriesFilter, Instance>(
+  (ref, instance) => SonarrSeriesFilter.all,
 );
 
 /// Search query string for Sonarr series.
@@ -77,16 +119,142 @@ final sonarrFilteredSeriesProvider = Provider.autoDispose
   final AsyncValue<List<SonarrSeries>> seriesAsync =
       ref.watch(sonarrSeriesProvider(instance));
 
+  final SonarrSeriesSortField sortField =
+      ref.watch(sonarrSeriesSortFieldProvider(instance));
+  final bool sortAscending =
+      ref.watch(sonarrSeriesSortAscendingProvider(instance));
+  final SonarrSeriesFilter filter =
+      ref.watch(sonarrSeriesFilterProvider(instance));
+
   return seriesAsync.whenData((List<SonarrSeries> list) {
-    if (query.isEmpty) {
-      return list;
+    Iterable<SonarrSeries> filtered = list;
+
+    // 1. Filter by search query
+    if (query.isNotEmpty) {
+      final String lowercaseQuery = query.toLowerCase();
+      filtered = filtered.where(
+        (SonarrSeries s) => s.title.toLowerCase().contains(lowercaseQuery),
+      );
     }
-    final String lowercaseQuery = query.toLowerCase();
-    return list
-        .where(
-          (SonarrSeries s) => s.title.toLowerCase().contains(lowercaseQuery),
-        )
-        .toList();
+
+    // 2. Filter by active filter setting
+    switch (filter) {
+      case SonarrSeriesFilter.all:
+        break;
+      case SonarrSeriesFilter.monitoredOnly:
+        filtered = filtered.where((SonarrSeries s) => s.monitored);
+        break;
+      case SonarrSeriesFilter.unmonitoredOnly:
+        filtered = filtered.where((SonarrSeries s) => !s.monitored);
+        break;
+      case SonarrSeriesFilter.continuingOnly:
+        filtered = filtered.where(
+          (SonarrSeries s) => s.status?.toLowerCase() == 'continuing',
+        );
+        break;
+      case SonarrSeriesFilter.endedOnly:
+        filtered = filtered.where(
+          (SonarrSeries s) => s.status?.toLowerCase() == 'ended',
+        );
+        break;
+      case SonarrSeriesFilter.missingEpisodes:
+        filtered = filtered.where((SonarrSeries s) {
+          final SonarrSeriesStatistics? stats = s.statistics;
+          if (stats == null) return false;
+          return stats.episodeFileCount < stats.episodeCount;
+        });
+        break;
+    }
+
+    // 3. Sort
+    final List<SonarrSeries> result = filtered.toList();
+    result.sort((SonarrSeries a, SonarrSeries b) {
+      int compare = 0;
+      switch (sortField) {
+        case SonarrSeriesSortField.monitoredStatus:
+          if (a.monitored != b.monitored) {
+            compare = a.monitored ? -1 : 1;
+          } else {
+            final String statusA = a.status?.toLowerCase() ?? '';
+            final String statusB = b.status?.toLowerCase() ?? '';
+            if (statusA != statusB) {
+              compare = statusA.compareTo(statusB);
+            } else {
+              final String titleA = a.sortTitle ?? a.title;
+              final String titleB = b.sortTitle ?? b.title;
+              compare = titleA.toLowerCase().compareTo(titleB.toLowerCase());
+            }
+          }
+          break;
+        case SonarrSeriesSortField.title:
+          final String titleA = a.sortTitle ?? a.title;
+          final String titleB = b.sortTitle ?? b.title;
+          compare = titleA.toLowerCase().compareTo(titleB.toLowerCase());
+          break;
+        case SonarrSeriesSortField.network:
+          final String netA = a.network ?? '';
+          final String netB = b.network ?? '';
+          compare = netA.toLowerCase().compareTo(netB.toLowerCase());
+          break;
+        case SonarrSeriesSortField.nextAiring:
+          if (a.nextAiring == null && b.nextAiring == null) {
+            compare = 0;
+          } else if (a.nextAiring == null) {
+            compare = 1;
+          } else if (b.nextAiring == null) {
+            compare = -1;
+          } else {
+            compare = a.nextAiring!.compareTo(b.nextAiring!);
+          }
+          break;
+        case SonarrSeriesSortField.previousAiring:
+          if (a.previousAiring == null && b.previousAiring == null) {
+            compare = 0;
+          } else if (a.previousAiring == null) {
+            compare = 1;
+          } else if (b.previousAiring == null) {
+            compare = -1;
+          } else {
+            compare = a.previousAiring!.compareTo(b.previousAiring!);
+          }
+          break;
+        case SonarrSeriesSortField.added:
+          if (a.added == null && b.added == null) {
+            compare = 0;
+          } else if (a.added == null) {
+            compare = 1;
+          } else if (b.added == null) {
+            compare = -1;
+          } else {
+            compare = a.added!.compareTo(b.added!);
+          }
+          break;
+        case SonarrSeriesSortField.seasons:
+          final int valA = a.statistics?.seasonCount ?? 0;
+          final int valB = b.statistics?.seasonCount ?? 0;
+          compare = valA.compareTo(valB);
+          break;
+        case SonarrSeriesSortField.episodes:
+          final int valA = a.statistics?.episodeFileCount ?? 0;
+          final int valB = b.statistics?.episodeFileCount ?? 0;
+          compare = valA.compareTo(valB);
+          break;
+        case SonarrSeriesSortField.episodeCount:
+          final int valA = a.statistics?.episodeCount ?? 0;
+          final int valB = b.statistics?.episodeCount ?? 0;
+          compare = valA.compareTo(valB);
+          break;
+        case SonarrSeriesSortField.sizeOnDisk:
+          final int valA = a.statistics?.sizeOnDisk ?? 0;
+          final int valB = b.statistics?.sizeOnDisk ?? 0;
+          compare = valA.compareTo(valB);
+          break;
+      }
+
+      return sortAscending ? compare : -compare;
+    });
+
+    return result;
   });
 });
 
@@ -106,7 +274,28 @@ final sonarrEpisodesProvider =
 ) async {
   final (Instance instance, int seriesId) = key;
   final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
-  return api.getEpisodes(seriesId);
+
+  final results = await Future.wait([
+    api.getEpisodes(seriesId),
+    api.getEpisodeFiles(seriesId),
+  ]);
+
+  final List<SonarrEpisode> episodes = results[0] as List<SonarrEpisode>;
+  final List<Map<String, dynamic>> files = results[1] as List<Map<String, dynamic>>;
+
+  final Map<int, Map<String, dynamic>> filesById = {
+    for (final file in files) file['id'] as int: file,
+  };
+
+  return episodes.map((episode) {
+    if (episode.hasFile && episode.episodeFileId != null) {
+      final fileMap = filesById[episode.episodeFileId!];
+      if (fileMap != null) {
+        return episode.copyWith(episodeFile: fileMap);
+      }
+    }
+    return episode;
+  }).toList();
 });
 
 /// All releases for an episode (interactive search).

--- a/services/service_sonarr/pubspec.yaml
+++ b/services/service_sonarr/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   core_models:
   core_networking:
   core_profile:
+  core_router:
   core_storage:
   core_ui:
   dio: ^5.7.0
@@ -20,6 +21,7 @@ dependencies:
     sdk: flutter
   flutter_riverpod: ^3.3.2
   freezed_annotation: ^3.1.0
+  go_router: ^17.3.0
   hive_ce: ^2.10.1
   intl: ^0.20.1
   json_annotation: ^4.9.0


### PR DESCRIPTION
## Summary
This PR implements multiple feature enhancements and layout polish items for the Sonarr integration and the app's global shell navigation:

### 1. Client-side Sort & Filter (Series Tab)
* Implemented full filtering and sorting matching the Sonarr Web UI.
* Added filter criteria: `All`, `Monitored Only`, `Unmonitored Only`, `Continuing Only`, `Ended Only`, and `Missing Episodes`.
* Added sorting parameters: `Monitored/Status`, `Title`, `Network`, `Next Airing`, `Previous Airing`, `Added`, `Seasons`, `Episodes`, `Episode Count`, and `Size on Disk` (including ascending/descending segmented toggle).
* Modified the Series data model to deserialize the `added` date-time field from the `/series` endpoint.
* Moved the Sort & Filter options to a small stacked Floating Action Button (FAB) beside the main "Add Series" FAB.

### 2. Disk Size Display
* Added a private `_formatSize` utility to format byte counts into readable strings (e.g. `2.2 GB`, `450 MB`).
* Displayed each series' total size on disk directly in the item subtitles for both Grid View (`_SeriesCard`) and List View (`_SeriesBannerCard`).

### 3. Sidebar Drawer Overlay & Hierarchy Fixes
* **Visual Polish:** Moved the `ServicesDrawer` declaration to the outer `ScaffoldWithNavBar` so that opening the drawer overlays the bottom navigation bar correctly.
* **Open Helper:** Implemented `openDrawer(BuildContext context)` in `core_ui` to traverse the widget tree upwards and open the nearest drawer-supporting Scaffold, solving nested Scaffold lookup constraints.
* Hooked up leading hamburger icon buttons on the AppBars of `DashboardScreen`, `CalendarScreen`, `ActivityScreen`, and `SettingsScreen` to trigger the global drawer.

### 4. Direct Instance Editing from Sidebar
* Exposed the `onLongPress` callback on the shared `ServiceTile` widget.
* Added a long-press quick-actions menu (bottom sheet) to sidebar service tiles, allowing users to tap **Edit connection settings** to jump straight to the editing form without opening the instance first.

### 5. Dialog & Bottom Sheet Layout Polish
* Wrapped the episode details dialog in `SingleChildScrollView` to prevent options/action buttons from clipping off-screen when the episode description is long.
* Refactored the sort/filter bottom sheet filters to use a wrapping layout instead of a horizontal single row, enhancing readability.
