### PR TITLE
Dashboard widget board, Glances GPU stats, and qBittorrent API-key auth

### DIFF
--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -1,0 +1,298 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:service_emby/service_emby.dart' as emby;
+import 'package:service_glances/service_glances.dart';
+import 'package:service_jellyfin/service_jellyfin.dart' as jf;
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+import 'package:service_sabnzbd/service_sabnzbd.dart';
+import 'package:service_seerr/service_seerr.dart';
+import 'package:service_tautulli/service_tautulli.dart';
+
+import '../health_providers.dart';
+import '../screens/calendar_screen.dart';
+import 'dashboard_layout.dart';
+import 'dashboard_widget_kind.dart';
+import 'widgets/disk_widget.dart';
+import 'widgets/downloads_widget.dart';
+import 'widgets/health_widget.dart';
+import 'widgets/requests_widget.dart';
+import 'widgets/streams_widget.dart';
+import 'widgets/upcoming_widget.dart';
+
+/// Whether the board is in inline edit (reorder / hide) mode. Toggled from
+/// the dashboard app bar; ephemeral by design (resets on app restart).
+final StateProvider<bool> dashboardEditModeProvider =
+    StateProvider<bool>((Ref ref) => false);
+
+/// The dashboard widget board: at-a-glance cards in the user's saved order,
+/// with an inline edit mode for reordering and hiding.
+class DashboardBoard extends ConsumerWidget {
+  const DashboardBoard({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<Instance> instances = ref.watch(activeInstancesProvider);
+    final List<DashboardWidgetConfig> layout =
+        ref.watch(dashboardLayoutProvider);
+    final bool editing = ref.watch(dashboardEditModeProvider);
+
+    if (editing) {
+      return _EditBoard(layout: layout, instances: instances);
+    }
+
+    final List<DashboardWidgetConfig> visible = <DashboardWidgetConfig>[
+      for (final DashboardWidgetConfig c in layout)
+        if (c.enabled && _configured(c.kind, instances)) c,
+    ];
+
+    if (visible.isEmpty) {
+      return const EmptyView(
+        icon: Icons.dashboard_customize_outlined,
+        title: 'No widgets to show',
+        message: 'Use the customize button (top right) to add widgets.',
+      );
+    }
+
+    return RefreshIndicator(
+      onRefresh: () async => _refreshAll(ref, instances),
+      child: ListView.separated(
+        padding: Insets.page,
+        itemCount: visible.length,
+        separatorBuilder: (_, __) => const SizedBox(height: Insets.md),
+        itemBuilder: (BuildContext context, int index) =>
+            _buildWidget(visible[index].kind, instances),
+      ),
+    );
+  }
+
+  static bool _configured(DashboardWidgetKind kind, List<Instance> instances) {
+    if (kind == DashboardWidgetKind.health) {
+      return instances.isNotEmpty;
+    }
+    return instances.any((Instance i) => kind.serviceKinds.contains(i.kind));
+  }
+
+  static List<Instance> _byKind(List<Instance> instances, ServiceKind kind) =>
+      <Instance>[
+        for (final Instance i in instances)
+          if (i.kind == kind) i,
+      ];
+
+  Widget _buildWidget(DashboardWidgetKind kind, List<Instance> instances) {
+    switch (kind) {
+      case DashboardWidgetKind.downloads:
+        return DashboardDownloadsWidget(
+          qbitInstances: _byKind(instances, ServiceKind.qbittorrent),
+          sabInstances: _byKind(instances, ServiceKind.sabnzbd),
+        );
+      case DashboardWidgetKind.streams:
+        return DashboardStreamsWidget(
+          tautulliInstances: _byKind(instances, ServiceKind.tautulli),
+          jellyfinInstances: _byKind(instances, ServiceKind.jellyfin),
+          embyInstances: _byKind(instances, ServiceKind.emby),
+        );
+      case DashboardWidgetKind.upcoming:
+        return const DashboardUpcomingWidget();
+      case DashboardWidgetKind.health:
+        return DashboardHealthWidget(instances: instances);
+      case DashboardWidgetKind.requests:
+        return DashboardRequestsWidget(
+          instances: _byKind(instances, ServiceKind.seerr),
+        );
+      case DashboardWidgetKind.diskSpace:
+        return DashboardDiskWidget(
+          sabInstances: _byKind(instances, ServiceKind.sabnzbd),
+          glancesInstances: _byKind(instances, ServiceKind.glances),
+        );
+    }
+  }
+
+  void _refreshAll(WidgetRef ref, List<Instance> instances) {
+    for (final Instance i in instances) {
+      ref.invalidate(instanceHealthProvider(i));
+      switch (i.kind) {
+        case ServiceKind.qbittorrent:
+          ref.invalidate(qbitRawTorrentsProvider(i));
+          ref.invalidate(qbitTransferProvider(i));
+        case ServiceKind.sabnzbd:
+          ref.invalidate(sabQueueProvider(i));
+        case ServiceKind.tautulli:
+          ref.invalidate(tautulliActivityProvider(i));
+        case ServiceKind.jellyfin:
+          ref.invalidate(jf.jellyfinSessionsProvider(i));
+        case ServiceKind.emby:
+          ref.invalidate(emby.embySessionsProvider(i));
+        case ServiceKind.seerr:
+          ref.invalidate(seerrRequestCountsProvider(i));
+          ref.invalidate(seerrRequestsProvider(i));
+        case ServiceKind.glances:
+          ref.invalidate(glancesStatsProvider(i));
+        default:
+          break;
+      }
+    }
+    for (final DateTime m in upcomingWindowMonths(DateTime.now())) {
+      ref.invalidate(globalCalendarProvider(m));
+    }
+  }
+}
+
+/// Edit mode: enabled widgets as a reorderable list of header tiles, hidden
+/// widgets greyed out below with a re-add button.
+class _EditBoard extends ConsumerWidget {
+  const _EditBoard({required this.layout, required this.instances});
+
+  final List<DashboardWidgetConfig> layout;
+  final List<Instance> instances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<DashboardWidgetConfig> enabled = <DashboardWidgetConfig>[
+      for (final DashboardWidgetConfig c in layout)
+        if (c.enabled) c,
+    ];
+    final List<DashboardWidgetConfig> hidden = <DashboardWidgetConfig>[
+      for (final DashboardWidgetConfig c in layout)
+        if (!c.enabled) c,
+    ];
+
+    return ReorderableListView(
+      padding: Insets.page,
+      buildDefaultDragHandles: false,
+      onReorder: (int oldIndex, int newIndex) => ref
+          .read(dashboardLayoutProvider.notifier)
+          .moveEnabled(oldIndex, newIndex),
+      footer: hidden.isEmpty
+          ? null
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: Insets.md),
+                  child: Text(
+                    'Hidden',
+                    style: Theme.of(context)
+                        .textTheme
+                        .labelLarge
+                        ?.copyWith(fontWeight: FontWeight.w700),
+                  ),
+                ),
+                for (final DashboardWidgetConfig c in hidden)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: Insets.sm),
+                    child: Opacity(
+                      opacity: 0.6,
+                      child: _EditTile(
+                        config: c,
+                        instances: instances,
+                        trailing: IconButton(
+                          tooltip: 'Show widget',
+                          icon: const Icon(Icons.add_circle_outline),
+                          onPressed: () => ref
+                              .read(dashboardLayoutProvider.notifier)
+                              .setEnabled(c.kind, true),
+                        ),
+                      ),
+                    ),
+                  ),
+              ],
+            ),
+      children: <Widget>[
+        for (int index = 0; index < enabled.length; index++)
+          Padding(
+            key: ValueKey<DashboardWidgetKind>(enabled[index].kind),
+            padding: const EdgeInsets.only(bottom: Insets.sm),
+            child: _EditTile(
+              config: enabled[index],
+              instances: instances,
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  IconButton(
+                    tooltip: 'Hide widget',
+                    icon: const Icon(Icons.visibility_off_outlined),
+                    onPressed: () => ref
+                        .read(dashboardLayoutProvider.notifier)
+                        .setEnabled(enabled[index].kind, false),
+                  ),
+                  ReorderableDragStartListener(
+                    index: index,
+                    child: const Padding(
+                      padding: EdgeInsets.all(8),
+                      child: Icon(Icons.drag_indicator),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}
+
+class _EditTile extends StatelessWidget {
+  const _EditTile({
+    required this.config,
+    required this.instances,
+    required this.trailing,
+  });
+
+  final DashboardWidgetConfig config;
+  final List<Instance> instances;
+  final Widget trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final bool configured = DashboardBoard._configured(config.kind, instances);
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: Insets.md,
+        vertical: Insets.sm,
+      ),
+      decoration: BoxDecoration(
+        color: cs.surfaceContainerHigh,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Row(
+        children: <Widget>[
+          Container(
+            width: 36,
+            height: 36,
+            alignment: Alignment.center,
+            decoration: BoxDecoration(
+              color: cs.primary.withValues(alpha: 0.15),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Icon(config.kind.icon, size: 20, color: cs.primary),
+          ),
+          const SizedBox(width: Insets.md),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  config.kind.label,
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                ),
+                if (!configured)
+                  Text(
+                    'Not configured',
+                    style: theme.textTheme.labelSmall
+                        ?.copyWith(color: cs.onSurfaceVariant),
+                  ),
+              ],
+            ),
+          ),
+          trailing,
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -3,12 +3,15 @@ import 'package:core_profile/core_profile.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/legacy.dart';
 import 'package:service_emby/service_emby.dart' as emby;
 import 'package:service_glances/service_glances.dart';
 import 'package:service_jellyfin/service_jellyfin.dart' as jf;
 import 'package:service_qbittorrent/service_qbittorrent.dart';
+import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sabnzbd/service_sabnzbd.dart';
 import 'package:service_seerr/service_seerr.dart';
+import 'package:service_sonarr/service_sonarr.dart';
 import 'package:service_tautulli/service_tautulli.dart';
 
 import '../health_providers.dart';
@@ -18,7 +21,9 @@ import 'dashboard_widget_kind.dart';
 import 'widgets/disk_widget.dart';
 import 'widgets/downloads_widget.dart';
 import 'widgets/health_widget.dart';
+import 'widgets/recently_added_widget.dart';
 import 'widgets/requests_widget.dart';
+import 'widgets/server_info_widget.dart';
 import 'widgets/streams_widget.dart';
 import 'widgets/upcoming_widget.dart';
 
@@ -45,7 +50,10 @@ class DashboardBoard extends ConsumerWidget {
 
     final List<DashboardWidgetConfig> visible = <DashboardWidgetConfig>[
       for (final DashboardWidgetConfig c in layout)
-        if (c.enabled && _configured(c.kind, instances)) c,
+        if (c.enabled &&
+            _configured(c.kind, instances) &&
+            _hasLiveContent(ref, c.kind))
+          c,
     ];
 
     if (visible.isEmpty) {
@@ -56,7 +64,7 @@ class DashboardBoard extends ConsumerWidget {
       );
     }
 
-    return RefreshIndicator(
+    return M3RefreshIndicator(
       onRefresh: () async => _refreshAll(ref, instances),
       child: ListView.separated(
         padding: Insets.page,
@@ -73,6 +81,18 @@ class DashboardBoard extends ConsumerWidget {
       return instances.isNotEmpty;
     }
     return instances.any((Instance i) => kind.serviceKinds.contains(i.kind));
+  }
+
+  /// Downloads and streams are activity-gated: they only appear on the board
+  /// while something is actually downloading / streaming, instead of sitting
+  /// there with an idle row. Every other widget shows whenever its service is
+  /// configured.
+  static bool _hasLiveContent(WidgetRef ref, DashboardWidgetKind kind) {
+    return switch (kind) {
+      DashboardWidgetKind.downloads => ref.watch(activeDownloadCountProvider) > 0,
+      DashboardWidgetKind.streams => ref.watch(activeStreamCountProvider) > 0,
+      _ => true,
+    };
   }
 
   static List<Instance> _byKind(List<Instance> instances, ServiceKind kind) =>
@@ -96,11 +116,20 @@ class DashboardBoard extends ConsumerWidget {
         );
       case DashboardWidgetKind.upcoming:
         return const DashboardUpcomingWidget();
+      case DashboardWidgetKind.recentlyAdded:
+        return DashboardRecentlyAddedWidget(
+          sonarrInstances: _byKind(instances, ServiceKind.sonarr),
+          radarrInstances: _byKind(instances, ServiceKind.radarr),
+        );
       case DashboardWidgetKind.health:
         return DashboardHealthWidget(instances: instances);
       case DashboardWidgetKind.requests:
         return DashboardRequestsWidget(
           instances: _byKind(instances, ServiceKind.seerr),
+        );
+      case DashboardWidgetKind.serverInfo:
+        return DashboardServerInfoWidget(
+          instances: _byKind(instances, ServiceKind.glances),
         );
       case DashboardWidgetKind.diskSpace:
         return DashboardDiskWidget(
@@ -114,6 +143,10 @@ class DashboardBoard extends ConsumerWidget {
     for (final Instance i in instances) {
       ref.invalidate(instanceHealthProvider(i));
       switch (i.kind) {
+        case ServiceKind.sonarr:
+          ref.invalidate(sonarrSeriesProvider(i));
+        case ServiceKind.radarr:
+          ref.invalidate(radarrMoviesProvider(i));
         case ServiceKind.qbittorrent:
           ref.invalidate(qbitRawTorrentsProvider(i));
           ref.invalidate(qbitTransferProvider(i));

--- a/app/lib/src/dashboard/dashboard_layout.dart
+++ b/app/lib/src/dashboard/dashboard_layout.dart
@@ -2,7 +2,6 @@ import 'dart:convert';
 
 import 'package:core_storage/core_storage.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:hive_ce/hive.dart';
 
 import 'dashboard_widget_kind.dart';
 

--- a/app/lib/src/dashboard/dashboard_layout.dart
+++ b/app/lib/src/dashboard/dashboard_layout.dart
@@ -1,0 +1,129 @@
+import 'dart:convert';
+
+import 'package:core_storage/core_storage.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:hive_ce/hive.dart';
+
+import 'dashboard_widget_kind.dart';
+
+/// One board entry: which widget, and whether it is currently shown.
+class DashboardWidgetConfig {
+  const DashboardWidgetConfig({required this.kind, required this.enabled});
+
+  final DashboardWidgetKind kind;
+  final bool enabled;
+
+  DashboardWidgetConfig copyWith({bool? enabled}) =>
+      DashboardWidgetConfig(kind: kind, enabled: enabled ?? this.enabled);
+}
+
+/// Stored JSON -> configs. Unknown kind names are dropped (forward compat);
+/// null / corrupt / non-list input decodes to an empty list.
+List<DashboardWidgetConfig> decodeLayout(String? raw) {
+  if (raw == null || raw.isEmpty) {
+    return const <DashboardWidgetConfig>[];
+  }
+  Object? decoded;
+  try {
+    decoded = jsonDecode(raw);
+  } on FormatException {
+    return const <DashboardWidgetConfig>[];
+  }
+  if (decoded is! List) {
+    return const <DashboardWidgetConfig>[];
+  }
+  final List<DashboardWidgetConfig> out = <DashboardWidgetConfig>[];
+  for (final Object? item in decoded) {
+    if (item is! Map) {
+      continue;
+    }
+    final DashboardWidgetKind? kind =
+        DashboardWidgetKind.values.asNameMap()[item['kind']];
+    if (kind == null) {
+      continue;
+    }
+    out.add(DashboardWidgetConfig(kind: kind, enabled: item['enabled'] != false));
+  }
+  return out;
+}
+
+String encodeLayout(List<DashboardWidgetConfig> layout) => jsonEncode(<Object>[
+      for (final DashboardWidgetConfig c in layout)
+        <String, Object>{'kind': c.kind.name, 'enabled': c.enabled},
+    ]);
+
+/// Stored order is kept (first occurrence wins), kinds missing from storage
+/// are appended enabled in enum order - so future widgets appear by default.
+List<DashboardWidgetConfig> mergeLayout(List<DashboardWidgetConfig> stored) {
+  final Set<DashboardWidgetKind> seen = <DashboardWidgetKind>{};
+  final List<DashboardWidgetConfig> out = <DashboardWidgetConfig>[];
+  for (final DashboardWidgetConfig c in stored) {
+    if (seen.add(c.kind)) {
+      out.add(c);
+    }
+  }
+  for (final DashboardWidgetKind kind in DashboardWidgetKind.values) {
+    if (seen.add(kind)) {
+      out.add(DashboardWidgetConfig(kind: kind, enabled: true));
+    }
+  }
+  return out;
+}
+
+/// Board layout (order + visibility), persisted in the app settings box.
+final NotifierProvider<DashboardLayoutController, List<DashboardWidgetConfig>>
+    dashboardLayoutProvider =
+    NotifierProvider<DashboardLayoutController, List<DashboardWidgetConfig>>(
+  DashboardLayoutController.new,
+);
+
+class DashboardLayoutController extends Notifier<List<DashboardWidgetConfig>> {
+  static const String _key = 'dashboard.widgetLayout';
+
+  /// The settings box, when open. Null where Hive wasn't booted (widget
+  /// tests) - the layout then just behaves in-memory.
+  Box<String>? get _box => Hive.isBoxOpen(AtriumBoxes.settings)
+      ? Hive.box<String>(AtriumBoxes.settings)
+      : null;
+
+  @override
+  List<DashboardWidgetConfig> build() =>
+      mergeLayout(decodeLayout(_box?.get(_key)));
+
+  /// Reorders within the ENABLED subset (the reorderable list only shows
+  /// enabled widgets). Disabled entries are re-appended after the enabled
+  /// ones - their relative position is meaningless while hidden.
+  void moveEnabled(int oldIndex, int newIndex) {
+    // ReorderableListView reports the insertion index including the dragged
+    // item; adjust when moving down.
+    if (newIndex > oldIndex) {
+      newIndex -= 1;
+    }
+    final List<DashboardWidgetConfig> enabled = <DashboardWidgetConfig>[
+      for (final DashboardWidgetConfig c in state)
+        if (c.enabled) c,
+    ];
+    if (oldIndex < 0 || oldIndex >= enabled.length) {
+      return;
+    }
+    final DashboardWidgetConfig moved = enabled.removeAt(oldIndex);
+    enabled.insert(newIndex.clamp(0, enabled.length), moved);
+    _save(<DashboardWidgetConfig>[
+      ...enabled,
+      for (final DashboardWidgetConfig c in state)
+        if (!c.enabled) c,
+    ]);
+  }
+
+  void setEnabled(DashboardWidgetKind kind, bool enabled) {
+    _save(<DashboardWidgetConfig>[
+      for (final DashboardWidgetConfig c in state)
+        c.kind == kind ? c.copyWith(enabled: enabled) : c,
+    ]);
+  }
+
+  void _save(List<DashboardWidgetConfig> next) {
+    state = next;
+    _box?.put(_key, encodeLayout(next));
+  }
+}

--- a/app/lib/src/dashboard/dashboard_widget_card.dart
+++ b/app/lib/src/dashboard/dashboard_widget_card.dart
@@ -3,8 +3,12 @@ import 'package:flutter/material.dart';
 
 import 'dashboard_widget_kind.dart';
 
-/// Shared chrome for every dashboard widget: tonal rounded card with an
-/// icon-badge header, optional trailing pill/text, and the widget body.
+/// Shared chrome for every dashboard widget: a single calm surface card with
+/// an accent-tinted icon badge, optional trailing pill/text, and the body.
+///
+/// Every card uses the same neutral tone; colour is carried only by the icon
+/// badge and the body's own pills/chips/bars, so the board reads as one system
+/// and the artwork and data lead rather than competing tonal fills.
 class DashboardWidgetCard extends StatelessWidget {
   const DashboardWidgetCard({
     required this.kind,
@@ -12,48 +16,23 @@ class DashboardWidgetCard extends StatelessWidget {
     required this.child,
     this.trailing,
     this.onTap,
-    this.neutral = false,
     super.key,
   });
 
   final DashboardWidgetKind kind;
+
+  /// Role colour for this widget - used for the icon badge only.
   final Color accent;
   final Widget child;
   final Widget? trailing;
   final VoidCallback? onTap;
 
-  /// Neutral cards keep the plain surface tone - used when the body is
-  /// artwork-heavy and a tonal fill would clash.
-  final bool neutral;
-
-  /// Maps the widget's accent role to its M3 container pair, giving each
-  /// card a distinct tonal fill (nzb360-style board) that tracks the
-  /// dynamic-color scheme in both light and dark themes.
-  (Color, Color) _palette(ColorScheme cs) {
-    if (neutral) {
-      return (cs.surfaceContainerHigh, cs.onSurface);
-    }
-    if (accent == cs.error) {
-      return (cs.errorContainer, cs.onErrorContainer);
-    }
-    if (accent == cs.tertiary) {
-      return (cs.tertiaryContainer, cs.onTertiaryContainer);
-    }
-    if (accent == cs.secondary) {
-      return (cs.secondaryContainer, cs.onSecondaryContainer);
-    }
-    if (accent == cs.primary) {
-      return (cs.primaryContainer, cs.onPrimaryContainer);
-    }
-    return (cs.surfaceContainerHigh, cs.onSurface);
-  }
-
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final (Color bg, Color fg) = _palette(theme.colorScheme);
+    final ColorScheme cs = theme.colorScheme;
     return Material(
-      color: bg,
+      color: cs.surfaceContainerHigh,
       borderRadius: BorderRadius.circular(28),
       clipBehavior: Clip.antiAlias,
       child: InkWell(
@@ -70,10 +49,10 @@ class DashboardWidgetCard extends StatelessWidget {
                     height: 44,
                     alignment: Alignment.center,
                     decoration: BoxDecoration(
-                      color: fg.withValues(alpha: 0.12),
+                      color: accent.withValues(alpha: 0.16),
                       borderRadius: BorderRadius.circular(16),
                     ),
-                    child: Icon(kind.icon, size: 24, color: fg),
+                    child: Icon(kind.icon, size: 24, color: accent),
                   ),
                   const SizedBox(width: Insets.md),
                   Expanded(
@@ -81,7 +60,7 @@ class DashboardWidgetCard extends StatelessWidget {
                       kind.label,
                       style: theme.textTheme.titleMedium?.copyWith(
                         fontWeight: FontWeight.w700,
-                        color: fg,
+                        color: cs.onSurface,
                       ),
                     ),
                   ),

--- a/app/lib/src/dashboard/dashboard_widget_card.dart
+++ b/app/lib/src/dashboard/dashboard_widget_card.dart
@@ -1,0 +1,181 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+
+import 'dashboard_widget_kind.dart';
+
+/// Shared chrome for every dashboard widget: tonal rounded card with an
+/// icon-badge header, optional trailing pill/text, and the widget body.
+class DashboardWidgetCard extends StatelessWidget {
+  const DashboardWidgetCard({
+    required this.kind,
+    required this.accent,
+    required this.child,
+    this.trailing,
+    this.onTap,
+    this.neutral = false,
+    super.key,
+  });
+
+  final DashboardWidgetKind kind;
+  final Color accent;
+  final Widget child;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+
+  /// Neutral cards keep the plain surface tone - used when the body is
+  /// artwork-heavy and a tonal fill would clash.
+  final bool neutral;
+
+  /// Maps the widget's accent role to its M3 container pair, giving each
+  /// card a distinct tonal fill (nzb360-style board) that tracks the
+  /// dynamic-color scheme in both light and dark themes.
+  (Color, Color) _palette(ColorScheme cs) {
+    if (neutral) {
+      return (cs.surfaceContainerHigh, cs.onSurface);
+    }
+    if (accent == cs.error) {
+      return (cs.errorContainer, cs.onErrorContainer);
+    }
+    if (accent == cs.tertiary) {
+      return (cs.tertiaryContainer, cs.onTertiaryContainer);
+    }
+    if (accent == cs.secondary) {
+      return (cs.secondaryContainer, cs.onSecondaryContainer);
+    }
+    if (accent == cs.primary) {
+      return (cs.primaryContainer, cs.onPrimaryContainer);
+    }
+    return (cs.surfaceContainerHigh, cs.onSurface);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final (Color bg, Color fg) = _palette(theme.colorScheme);
+    return Material(
+      color: bg,
+      borderRadius: BorderRadius.circular(28),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTap: onTap,
+        child: Padding(
+          padding: const EdgeInsets.all(Insets.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  Container(
+                    width: 44,
+                    height: 44,
+                    alignment: Alignment.center,
+                    decoration: BoxDecoration(
+                      color: fg.withValues(alpha: 0.12),
+                      borderRadius: BorderRadius.circular(16),
+                    ),
+                    child: Icon(kind.icon, size: 24, color: fg),
+                  ),
+                  const SizedBox(width: Insets.md),
+                  Expanded(
+                    child: Text(
+                      kind.label,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        color: fg,
+                      ),
+                    ),
+                  ),
+                  if (trailing != null) trailing!,
+                ],
+              ),
+              const SizedBox(height: Insets.md),
+              child,
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// Small tonal metadata pill, matching the module screens.
+class DashboardPill extends StatelessWidget {
+  const DashboardPill({
+    required this.icon,
+    required this.label,
+    required this.color,
+    super.key,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Icon(icon, size: 14, color: color),
+          const SizedBox(width: 4),
+          Text(
+            label,
+            style: Theme.of(context)
+                .textTheme
+                .labelSmall
+                ?.copyWith(fontWeight: FontWeight.w600, color: color),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// Quiet single-line body used when a configured widget has nothing to show.
+class DashboardIdleRow extends StatelessWidget {
+  const DashboardIdleRow({required this.text, super.key});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Text(
+      text,
+      style: theme.textTheme.bodySmall
+          ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+    );
+  }
+}
+
+/// Compact inline error state with a retry action; the widget stays visible.
+class DashboardErrorRow extends StatelessWidget {
+  const DashboardErrorRow({required this.onRetry, super.key});
+
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    return Row(
+      children: <Widget>[
+        Icon(Icons.error_outline, size: 18, color: theme.colorScheme.error),
+        const SizedBox(width: Insets.sm),
+        Expanded(
+          child: Text(
+            'Could not load',
+            style: theme.textTheme.bodySmall
+                ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+          ),
+        ),
+        TextButton(onPressed: onRetry, child: const Text('Retry')),
+      ],
+    );
+  }
+}

--- a/app/lib/src/dashboard/dashboard_widget_kind.dart
+++ b/app/lib/src/dashboard/dashboard_widget_kind.dart
@@ -2,15 +2,26 @@ import 'package:core_models/core_models.dart';
 import 'package:flutter/material.dart';
 
 /// The widget types the dashboard board can show, in default display order.
-enum DashboardWidgetKind { downloads, streams, upcoming, health, requests, diskSpace }
+enum DashboardWidgetKind {
+  downloads,
+  streams,
+  upcoming,
+  recentlyAdded,
+  health,
+  requests,
+  serverInfo,
+  diskSpace,
+}
 
 extension DashboardWidgetKindX on DashboardWidgetKind {
   String get label => switch (this) {
         DashboardWidgetKind.downloads => 'Active downloads',
         DashboardWidgetKind.streams => 'Now streaming',
         DashboardWidgetKind.upcoming => 'Upcoming releases',
+        DashboardWidgetKind.recentlyAdded => 'Recently added',
         DashboardWidgetKind.health => 'Service health',
-        DashboardWidgetKind.requests => 'Pending requests',
+        DashboardWidgetKind.requests => 'Requests',
+        DashboardWidgetKind.serverInfo => 'Server info',
         DashboardWidgetKind.diskSpace => 'Disk space',
       };
 
@@ -18,8 +29,10 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.downloads => Icons.download_rounded,
         DashboardWidgetKind.streams => Icons.play_circle_outline,
         DashboardWidgetKind.upcoming => Icons.event_outlined,
+        DashboardWidgetKind.recentlyAdded => Icons.new_releases_outlined,
         DashboardWidgetKind.health => Icons.monitor_heart_outlined,
-        DashboardWidgetKind.requests => Icons.how_to_vote_outlined,
+        DashboardWidgetKind.requests => Icons.bookmark_added_outlined,
+        DashboardWidgetKind.serverInfo => Icons.memory,
         DashboardWidgetKind.diskSpace => Icons.storage_outlined,
       };
 
@@ -35,8 +48,12 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
           ],
         DashboardWidgetKind.upcoming =>
           const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
+        DashboardWidgetKind.recentlyAdded =>
+          const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
         DashboardWidgetKind.health => ServiceKind.values,
         DashboardWidgetKind.requests => const <ServiceKind>[ServiceKind.seerr],
+        DashboardWidgetKind.serverInfo =>
+          const <ServiceKind>[ServiceKind.glances],
         DashboardWidgetKind.diskSpace =>
           const <ServiceKind>[ServiceKind.sabnzbd, ServiceKind.glances],
       };

--- a/app/lib/src/dashboard/dashboard_widget_kind.dart
+++ b/app/lib/src/dashboard/dashboard_widget_kind.dart
@@ -1,0 +1,43 @@
+import 'package:core_models/core_models.dart';
+import 'package:flutter/material.dart';
+
+/// The widget types the dashboard board can show, in default display order.
+enum DashboardWidgetKind { downloads, streams, upcoming, health, requests, diskSpace }
+
+extension DashboardWidgetKindX on DashboardWidgetKind {
+  String get label => switch (this) {
+        DashboardWidgetKind.downloads => 'Active downloads',
+        DashboardWidgetKind.streams => 'Now streaming',
+        DashboardWidgetKind.upcoming => 'Upcoming releases',
+        DashboardWidgetKind.health => 'Service health',
+        DashboardWidgetKind.requests => 'Pending requests',
+        DashboardWidgetKind.diskSpace => 'Disk space',
+      };
+
+  IconData get icon => switch (this) {
+        DashboardWidgetKind.downloads => Icons.download_rounded,
+        DashboardWidgetKind.streams => Icons.play_circle_outline,
+        DashboardWidgetKind.upcoming => Icons.event_outlined,
+        DashboardWidgetKind.health => Icons.monitor_heart_outlined,
+        DashboardWidgetKind.requests => Icons.how_to_vote_outlined,
+        DashboardWidgetKind.diskSpace => Icons.storage_outlined,
+      };
+
+  /// Service kinds whose presence makes this widget "configured". The health
+  /// widget is configured whenever ANY instance exists.
+  List<ServiceKind> get serviceKinds => switch (this) {
+        DashboardWidgetKind.downloads =>
+          const <ServiceKind>[ServiceKind.qbittorrent, ServiceKind.sabnzbd],
+        DashboardWidgetKind.streams => const <ServiceKind>[
+            ServiceKind.tautulli,
+            ServiceKind.jellyfin,
+            ServiceKind.emby,
+          ],
+        DashboardWidgetKind.upcoming =>
+          const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
+        DashboardWidgetKind.health => ServiceKind.values,
+        DashboardWidgetKind.requests => const <ServiceKind>[ServiceKind.seerr],
+        DashboardWidgetKind.diskSpace =>
+          const <ServiceKind>[ServiceKind.sabnzbd, ServiceKind.glances],
+      };
+}

--- a/app/lib/src/dashboard/widgets/disk_widget.dart
+++ b/app/lib/src/dashboard/widgets/disk_widget.dart
@@ -1,0 +1,183 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:service_glances/service_glances.dart';
+import 'package:service_sabnzbd/service_sabnzbd.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+class _DiskRow {
+  const _DiskRow({
+    required this.label,
+    required this.fraction,
+    required this.detail,
+  });
+
+  final String label;
+  final double fraction; // used fraction 0..1
+  final String detail;
+}
+
+String _fmtBytes(num bytes) {
+  if (bytes <= 0) {
+    return '0 B';
+  }
+  const List<String> units = <String>['B', 'KB', 'MB', 'GB', 'TB'];
+  double v = bytes.toDouble();
+  int u = 0;
+  while (v >= 1024 && u < units.length - 1) {
+    v /= 1024;
+    u++;
+  }
+  return '${v.toStringAsFixed(v >= 100 ? 0 : 1)} ${units[u]}';
+}
+
+/// Free space from whatever reports it: SABnzbd's download disk and Glances
+/// filesystems. Not tappable.
+class DashboardDiskWidget extends ConsumerWidget {
+  const DashboardDiskWidget({
+    required this.sabInstances,
+    required this.glancesInstances,
+    super.key,
+  });
+
+  final List<Instance> sabInstances;
+  final List<Instance> glancesInstances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final List<_DiskRow> rows = <_DiskRow>[];
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in sabInstances) {
+      final AsyncValue<SabQueue> queue = ref.watch(sabQueueProvider(i));
+      anyLoading |= queue.isLoading && !queue.hasValue;
+      anyError |= queue.hasError;
+      final SabQueue? q = queue.valueOrNull;
+      final double free = double.tryParse(q?.diskspace1 ?? '') ?? 0;
+      final double total = double.tryParse(q?.diskspacetotal1 ?? '') ?? 0;
+      if (total > 0) {
+        rows.add(_DiskRow(
+          label: i.name,
+          fraction: ((total - free) / total).clamp(0, 1).toDouble(),
+          detail:
+              '${free.toStringAsFixed(0)} GB free of ${total.toStringAsFixed(0)} GB',
+        ));
+      }
+    }
+    for (final Instance i in glancesInstances) {
+      final AsyncValue<GlancesStats> stats = ref.watch(glancesStatsProvider(i));
+      anyLoading |= stats.isLoading && !stats.hasValue;
+      anyError |= stats.hasError;
+      for (final GlancesDisk d
+          in stats.valueOrNull?.disks ?? const <GlancesDisk>[]) {
+        if (d.total > 0) {
+          rows.add(_DiskRow(
+            label: '${i.name} ${d.path}',
+            fraction: (d.percentage / 100).clamp(0, 1).toDouble(),
+            detail:
+                '${_fmtBytes(d.total - d.used)} free of ${_fmtBytes(d.total)}',
+          ));
+        }
+      }
+    }
+
+    final List<_DiskRow> top = rows.take(5).toList();
+
+    Widget body;
+    if (rows.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (rows.isEmpty && anyError) {
+      body = DashboardErrorRow(
+        onRetry: () {
+          for (final Instance i in sabInstances) {
+            ref.invalidate(sabQueueProvider(i));
+          }
+          for (final Instance i in glancesInstances) {
+            ref.invalidate(glancesStatsProvider(i));
+          }
+        },
+      );
+    } else if (rows.isEmpty) {
+      body = const DashboardIdleRow(text: 'No disk info available');
+    } else {
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (final _DiskRow row in top) _BarRow(row: row),
+          if (rows.length > top.length)
+            DashboardIdleRow(text: '+${rows.length - top.length} more'),
+        ],
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.diskSpace,
+      accent: cs.primary,
+      child: body,
+    );
+  }
+}
+
+class _BarRow extends StatelessWidget {
+  const _BarRow({required this.row});
+
+  final _DiskRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final Color barColor = row.fraction > 0.9 ? cs.error : cs.primary;
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  row.label,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+              const SizedBox(width: Insets.sm),
+              Text(
+                row.detail,
+                style: theme.textTheme.labelSmall
+                    ?.copyWith(color: cs.onSurfaceVariant),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: row.fraction,
+              minHeight: 5,
+              color: barColor,
+              backgroundColor: cs.surfaceContainerHighest,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/widgets/disk_widget.dart
+++ b/app/lib/src/dashboard/widgets/disk_widget.dart
@@ -58,7 +58,7 @@ class DashboardDiskWidget extends ConsumerWidget {
       final AsyncValue<SabQueue> queue = ref.watch(sabQueueProvider(i));
       anyLoading |= queue.isLoading && !queue.hasValue;
       anyError |= queue.hasError;
-      final SabQueue? q = queue.valueOrNull;
+      final SabQueue? q = queue.value;
       final double free = double.tryParse(q?.diskspace1 ?? '') ?? 0;
       final double total = double.tryParse(q?.diskspacetotal1 ?? '') ?? 0;
       if (total > 0) {
@@ -75,7 +75,7 @@ class DashboardDiskWidget extends ConsumerWidget {
       anyLoading |= stats.isLoading && !stats.hasValue;
       anyError |= stats.hasError;
       for (final GlancesDisk d
-          in stats.valueOrNull?.disks ?? const <GlancesDisk>[]) {
+          in stats.value?.disks ?? const <GlancesDisk>[]) {
         if (d.total > 0) {
           rows.add(_DiskRow(
             label: '${i.name} ${d.path}',

--- a/app/lib/src/dashboard/widgets/downloads_widget.dart
+++ b/app/lib/src/dashboard/widgets/downloads_widget.dart
@@ -1,4 +1,5 @@
 import 'package:core_models/core_models.dart';
+import 'package:core_profile/core_profile.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -20,6 +21,29 @@ const Set<String> _activeDlStates = <String>{
   'checkingDL',
   'allocating',
 };
+
+/// Live count of active downloads across every qBittorrent + SABnzbd instance.
+/// Instances still loading or in error contribute 0, so the dashboard only
+/// surfaces the downloads widget once real activity is confirmed.
+final activeDownloadCountProvider = Provider.autoDispose<int>((Ref ref) {
+  final List<Instance> instances = ref.watch(activeInstancesProvider);
+  int count = 0;
+  for (final Instance i in instances) {
+    if (i.kind == ServiceKind.qbittorrent) {
+      final List<QbitTorrent> torrents =
+          ref.watch(qbitRawTorrentsProvider(i)).value ??
+              const <QbitTorrent>[];
+      for (final QbitTorrent t in torrents) {
+        if (_activeDlStates.contains(t.state)) {
+          count++;
+        }
+      }
+    } else if (i.kind == ServiceKind.sabnzbd) {
+      count += ref.watch(sabQueueProvider(i)).value?.slots.length ?? 0;
+    }
+  }
+  return count;
+});
 
 /// Parses SABnzbd's human speed string ("1.2 M", "512 K") into bytes/s.
 int parseSabSpeed(String raw) {
@@ -77,7 +101,7 @@ class DashboardDownloadsWidget extends ConsumerWidget {
           ref.watch(qbitRawTorrentsProvider(i));
       anyLoading |= torrents.isLoading && !torrents.hasValue;
       anyError |= torrents.hasError;
-      for (final QbitTorrent t in torrents.valueOrNull ?? const <QbitTorrent>[]) {
+      for (final QbitTorrent t in torrents.value ?? const <QbitTorrent>[]) {
         if (_activeDlStates.contains(t.state)) {
           rows.add(_DownloadRow(
             name: t.name,
@@ -86,13 +110,13 @@ class DashboardDownloadsWidget extends ConsumerWidget {
           ));
         }
       }
-      totalSpeed += ref.watch(qbitTransferProvider(i)).valueOrNull?.dlSpeed ?? 0;
+      totalSpeed += ref.watch(qbitTransferProvider(i)).value?.dlSpeed ?? 0;
     }
     for (final Instance i in sabInstances) {
       final AsyncValue<SabQueue> queue = ref.watch(sabQueueProvider(i));
       anyLoading |= queue.isLoading && !queue.hasValue;
       anyError |= queue.hasError;
-      final SabQueue? q = queue.valueOrNull;
+      final SabQueue? q = queue.value;
       if (q != null) {
         totalSpeed += parseSabSpeed(q.speed);
         for (final SabSlot s in q.slots) {

--- a/app/lib/src/dashboard/widgets/downloads_widget.dart
+++ b/app/lib/src/dashboard/widgets/downloads_widget.dart
@@ -1,0 +1,217 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+import 'package:service_sabnzbd/service_sabnzbd.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+/// qBittorrent states that count as actively downloading.
+const Set<String> _activeDlStates = <String>{
+  'downloading',
+  'forcedDL',
+  'metaDL',
+  'stalledDL',
+  'queuedDL',
+  'checkingDL',
+  'allocating',
+};
+
+/// Parses SABnzbd's human speed string ("1.2 M", "512 K") into bytes/s.
+int parseSabSpeed(String raw) {
+  final RegExpMatch? m =
+      RegExp(r'^([\d.]+)\s*([KMGT]?)$').firstMatch(raw.trim());
+  if (m == null) {
+    return 0;
+  }
+  final double value = double.tryParse(m.group(1)!) ?? 0;
+  const Map<String, int> mult = <String, int>{
+    '': 1,
+    'K': 1024,
+    'M': 1024 * 1024,
+    'G': 1024 * 1024 * 1024,
+    'T': 1024 * 1024 * 1024 * 1024,
+  };
+  return (value * mult[m.group(2)]!).round();
+}
+
+class _DownloadRow {
+  const _DownloadRow({
+    required this.name,
+    required this.progress,
+    required this.instance,
+  });
+
+  final String name;
+  final double progress;
+  final Instance instance;
+}
+
+/// Combined qBittorrent + SABnzbd activity: total speed, count, top items.
+class DashboardDownloadsWidget extends ConsumerWidget {
+  const DashboardDownloadsWidget({
+    required this.qbitInstances,
+    required this.sabInstances,
+    super.key,
+  });
+
+  final List<Instance> qbitInstances;
+  final List<Instance> sabInstances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    final List<_DownloadRow> rows = <_DownloadRow>[];
+    int totalSpeed = 0;
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in qbitInstances) {
+      final AsyncValue<List<QbitTorrent>> torrents =
+          ref.watch(qbitRawTorrentsProvider(i));
+      anyLoading |= torrents.isLoading && !torrents.hasValue;
+      anyError |= torrents.hasError;
+      for (final QbitTorrent t in torrents.valueOrNull ?? const <QbitTorrent>[]) {
+        if (_activeDlStates.contains(t.state)) {
+          rows.add(_DownloadRow(
+            name: t.name,
+            progress: t.progress.clamp(0, 1).toDouble(),
+            instance: i,
+          ));
+        }
+      }
+      totalSpeed += ref.watch(qbitTransferProvider(i)).valueOrNull?.dlSpeed ?? 0;
+    }
+    for (final Instance i in sabInstances) {
+      final AsyncValue<SabQueue> queue = ref.watch(sabQueueProvider(i));
+      anyLoading |= queue.isLoading && !queue.hasValue;
+      anyError |= queue.hasError;
+      final SabQueue? q = queue.valueOrNull;
+      if (q != null) {
+        totalSpeed += parseSabSpeed(q.speed);
+        for (final SabSlot s in q.slots) {
+          rows.add(_DownloadRow(
+            name: s.filename,
+            progress: ((double.tryParse(s.percentage) ?? 0) / 100)
+                .clamp(0, 1)
+                .toDouble(),
+            instance: i,
+          ));
+        }
+      }
+    }
+
+    rows.sort((_DownloadRow a, _DownloadRow b) => b.progress.compareTo(a.progress));
+    final List<_DownloadRow> top = rows.take(3).toList();
+
+    Widget body;
+    if (rows.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (rows.isEmpty && anyError) {
+      body = DashboardErrorRow(onRetry: () => _refresh(ref));
+    } else if (rows.isEmpty) {
+      body = const DashboardIdleRow(text: 'Nothing downloading');
+    } else {
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (final _DownloadRow row in top) _ItemRow(row: row),
+          if (rows.length > top.length)
+            DashboardIdleRow(text: '+${rows.length - top.length} more'),
+        ],
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.downloads,
+      accent: cs.primary,
+      trailing: totalSpeed > 0
+          ? DashboardPill(
+              icon: Icons.arrow_downward_rounded,
+              label: '${fmtBytes(totalSpeed)}/s',
+              color: cs.primary,
+            )
+          : null,
+      child: body,
+    );
+  }
+
+  void _refresh(WidgetRef ref) {
+    for (final Instance i in qbitInstances) {
+      ref.invalidate(qbitRawTorrentsProvider(i));
+      ref.invalidate(qbitTransferProvider(i));
+    }
+    for (final Instance i in sabInstances) {
+      ref.invalidate(sabQueueProvider(i));
+    }
+  }
+}
+
+class _ItemRow extends StatelessWidget {
+  const _ItemRow({required this.row});
+
+  final _DownloadRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => context.go(
+        AtriumRoutes.servicePath(row.instance.kind.name, row.instance.id),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    row.name,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+                const SizedBox(width: Insets.sm),
+                Text(
+                  '${(row.progress * 100).toStringAsFixed(0)}%',
+                  style: theme.textTheme.labelSmall
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: row.progress,
+                minHeight: 5,
+                color: cs.primary,
+                backgroundColor: cs.surfaceContainerHighest,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/widgets/health_widget.dart
+++ b/app/lib/src/dashboard/widgets/health_widget.dart
@@ -1,0 +1,98 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../health_providers.dart';
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+/// Live status of every configured instance, as a chip grid with a summary.
+class DashboardHealthWidget extends ConsumerWidget {
+  const DashboardHealthWidget({required this.instances, super.key});
+
+  final List<Instance> instances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final Map<Instance, Health> health = <Instance, Health>{
+      for (final Instance i in instances)
+        i: ref.watch(instanceHealthProvider(i)).maybeWhen(
+              data: (Health h) => h,
+              orElse: () => Health.unknown,
+            ),
+    };
+    final int issues = health.values
+        .where((Health h) => h == Health.warning || h == Health.error)
+        .length;
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.health,
+      accent: issues > 0 ? cs.error : cs.tertiary,
+      trailing: DashboardPill(
+        icon: issues > 0 ? Icons.warning_amber_rounded : Icons.check_rounded,
+        label:
+            issues > 0 ? '$issues issue${issues == 1 ? '' : 's'}' : 'All online',
+        color: issues > 0 ? cs.error : cs.tertiary,
+      ),
+      child: Wrap(
+        spacing: Insets.sm,
+        runSpacing: Insets.sm,
+        children: <Widget>[
+          for (final MapEntry<Instance, Health> e in health.entries)
+            _HealthChip(instance: e.key, health: e.value),
+        ],
+      ),
+    );
+  }
+}
+
+class _HealthChip extends StatelessWidget {
+  const _HealthChip({required this.instance, required this.health});
+
+  final Instance instance;
+  final Health health;
+
+  Color _dot(ColorScheme cs) => switch (health) {
+        Health.ok => cs.tertiary,
+        Health.warning => cs.secondary,
+        Health.error => cs.error,
+        _ => cs.outline,
+      };
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    return InkWell(
+      borderRadius: BorderRadius.circular(10),
+      onTap: () => context.go(
+        AtriumRoutes.servicePath(instance.kind.name, instance.id),
+      ),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        decoration: BoxDecoration(
+          color: cs.surfaceContainerHighest,
+          borderRadius: BorderRadius.circular(10),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Container(
+              width: 8,
+              height: 8,
+              decoration:
+                  BoxDecoration(color: _dot(cs), shape: BoxShape.circle),
+            ),
+            const SizedBox(width: 6),
+            Text(instance.name, style: theme.textTheme.labelMedium),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/widgets/recently_added_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_added_widget.dart
@@ -1,0 +1,218 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:collection/collection.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:service_radarr/service_radarr.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+class _RecentItem {
+  const _RecentItem({
+    required this.title,
+    required this.added,
+    required this.isMovie,
+    required this.instance,
+    this.posterUrl,
+    this.year,
+  });
+
+  final String title;
+  final DateTime added;
+  final bool isMovie;
+  final Instance instance;
+  final String? posterUrl;
+  final int? year;
+}
+
+/// The most recently added Sonarr series and Radarr movies across every
+/// instance, merged and shown as a horizontally scrollable poster row.
+class DashboardRecentlyAddedWidget extends ConsumerWidget {
+  const DashboardRecentlyAddedWidget({
+    required this.sonarrInstances,
+    required this.radarrInstances,
+    super.key,
+  });
+
+  final List<Instance> sonarrInstances;
+  final List<Instance> radarrInstances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final List<_RecentItem> items = <_RecentItem>[];
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in sonarrInstances) {
+      final AsyncValue<List<SonarrSeries>> series =
+          ref.watch(sonarrSeriesProvider(i));
+      anyLoading |= series.isLoading && !series.hasValue;
+      anyError |= series.hasError;
+      for (final SonarrSeries s in series.value ?? const <SonarrSeries>[]) {
+        final DateTime? added = DateTime.tryParse(s.added ?? '');
+        if (added == null) {
+          continue;
+        }
+        items.add(_RecentItem(
+          title: s.title,
+          added: added,
+          isMovie: false,
+          instance: i,
+          year: s.year,
+          posterUrl: s.images
+              .firstWhereOrNull((SonarrImage im) => im.coverType == 'poster')
+              ?.remoteUrl,
+        ));
+      }
+    }
+    for (final Instance i in radarrInstances) {
+      final AsyncValue<List<RadarrMovie>> movies =
+          ref.watch(radarrMoviesProvider(i));
+      anyLoading |= movies.isLoading && !movies.hasValue;
+      anyError |= movies.hasError;
+      for (final RadarrMovie m in movies.value ?? const <RadarrMovie>[]) {
+        final DateTime? added = DateTime.tryParse(m.added ?? '');
+        if (added == null) {
+          continue;
+        }
+        items.add(_RecentItem(
+          title: m.title,
+          added: added,
+          isMovie: true,
+          instance: i,
+          year: m.year,
+          posterUrl: m.images
+              .firstWhereOrNull((RadarrImage im) => im.coverType == 'poster')
+              ?.remoteUrl,
+        ));
+      }
+    }
+
+    items.sort((_RecentItem a, _RecentItem b) => b.added.compareTo(a.added));
+    final List<_RecentItem> top = items.take(15).toList();
+
+    Widget body;
+    if (items.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (items.isEmpty && anyError) {
+      body = DashboardErrorRow(
+        onRetry: () {
+          for (final Instance i in sonarrInstances) {
+            ref.invalidate(sonarrSeriesProvider(i));
+          }
+          for (final Instance i in radarrInstances) {
+            ref.invalidate(radarrMoviesProvider(i));
+          }
+        },
+      );
+    } else if (items.isEmpty) {
+      body = const DashboardIdleRow(text: 'Nothing added yet');
+    } else {
+      body = SizedBox(
+        height: 184,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: EdgeInsets.zero,
+          itemCount: top.length,
+          separatorBuilder: (_, __) => const SizedBox(width: Insets.sm),
+          itemBuilder: (BuildContext context, int index) =>
+              _PosterTile(item: top[index]),
+        ),
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.recentlyAdded,
+      accent: cs.primary,
+      child: body,
+    );
+  }
+}
+
+class _PosterTile extends StatelessWidget {
+  const _PosterTile({required this.item});
+
+  final _RecentItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final String? poster = item.posterUrl;
+    final String subtitle = <String>[
+      item.isMovie ? 'Movie' : 'Series',
+      if (item.year != null) '${item.year}',
+    ].join(' · ');
+
+    return SizedBox(
+      width: 94,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(10),
+        onTap: () => context.go(
+          AtriumRoutes.servicePath(item.instance.kind.name, item.instance.id),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            ClipRRect(
+              borderRadius: BorderRadius.circular(10),
+              child: SizedBox(
+                width: 94,
+                height: 140,
+                child: (poster == null || poster.isEmpty)
+                    ? _posterFallback(cs)
+                    : CachedNetworkImage(
+                        imageUrl: poster,
+                        fit: BoxFit.cover,
+                        memCacheWidth: 220,
+                        errorWidget: (_, __, ___) => _posterFallback(cs),
+                      ),
+              ),
+            ),
+            const SizedBox(height: 6),
+            Text(
+              item.title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.labelMedium
+                  ?.copyWith(fontWeight: FontWeight.w600),
+            ),
+            Text(
+              subtitle,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodySmall
+                  ?.copyWith(color: cs.onSurfaceVariant),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _posterFallback(ColorScheme cs) => Container(
+        color: cs.surfaceContainerHighest,
+        alignment: Alignment.center,
+        child: Icon(
+          item.isMovie ? Icons.movie_outlined : Icons.live_tv_outlined,
+          size: 22,
+          color: cs.onSurfaceVariant,
+        ),
+      );
+}

--- a/app/lib/src/dashboard/widgets/requests_widget.dart
+++ b/app/lib/src/dashboard/widgets/requests_widget.dart
@@ -1,0 +1,168 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:service_seerr/service_seerr.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+class _PendingRequest {
+  const _PendingRequest({required this.request, required this.instance});
+
+  final SeerrRequest request;
+  final Instance instance;
+}
+
+/// Seerr requests awaiting approval: count plus the newest titles.
+class DashboardRequestsWidget extends ConsumerWidget {
+  const DashboardRequestsWidget({required this.instances, super.key});
+
+  final List<Instance> instances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    int pendingCount = 0;
+    final List<_PendingRequest> pending = <_PendingRequest>[];
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in instances) {
+      final AsyncValue<SeerrCounts> counts =
+          ref.watch(seerrRequestCountsProvider(i));
+      anyLoading |= counts.isLoading && !counts.hasValue;
+      anyError |= counts.hasError;
+      pendingCount += counts.valueOrNull?.pending ?? 0;
+
+      final List<SeerrRequest> requests =
+          ref.watch(seerrRequestsProvider(i)).valueOrNull ??
+              const <SeerrRequest>[];
+      for (final SeerrRequest r in requests) {
+        // Request status 1 = pending approval.
+        if (r.status == 1) {
+          pending.add(_PendingRequest(request: r, instance: i));
+        }
+      }
+    }
+
+    pending.sort((_PendingRequest a, _PendingRequest b) {
+      final DateTime da =
+          DateTime.tryParse(a.request.createdAt ?? '') ?? DateTime(1970);
+      final DateTime db =
+          DateTime.tryParse(b.request.createdAt ?? '') ?? DateTime(1970);
+      return db.compareTo(da);
+    });
+    final List<_PendingRequest> top = pending.take(2).toList();
+
+    Widget body;
+    if (pendingCount == 0 && pending.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (pendingCount == 0 && pending.isEmpty && anyError) {
+      body = DashboardErrorRow(
+        onRetry: () {
+          for (final Instance i in instances) {
+            ref.invalidate(seerrRequestCountsProvider(i));
+            ref.invalidate(seerrRequestsProvider(i));
+          }
+        },
+      );
+    } else if (pendingCount == 0 && pending.isEmpty) {
+      body = const DashboardIdleRow(text: 'No pending requests');
+    } else {
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (final _PendingRequest p in top) _RequestRow(pending: p),
+          if (pending.length > top.length)
+            DashboardIdleRow(text: '+${pending.length - top.length} more'),
+        ],
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.requests,
+      accent: cs.secondary,
+      onTap: instances.length == 1
+          ? () => context.go(
+                AtriumRoutes.servicePath(
+                  instances.first.kind.name,
+                  instances.first.id,
+                ),
+              )
+          : null,
+      trailing: pendingCount > 0
+          ? DashboardPill(
+              icon: Icons.hourglass_top_rounded,
+              label: '$pendingCount pending',
+              color: cs.secondary,
+            )
+          : null,
+      child: body,
+    );
+  }
+}
+
+class _RequestRow extends ConsumerWidget {
+  const _RequestRow({required this.pending});
+
+  final _PendingRequest pending;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final SeerrRequest r = pending.request;
+
+    // Resolve the title like the Seerr requests tab does; fall back to the
+    // request type while it loads or when there is no tmdb id.
+    final int? tmdbId = r.media?.tmdbId;
+    String title = r.type == 'movie' ? 'Movie request' : 'Series request';
+    if (tmdbId != null) {
+      final String mediaType =
+          r.media!.mediaType.isNotEmpty ? r.media!.mediaType : r.type;
+      final SeerrDiscoverResult? details = ref
+          .watch(seerrMediaDetailsProvider(
+            (instance: pending.instance, mediaType: mediaType, tmdbId: tmdbId),
+          ))
+          .valueOrNull;
+      if (details != null) {
+        title = details.displayTitle;
+      }
+    }
+    final String by = r.requestedBy?.displayName ?? '';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+      child: Row(
+        children: <Widget>[
+          Icon(
+            r.type == 'movie' ? Icons.movie_outlined : Icons.live_tv_outlined,
+            size: 16,
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+          const SizedBox(width: Insets.sm),
+          Expanded(
+            child: Text(
+              by.isEmpty ? title : '$title - $by',
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: theme.textTheme.bodyMedium,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/widgets/requests_widget.dart
+++ b/app/lib/src/dashboard/widgets/requests_widget.dart
@@ -1,3 +1,4 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
@@ -9,14 +10,18 @@ import 'package:service_seerr/service_seerr.dart';
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
 
-class _PendingRequest {
-  const _PendingRequest({required this.request, required this.instance});
+String _tmdbImage(String path, String size) =>
+    'https://image.tmdb.org/t/p/$size$path';
+
+class _Request {
+  const _Request({required this.request, required this.instance});
 
   final SeerrRequest request;
   final Instance instance;
 }
 
-/// Seerr requests awaiting approval: count plus the newest titles.
+/// Recent Seerr requests across every instance, newest first, each with its
+/// poster and live availability status - not just the approval queue.
 class DashboardRequestsWidget extends ConsumerWidget {
   const DashboardRequestsWidget({required this.instances, super.key});
 
@@ -26,40 +31,36 @@ class DashboardRequestsWidget extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ColorScheme cs = Theme.of(context).colorScheme;
 
-    int pendingCount = 0;
-    final List<_PendingRequest> pending = <_PendingRequest>[];
+    int totalRequested = 0;
+    final List<_Request> requests = <_Request>[];
     bool anyLoading = false;
     bool anyError = false;
 
     for (final Instance i in instances) {
       final AsyncValue<SeerrCounts> counts =
           ref.watch(seerrRequestCountsProvider(i));
-      anyLoading |= counts.isLoading && !counts.hasValue;
-      anyError |= counts.hasError;
-      pendingCount += counts.valueOrNull?.pending ?? 0;
+      totalRequested += counts.value?.total ?? 0;
 
-      final List<SeerrRequest> requests =
-          ref.watch(seerrRequestsProvider(i)).valueOrNull ??
-              const <SeerrRequest>[];
-      for (final SeerrRequest r in requests) {
-        // Request status 1 = pending approval.
-        if (r.status == 1) {
-          pending.add(_PendingRequest(request: r, instance: i));
-        }
+      final AsyncValue<List<SeerrRequest>> list =
+          ref.watch(seerrRequestsProvider(i));
+      anyLoading |= list.isLoading && !list.hasValue;
+      anyError |= list.hasError;
+      for (final SeerrRequest r in list.value ?? const <SeerrRequest>[]) {
+        requests.add(_Request(request: r, instance: i));
       }
     }
 
-    pending.sort((_PendingRequest a, _PendingRequest b) {
+    requests.sort((_Request a, _Request b) {
       final DateTime da =
           DateTime.tryParse(a.request.createdAt ?? '') ?? DateTime(1970);
       final DateTime db =
           DateTime.tryParse(b.request.createdAt ?? '') ?? DateTime(1970);
       return db.compareTo(da);
     });
-    final List<_PendingRequest> top = pending.take(2).toList();
+    final List<_Request> top = requests.take(3).toList();
 
     Widget body;
-    if (pendingCount == 0 && pending.isEmpty && anyLoading) {
+    if (requests.isEmpty && anyLoading) {
       body = const Center(
         child: Padding(
           padding: EdgeInsets.all(Insets.sm),
@@ -70,7 +71,7 @@ class DashboardRequestsWidget extends ConsumerWidget {
           ),
         ),
       );
-    } else if (pendingCount == 0 && pending.isEmpty && anyError) {
+    } else if (requests.isEmpty && anyError) {
       body = DashboardErrorRow(
         onRetry: () {
           for (final Instance i in instances) {
@@ -79,15 +80,22 @@ class DashboardRequestsWidget extends ConsumerWidget {
           }
         },
       );
-    } else if (pendingCount == 0 && pending.isEmpty) {
-      body = const DashboardIdleRow(text: 'No pending requests');
+    } else if (requests.isEmpty) {
+      body = const DashboardIdleRow(text: 'No requests yet');
     } else {
       body = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          for (final _PendingRequest p in top) _RequestRow(pending: p),
-          if (pending.length > top.length)
-            DashboardIdleRow(text: '+${pending.length - top.length} more'),
+          for (int j = 0; j < top.length; j++) ...<Widget>[
+            if (j > 0) const SizedBox(height: Insets.sm),
+            _RequestRow(request: top[j]),
+          ],
+          if (requests.length > top.length)
+            Padding(
+              padding: const EdgeInsets.only(top: Insets.sm),
+              child:
+                  DashboardIdleRow(text: '+${requests.length - top.length} more'),
+            ),
         ],
       );
     }
@@ -103,10 +111,10 @@ class DashboardRequestsWidget extends ConsumerWidget {
                 ),
               )
           : null,
-      trailing: pendingCount > 0
+      trailing: totalRequested > 0
           ? DashboardPill(
-              icon: Icons.hourglass_top_rounded,
-              label: '$pendingCount pending',
+              icon: Icons.bookmark_added_outlined,
+              label: '$totalRequested requested',
               color: cs.secondary,
             )
           : null,
@@ -115,53 +123,154 @@ class DashboardRequestsWidget extends ConsumerWidget {
   }
 }
 
+/// A single request as a poster banner: artwork thumb, resolved title, the
+/// requester, and an availability chip.
 class _RequestRow extends ConsumerWidget {
-  const _RequestRow({required this.pending});
+  const _RequestRow({required this.request});
 
-  final _PendingRequest pending;
+  final _Request request;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    final SeerrRequest r = pending.request;
+    final ColorScheme cs = theme.colorScheme;
+    final SeerrRequest r = request.request;
 
-    // Resolve the title like the Seerr requests tab does; fall back to the
-    // request type while it loads or when there is no tmdb id.
+    // Resolve the title + poster like the Seerr requests tab does; fall back
+    // to the request type while it loads or when there is no tmdb id.
     final int? tmdbId = r.media?.tmdbId;
     String title = r.type == 'movie' ? 'Movie request' : 'Series request';
+    String? posterPath;
     if (tmdbId != null) {
       final String mediaType =
-          r.media!.mediaType.isNotEmpty ? r.media!.mediaType : r.type;
+          (r.media?.mediaType ?? '').isNotEmpty ? r.media!.mediaType : r.type;
       final SeerrDiscoverResult? details = ref
           .watch(seerrMediaDetailsProvider(
-            (instance: pending.instance, mediaType: mediaType, tmdbId: tmdbId),
+            (instance: request.instance, mediaType: mediaType, tmdbId: tmdbId),
           ))
-          .valueOrNull;
+          .value;
       if (details != null) {
         title = details.displayTitle;
+        posterPath = details.posterPath;
       }
     }
     final String by = r.requestedBy?.displayName ?? '';
+    final (String statusLabel, Color statusColor) = _status(r, cs);
 
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: () => context.go(
+        AtriumRoutes.servicePath(
+          request.instance.kind.name,
+          request.instance.id,
+        ),
+      ),
       child: Row(
         children: <Widget>[
-          Icon(
-            r.type == 'movie' ? Icons.movie_outlined : Icons.live_tv_outlined,
-            size: 16,
-            color: theme.colorScheme.onSurfaceVariant,
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: SizedBox(
+              width: 40,
+              height: 56,
+              child: posterPath == null
+                  ? _posterFallback(cs, r.type)
+                  : CachedNetworkImage(
+                      imageUrl: _tmdbImage(posterPath, 'w185'),
+                      fit: BoxFit.cover,
+                      memCacheWidth: 120,
+                      errorWidget: (_, __, ___) => _posterFallback(cs, r.type),
+                    ),
+            ),
           ),
-          const SizedBox(width: Insets.sm),
+          const SizedBox(width: Insets.md),
           Expanded(
-            child: Text(
-              by.isEmpty ? title : '$title - $by',
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: theme.textTheme.bodyMedium,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  title,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.w700),
+                ),
+                const SizedBox(height: 3),
+                Row(
+                  children: <Widget>[
+                    _StatusChip(label: statusLabel, color: statusColor),
+                    if (by.isNotEmpty) ...<Widget>[
+                      const SizedBox(width: Insets.sm),
+                      Flexible(
+                        child: Text(
+                          by,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall
+                              ?.copyWith(color: cs.onSurfaceVariant),
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ],
             ),
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _posterFallback(ColorScheme cs, String type) => Container(
+        color: cs.surfaceContainerHighest,
+        alignment: Alignment.center,
+        child: Icon(
+          type == 'movie' ? Icons.movie_outlined : Icons.live_tv_outlined,
+          size: 18,
+          color: cs.onSurfaceVariant,
+        ),
+      );
+
+  /// Request state -> (label, colour). Approval status wins; otherwise the
+  /// media availability status (1 unknown, 2 pending, 3 processing, 4 partial,
+  /// 5 available) is surfaced.
+  (String, Color) _status(SeerrRequest r, ColorScheme cs) {
+    if (r.status == 3) {
+      return ('Declined', cs.onSurfaceVariant);
+    }
+    if (r.status == 1) {
+      return ('Needs approval', cs.primary);
+    }
+    return switch (r.media?.status ?? 1) {
+      5 => ('Available', cs.tertiary),
+      4 => ('Partial', cs.tertiary),
+      3 => ('Processing', cs.secondary),
+      _ => ('Requested', cs.onSurfaceVariant),
+    };
+  }
+}
+
+/// A compact filled status chip for a request row.
+class _StatusChip extends StatelessWidget {
+  const _StatusChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context)
+            .textTheme
+            .labelSmall
+            ?.copyWith(fontWeight: FontWeight.w700, color: color),
       ),
     );
   }

--- a/app/lib/src/dashboard/widgets/server_info_widget.dart
+++ b/app/lib/src/dashboard/widgets/server_info_widget.dart
@@ -1,0 +1,288 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
+import 'package:service_glances/service_glances.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+String _fmtBytes(num bytes) {
+  if (bytes <= 0) {
+    return '0 B';
+  }
+  const List<String> units = <String>['B', 'KB', 'MB', 'GB', 'TB'];
+  double v = bytes.toDouble();
+  int u = 0;
+  while (v >= 1024 && u < units.length - 1) {
+    v /= 1024;
+    u++;
+  }
+  return '${v.toStringAsFixed(v >= 100 ? 0 : 1)} ${units[u]}';
+}
+
+/// Colour for a load bar: red past 90%, otherwise the primary accent.
+Color _loadColor(double percent, ColorScheme cs) =>
+    percent >= 90 ? cs.error : cs.primary;
+
+/// Live server vitals from Glances: CPU, memory, GPU (when present) and the
+/// filesystems, one section per Glances instance.
+class DashboardServerInfoWidget extends ConsumerWidget {
+  const DashboardServerInfoWidget({required this.instances, super.key});
+
+  final List<Instance> instances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final List<({Instance instance, GlancesStats stats})> servers =
+        <({Instance instance, GlancesStats stats})>[];
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in instances) {
+      final AsyncValue<GlancesStats> stats = ref.watch(glancesStatsProvider(i));
+      anyLoading |= stats.isLoading && !stats.hasValue;
+      anyError |= stats.hasError;
+      final GlancesStats? value = stats.value;
+      if (value != null) {
+        servers.add((instance: i, stats: value));
+      }
+    }
+
+    Widget body;
+    if (servers.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (servers.isEmpty && anyError) {
+      body = DashboardErrorRow(
+        onRetry: () {
+          for (final Instance i in instances) {
+            ref.invalidate(glancesStatsProvider(i));
+          }
+        },
+      );
+    } else if (servers.isEmpty) {
+      body = const DashboardIdleRow(text: 'No server stats available');
+    } else {
+      final bool showName = servers.length > 1;
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (int j = 0; j < servers.length; j++) ...<Widget>[
+            if (j > 0) const SizedBox(height: Insets.md),
+            _ServerBlock(
+              instance: servers[j].instance,
+              stats: servers[j].stats,
+              showName: showName,
+            ),
+          ],
+        ],
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.serverInfo,
+      accent: Theme.of(context).colorScheme.primary,
+      child: body,
+    );
+  }
+}
+
+class _ServerBlock extends StatelessWidget {
+  const _ServerBlock({
+    required this.instance,
+    required this.stats,
+    required this.showName,
+  });
+
+  final Instance instance;
+  final GlancesStats stats;
+  final bool showName;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final GlancesGpu? gpu = stats.gpus.isNotEmpty ? stats.gpus.first : null;
+    final List<GlancesDisk> disks = <GlancesDisk>[
+      for (final GlancesDisk d in stats.disks)
+        if (d.total > 0) d,
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (showName)
+          Padding(
+            padding: const EdgeInsets.only(bottom: Insets.sm),
+            child: Text(
+              instance.name,
+              style: theme.textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: cs.onSurfaceVariant,
+              ),
+            ),
+          ),
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Expanded(
+              child: _MetricTile(
+                label: 'CPU',
+                percent: stats.cpu.totalUsage,
+                detail: stats.cpu.packageTemp > 0
+                    ? '${stats.cpu.packageTemp.round()}°C'
+                    : '${stats.cpu.logicalCores} cores',
+              ),
+            ),
+            const SizedBox(width: Insets.md),
+            Expanded(
+              child: _MetricTile(
+                label: 'Memory',
+                percent: stats.memory.percentage,
+                detail:
+                    '${_fmtBytes(stats.memory.used)} / ${_fmtBytes(stats.memory.total)}',
+              ),
+            ),
+            if (gpu != null) ...<Widget>[
+              const SizedBox(width: Insets.md),
+              Expanded(
+                child: _MetricTile(
+                  label: 'GPU',
+                  percent: gpu.proc,
+                  detail: gpu.temp > 0
+                      ? '${gpu.temp.round()}°C'
+                      : 'MEM ${gpu.mem.round()}%',
+                ),
+              ),
+            ],
+          ],
+        ),
+        if (disks.isNotEmpty) ...<Widget>[
+          const SizedBox(height: Insets.md),
+          for (final GlancesDisk d in disks.take(4)) _DiskBar(disk: d),
+          if (disks.length > 4)
+            DashboardIdleRow(text: '+${disks.length - 4} more'),
+        ],
+      ],
+    );
+  }
+}
+
+class _MetricTile extends StatelessWidget {
+  const _MetricTile({
+    required this.label,
+    required this.percent,
+    required this.detail,
+  });
+
+  final String label;
+  final double percent;
+  final String detail;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final Color color = _loadColor(percent, cs);
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        SizedBox(
+          width: 52,
+          height: 52,
+          child: Stack(
+            alignment: Alignment.center,
+            children: <Widget>[
+              CircularProgressIndicatorM3E(
+                value: (percent / 100).clamp(0, 1).toDouble(),
+                size: CircularProgressM3ESize.m,
+                shape: ProgressM3EShape.flat,
+                activeColor: color,
+                trackColor: cs.surfaceContainerHighest,
+              ),
+              Text(
+                '${percent.round()}%',
+                style: theme.textTheme.labelLarge
+                    ?.copyWith(fontWeight: FontWeight.w800),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          label,
+          style: theme.textTheme.labelSmall?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: cs.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 1),
+        Text(
+          detail,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+        ),
+      ],
+    );
+  }
+}
+
+class _DiskBar extends StatelessWidget {
+  const _DiskBar({required this.disk});
+
+  final GlancesDisk disk;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final double fraction = (disk.percentage / 100).clamp(0, 1).toDouble();
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Expanded(
+                child: Text(
+                  disk.path,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+              const SizedBox(width: Insets.sm),
+              Text(
+                '${_fmtBytes(disk.total - disk.used)} free of ${_fmtBytes(disk.total)}',
+                style: theme.textTheme.labelSmall
+                    ?.copyWith(color: cs.onSurfaceVariant),
+              ),
+            ],
+          ),
+          const SizedBox(height: 4),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(4),
+            child: LinearProgressIndicator(
+              value: fraction,
+              minHeight: 5,
+              color: _loadColor(disk.percentage, cs),
+              backgroundColor: cs.surfaceContainerHighest,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/widgets/streams_widget.dart
+++ b/app/lib/src/dashboard/widgets/streams_widget.dart
@@ -1,0 +1,207 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:service_emby/service_emby.dart' as emby;
+import 'package:service_jellyfin/service_jellyfin.dart' as jf;
+import 'package:service_tautulli/service_tautulli.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+class _StreamRow {
+  const _StreamRow({
+    required this.user,
+    required this.title,
+    required this.progress,
+    required this.instance,
+  });
+
+  final String user;
+  final String title;
+  final double progress;
+  final Instance instance;
+}
+
+/// Active sessions across Tautulli, Jellyfin and Emby.
+class DashboardStreamsWidget extends ConsumerWidget {
+  const DashboardStreamsWidget({
+    required this.tautulliInstances,
+    required this.jellyfinInstances,
+    required this.embyInstances,
+    super.key,
+  });
+
+  final List<Instance> tautulliInstances;
+  final List<Instance> jellyfinInstances;
+  final List<Instance> embyInstances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final List<_StreamRow> rows = <_StreamRow>[];
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in tautulliInstances) {
+      final AsyncValue<TautulliActivity> activity =
+          ref.watch(tautulliActivityProvider(i));
+      anyLoading |= activity.isLoading && !activity.hasValue;
+      anyError |= activity.hasError;
+      for (final TautulliSession s
+          in activity.valueOrNull?.sessions ?? const <TautulliSession>[]) {
+        rows.add(_StreamRow(
+          user: s.friendlyName,
+          title: s.fullTitle,
+          progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
+          instance: i,
+        ));
+      }
+    }
+    for (final Instance i in jellyfinInstances) {
+      final AsyncValue<List<jf.ActiveSession>> sessions =
+          ref.watch(jf.jellyfinSessionsProvider(i));
+      anyLoading |= sessions.isLoading && !sessions.hasValue;
+      anyError |= sessions.hasError;
+      for (final jf.ActiveSession s
+          in sessions.valueOrNull ?? const <jf.ActiveSession>[]) {
+        rows.add(_StreamRow(
+          user: s.user,
+          title: s.episodeName == null
+              ? s.showTitle
+              : '${s.showTitle} - ${s.episodeName}',
+          progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
+          instance: i,
+        ));
+      }
+    }
+    for (final Instance i in embyInstances) {
+      final AsyncValue<List<emby.ActiveSession>> sessions =
+          ref.watch(emby.embySessionsProvider(i));
+      anyLoading |= sessions.isLoading && !sessions.hasValue;
+      anyError |= sessions.hasError;
+      for (final emby.ActiveSession s
+          in sessions.valueOrNull ?? const <emby.ActiveSession>[]) {
+        rows.add(_StreamRow(
+          user: s.user,
+          title: s.episodeName == null
+              ? s.showTitle
+              : '${s.showTitle} - ${s.episodeName}',
+          progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
+          instance: i,
+        ));
+      }
+    }
+
+    final List<_StreamRow> top = rows.take(3).toList();
+
+    Widget body;
+    if (rows.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (rows.isEmpty && anyError) {
+      body = DashboardErrorRow(onRetry: () => _refresh(ref));
+    } else if (rows.isEmpty) {
+      body = const DashboardIdleRow(text: 'No one is streaming');
+    } else {
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (final _StreamRow row in top) _SessionRow(row: row),
+          if (rows.length > top.length)
+            DashboardIdleRow(text: '+${rows.length - top.length} more'),
+        ],
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.streams,
+      accent: cs.tertiary,
+      trailing: rows.isNotEmpty
+          ? DashboardPill(
+              icon: Icons.play_arrow_rounded,
+              label: '${rows.length} streaming',
+              color: cs.tertiary,
+            )
+          : null,
+      child: body,
+    );
+  }
+
+  void _refresh(WidgetRef ref) {
+    for (final Instance i in tautulliInstances) {
+      ref.invalidate(tautulliActivityProvider(i));
+    }
+    for (final Instance i in jellyfinInstances) {
+      ref.invalidate(jf.jellyfinSessionsProvider(i));
+    }
+    for (final Instance i in embyInstances) {
+      ref.invalidate(emby.embySessionsProvider(i));
+    }
+  }
+}
+
+class _SessionRow extends StatelessWidget {
+  const _SessionRow({required this.row});
+
+  final _StreamRow row;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    return InkWell(
+      borderRadius: BorderRadius.circular(8),
+      onTap: () => context.go(
+        AtriumRoutes.servicePath(row.instance.kind.name, row.instance.id),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    '${row.user} - ${row.title}',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: theme.textTheme.bodyMedium,
+                  ),
+                ),
+                const SizedBox(width: Insets.sm),
+                Text(
+                  '${(row.progress * 100).toStringAsFixed(0)}%',
+                  style: theme.textTheme.labelSmall
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                ),
+              ],
+            ),
+            const SizedBox(height: 4),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(4),
+              child: LinearProgressIndicator(
+                value: row.progress,
+                minHeight: 5,
+                color: cs.tertiary,
+                backgroundColor: cs.surfaceContainerHighest,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/dashboard/widgets/streams_widget.dart
+++ b/app/lib/src/dashboard/widgets/streams_widget.dart
@@ -1,4 +1,6 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
+import 'package:core_profile/core_profile.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -11,21 +13,72 @@ import 'package:service_tautulli/service_tautulli.dart';
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
 
+/// Live count of active sessions across every Tautulli, Jellyfin and Emby
+/// instance. Instances still loading or in error contribute 0, so the
+/// dashboard only surfaces the streams widget while someone is actually
+/// watching.
+final activeStreamCountProvider = Provider.autoDispose<int>((Ref ref) {
+  final List<Instance> instances = ref.watch(activeInstancesProvider);
+  int count = 0;
+  for (final Instance i in instances) {
+    switch (i.kind) {
+      case ServiceKind.tautulli:
+        count +=
+            ref.watch(tautulliActivityProvider(i)).value?.sessions.length ?? 0;
+      case ServiceKind.jellyfin:
+        count += ref.watch(jf.jellyfinSessionsProvider(i)).value?.length ?? 0;
+      case ServiceKind.emby:
+        count += ref.watch(emby.embySessionsProvider(i)).value?.length ?? 0;
+      default:
+        break;
+    }
+  }
+  return count;
+});
+
 class _StreamRow {
   const _StreamRow({
     required this.user,
     required this.title,
     required this.progress,
+    required this.paused,
     required this.instance,
+    this.device = '',
+    this.posterUrl,
+    this.quality,
+    this.transcoding = false,
+    this.timeLabel,
   });
 
   final String user;
   final String title;
   final double progress;
+  final bool paused;
   final Instance instance;
+
+  /// Player / client the session is on (e.g. "Chrome", "Apple TV").
+  final String device;
+  final String? posterUrl;
+
+  /// Stream resolution (e.g. "1080p"), when the backend reports it.
+  final String? quality;
+
+  /// Whether the server is transcoding the stream (vs direct play).
+  final bool transcoding;
+
+  /// Elapsed / total time (e.g. "12:04 / 45:00"), when available.
+  final String? timeLabel;
 }
 
-/// Active sessions across Tautulli, Jellyfin and Emby.
+/// "elapsed / total", or null when either side is missing.
+String? _timeLabel(String position, String duration) {
+  if (position.isEmpty || duration.isEmpty) {
+    return null;
+  }
+  return '$position / $duration';
+}
+
+/// Active sessions across Tautulli, Jellyfin and Emby, each with its poster.
 class DashboardStreamsWidget extends ConsumerWidget {
   const DashboardStreamsWidget({
     required this.tautulliInstances,
@@ -51,12 +104,18 @@ class DashboardStreamsWidget extends ConsumerWidget {
           ref.watch(tautulliActivityProvider(i));
       anyLoading |= activity.isLoading && !activity.hasValue;
       anyError |= activity.hasError;
+      final TautulliApi? api = ref.watch(tautulliApiProvider(i)).value;
       for (final TautulliSession s
-          in activity.valueOrNull?.sessions ?? const <TautulliSession>[]) {
+          in activity.value?.sessions ?? const <TautulliSession>[]) {
         rows.add(_StreamRow(
           user: s.friendlyName,
           title: s.fullTitle,
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
+          paused: s.state.toLowerCase() == 'paused',
+          posterUrl: api?.imageUrl(s.posterThumb),
+          device: s.player,
+          quality: s.videoResolution.isEmpty ? null : s.videoResolution,
+          transcoding: s.transcodeDecision.toLowerCase() == 'transcode',
           instance: i,
         ));
       }
@@ -67,13 +126,17 @@ class DashboardStreamsWidget extends ConsumerWidget {
       anyLoading |= sessions.isLoading && !sessions.hasValue;
       anyError |= sessions.hasError;
       for (final jf.ActiveSession s
-          in sessions.valueOrNull ?? const <jf.ActiveSession>[]) {
+          in sessions.value ?? const <jf.ActiveSession>[]) {
         rows.add(_StreamRow(
           user: s.user,
           title: s.episodeName == null
               ? s.showTitle
               : '${s.showTitle} - ${s.episodeName}',
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
+          paused: s.status.toLowerCase() == 'paused',
+          posterUrl: s.posterUrl,
+          device: s.device,
+          timeLabel: _timeLabel(s.timePosition, s.timeDuration),
           instance: i,
         ));
       }
@@ -84,13 +147,17 @@ class DashboardStreamsWidget extends ConsumerWidget {
       anyLoading |= sessions.isLoading && !sessions.hasValue;
       anyError |= sessions.hasError;
       for (final emby.ActiveSession s
-          in sessions.valueOrNull ?? const <emby.ActiveSession>[]) {
+          in sessions.value ?? const <emby.ActiveSession>[]) {
         rows.add(_StreamRow(
           user: s.user,
           title: s.episodeName == null
               ? s.showTitle
               : '${s.showTitle} - ${s.episodeName}',
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
+          paused: s.status.toLowerCase() == 'paused',
+          posterUrl: s.posterUrl,
+          device: s.device,
+          timeLabel: _timeLabel(s.timePosition, s.timeDuration),
           instance: i,
         ));
       }
@@ -118,9 +185,15 @@ class DashboardStreamsWidget extends ConsumerWidget {
       body = Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          for (final _StreamRow row in top) _SessionRow(row: row),
+          for (int j = 0; j < top.length; j++) ...<Widget>[
+            if (j > 0) const SizedBox(height: Insets.sm),
+            _SessionRow(row: top[j]),
+          ],
           if (rows.length > top.length)
-            DashboardIdleRow(text: '+${rows.length - top.length} more'),
+            Padding(
+              padding: const EdgeInsets.only(top: Insets.sm),
+              child: DashboardIdleRow(text: '+${rows.length - top.length} more'),
+            ),
         ],
       );
     }
@@ -161,46 +234,154 @@ class _SessionRow extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
+    final String? poster = row.posterUrl;
     return InkWell(
-      borderRadius: BorderRadius.circular(8),
+      borderRadius: BorderRadius.circular(12),
       onTap: () => context.go(
         AtriumRoutes.servicePath(row.instance.kind.name, row.instance.id),
       ),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(vertical: Insets.xs),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Row(
+      child: Row(
+        children: <Widget>[
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: SizedBox(
+              width: 40,
+              height: 56,
+              child: (poster == null || poster.isEmpty)
+                  ? _posterFallback(cs)
+                  : CachedNetworkImage(
+                      imageUrl: poster,
+                      fit: BoxFit.cover,
+                      memCacheWidth: 120,
+                      errorWidget: (_, __, ___) => _posterFallback(cs),
+                    ),
+            ),
+          ),
+          const SizedBox(width: Insets.md),
+          Expanded(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                Expanded(
-                  child: Text(
-                    '${row.user} - ${row.title}',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: theme.textTheme.bodyMedium,
-                  ),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Text(
+                        row.title,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.titleSmall
+                            ?.copyWith(fontWeight: FontWeight.w700),
+                      ),
+                    ),
+                    if (row.quality != null) ...<Widget>[
+                      const SizedBox(width: Insets.sm),
+                      _QualityChip(
+                        label: row.quality!,
+                        transcoding: row.transcoding,
+                      ),
+                    ],
+                  ],
                 ),
-                const SizedBox(width: Insets.sm),
-                Text(
-                  '${(row.progress * 100).toStringAsFixed(0)}%',
-                  style: theme.textTheme.labelSmall
-                      ?.copyWith(color: cs.onSurfaceVariant),
+                const SizedBox(height: 2),
+                Row(
+                  children: <Widget>[
+                    Icon(
+                      row.paused
+                          ? Icons.pause_rounded
+                          : Icons.play_arrow_rounded,
+                      size: 14,
+                      color: cs.onSurfaceVariant,
+                    ),
+                    const SizedBox(width: 2),
+                    Expanded(
+                      child: Text(
+                        row.device.isEmpty
+                            ? row.user
+                            : '${row.user} · ${row.device}',
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: theme.textTheme.bodySmall
+                            ?.copyWith(color: cs.onSurfaceVariant),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 6),
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(4),
+                        child: LinearProgressIndicator(
+                          value: row.progress,
+                          minHeight: 5,
+                          color: cs.tertiary,
+                          backgroundColor: cs.surfaceContainerHighest,
+                        ),
+                      ),
+                    ),
+                    const SizedBox(width: Insets.sm),
+                    Text(
+                      row.timeLabel ??
+                          '${(row.progress * 100).toStringAsFixed(0)}%',
+                      style: theme.textTheme.labelSmall
+                          ?.copyWith(color: cs.onSurfaceVariant),
+                    ),
+                  ],
                 ),
               ],
             ),
-            const SizedBox(height: 4),
-            ClipRRect(
-              borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
-                value: row.progress,
-                minHeight: 5,
-                color: cs.tertiary,
-                backgroundColor: cs.surfaceContainerHighest,
-              ),
-            ),
-          ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _posterFallback(ColorScheme cs) => Container(
+        color: cs.surfaceContainerHighest,
+        alignment: Alignment.center,
+        child: Icon(
+          Icons.play_circle_outline,
+          size: 18,
+          color: cs.onSurfaceVariant,
         ),
+      );
+}
+
+/// Stream resolution chip; a transcode marker and warmer colour when the
+/// server is re-encoding, a calm tertiary tone for direct play.
+class _QualityChip extends StatelessWidget {
+  const _QualityChip({required this.label, required this.transcoding});
+
+  final String label;
+  final bool transcoding;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    final Color color = transcoding ? cs.secondary : cs.tertiary;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.14),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (transcoding) ...<Widget>[
+            Icon(Icons.autorenew_rounded, size: 11, color: color),
+            const SizedBox(width: 2),
+          ],
+          Text(
+            label,
+            style: Theme.of(context)
+                .textTheme
+                .labelSmall
+                ?.copyWith(fontWeight: FontWeight.w700, color: color),
+          ),
+        ],
       ),
     );
   }

--- a/app/lib/src/dashboard/widgets/upcoming_widget.dart
+++ b/app/lib/src/dashboard/widgets/upcoming_widget.dart
@@ -43,7 +43,7 @@ class DashboardUpcomingWidget extends ConsumerWidget {
           ref.watch(globalCalendarProvider(month));
       anyLoading |= value.isLoading && !value.hasValue;
       anyError |= value.hasError;
-      for (final CalendarEvent e in value.valueOrNull ?? const <CalendarEvent>[]) {
+      for (final CalendarEvent e in value.value ?? const <CalendarEvent>[]) {
         if (seen.add(e)) {
           events.add(e);
         }
@@ -89,18 +89,33 @@ class DashboardUpcomingWidget extends ConsumerWidget {
         final DateTime day = DateTime(d.year, d.month, d.day);
         if (lastDay == null || day != lastDay) {
           lastDay = day;
+          final bool isToday = day == windowStart;
           rows.add(Padding(
             padding: EdgeInsets.only(
-              top: rows.isEmpty ? 0 : Insets.md,
-              bottom: Insets.xs,
-              left: 2,
+              top: rows.isEmpty ? 2 : Insets.md,
+              bottom: Insets.sm,
             ),
-            child: Text(
-              _dayLabel(day, windowStart),
-              style: theme.textTheme.labelMedium?.copyWith(
-                fontWeight: FontWeight.w700,
-                color: day == windowStart ? cs.primary : cs.onSurfaceVariant,
-              ),
+            child: Row(
+              children: <Widget>[
+                Container(
+                  width: 8,
+                  height: 8,
+                  decoration: BoxDecoration(
+                    color: isToday ? cs.primary : cs.outline,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+                const SizedBox(width: Insets.sm),
+                Text(
+                  _dayLabel(day, windowStart),
+                  style: theme.textTheme.labelMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: isToday ? cs.primary : cs.onSurface,
+                  ),
+                ),
+                const SizedBox(width: Insets.md),
+                Expanded(child: Container(height: 1, color: cs.outlineVariant)),
+              ],
             ),
           ));
         } else {
@@ -147,8 +162,9 @@ class DashboardUpcomingWidget extends ConsumerWidget {
   }
 }
 
-/// One release as an artwork banner: fanart background with a scrim, poster
-/// thumb, title + episode line, and a downloaded/pending badge.
+/// One release as an artwork banner: fanart backdrop with a legibility scrim,
+/// poster thumb, title + meta line, and a trailing badge - a check for a
+/// grabbed release, an airtime chip for an episode still to air.
 class _ReleaseBanner extends StatelessWidget {
   const _ReleaseBanner({required this.event});
 
@@ -161,15 +177,24 @@ class _ReleaseBanner extends StatelessWidget {
     final String? backdrop = event.backdropUrl;
     final String? poster = event.posterUrl;
     final bool hasArt = backdrop != null;
-    final Color titleColor = hasArt ? Colors.white : cs.onSurface;
+    // Over a backdrop the scrim + text follow the theme: light mode gets a
+    // light scrim with dark text (not a heavy black band), dark mode keeps the
+    // classic dark scrim with white text. Either way the text stays legible.
+    final bool isLight = theme.brightness == Brightness.light;
+    final Color scrim = isLight ? Colors.white : Colors.black;
+    final Color onArt = isLight ? const Color(0xFF141414) : Colors.white;
+    final Color titleColor = hasArt ? onArt : cs.onSurface;
     final Color subColor =
-        hasArt ? Colors.white.withValues(alpha: 0.75) : cs.onSurfaceVariant;
-    final Color edge = event.hasFile ? cs.tertiary : cs.primary;
+        hasArt ? onArt.withValues(alpha: 0.78) : cs.onSurfaceVariant;
+    // Episodes carry a real airtime; movie release dates do not.
+    final String? airTime = event is SonarrCalendarEvent
+        ? DateFormat.jm().format(event.date.toLocal())
+        : null;
 
     return ClipRRect(
-      borderRadius: BorderRadius.circular(14),
+      borderRadius: BorderRadius.circular(16),
       child: SizedBox(
-        height: 72,
+        height: 78,
         child: Stack(
           fit: StackFit.expand,
           children: <Widget>[
@@ -178,7 +203,7 @@ class _ReleaseBanner extends StatelessWidget {
                 imageUrl: backdrop,
                 fit: BoxFit.cover,
                 memCacheWidth: 600,
-                errorWidget: (BuildContext context, String url, Object error) =>
+                errorWidget: (_, __, ___) =>
                     Container(color: cs.surfaceContainerHighest),
               )
             else
@@ -188,55 +213,30 @@ class _ReleaseBanner extends StatelessWidget {
                 decoration: BoxDecoration(
                   gradient: LinearGradient(
                     colors: <Color>[
-                      Colors.black.withValues(alpha: 0.78),
-                      Colors.black.withValues(alpha: 0.35),
+                      scrim.withValues(alpha: 0.88),
+                      scrim.withValues(alpha: 0.60),
+                      scrim.withValues(alpha: 0.20),
                     ],
+                    stops: const <double>[0.0, 0.55, 1.0],
                   ),
                 ),
               ),
-            Positioned(
-              left: 0,
-              top: 0,
-              bottom: 0,
-              child: Container(width: 4, color: edge),
-            ),
             Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: Insets.md,
-                vertical: Insets.sm,
-              ),
+              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
               child: Row(
                 children: <Widget>[
                   ClipRRect(
                     borderRadius: BorderRadius.circular(8),
                     child: SizedBox(
-                      width: 38,
-                      height: 56,
+                      width: 44,
+                      height: 66,
                       child: poster == null
-                          ? Container(
-                              color: cs.surfaceContainerHigh,
-                              alignment: Alignment.center,
-                              child: Icon(
-                                Icons.movie_outlined,
-                                size: 18,
-                                color: cs.onSurfaceVariant,
-                              ),
-                            )
+                          ? _posterFallback(cs)
                           : CachedNetworkImage(
                               imageUrl: poster,
                               fit: BoxFit.cover,
-                              memCacheWidth: 120,
-                              errorWidget: (BuildContext context, String url,
-                                      Object error) =>
-                                  Container(
-                                color: cs.surfaceContainerHigh,
-                                alignment: Alignment.center,
-                                child: Icon(
-                                  Icons.movie_outlined,
-                                  size: 18,
-                                  color: cs.onSurfaceVariant,
-                                ),
-                              ),
+                              memCacheWidth: 132,
+                              errorWidget: (_, __, ___) => _posterFallback(cs),
                             ),
                     ),
                   ),
@@ -255,7 +255,7 @@ class _ReleaseBanner extends StatelessWidget {
                             color: titleColor,
                           ),
                         ),
-                        const SizedBox(height: 2),
+                        const SizedBox(height: 3),
                         Text(
                           event.subtitle,
                           maxLines: 1,
@@ -266,24 +266,14 @@ class _ReleaseBanner extends StatelessWidget {
                       ],
                     ),
                   ),
-                  if (event.hasFile) ...<Widget>[
-                    const SizedBox(width: Insets.sm),
-                    Container(
-                      width: 34,
-                      height: 34,
-                      alignment: Alignment.center,
-                      decoration: BoxDecoration(
-                        color: (hasArt ? Colors.white : cs.onSurface)
-                            .withValues(alpha: 0.12),
-                        shape: BoxShape.circle,
-                      ),
-                      child: Icon(
-                        Icons.check_rounded,
-                        size: 18,
-                        color: cs.tertiary,
-                      ),
-                    ),
-                  ],
+                  const SizedBox(width: Insets.sm),
+                  _StatusBadge(
+                    hasArt: hasArt,
+                    hasFile: event.hasFile,
+                    airTime: airTime,
+                    onArt: onArt,
+                    scrim: scrim,
+                  ),
                 ],
               ),
             ),
@@ -291,5 +281,83 @@ class _ReleaseBanner extends StatelessWidget {
         ),
       ),
     );
+  }
+
+  Widget _posterFallback(ColorScheme cs) => Container(
+        color: cs.surfaceContainerHigh,
+        alignment: Alignment.center,
+        child: Icon(Icons.movie_outlined, size: 18, color: cs.onSurfaceVariant),
+      );
+}
+
+/// Trailing status on a release banner: a check for a grabbed release, an
+/// airtime chip for an episode still to air, nothing otherwise.
+class _StatusBadge extends StatelessWidget {
+  const _StatusBadge({
+    required this.hasArt,
+    required this.hasFile,
+    required this.airTime,
+    required this.onArt,
+    required this.scrim,
+  });
+
+  final bool hasArt;
+  final bool hasFile;
+  final String? airTime;
+
+  /// Legible foreground over the scrim for the current theme (white in dark
+  /// mode, near-black in light mode).
+  final Color onArt;
+
+  /// The scrim base tone (opposite of [onArt]): black in dark mode, white in
+  /// light mode. Used as the inverted, low-opacity airtime-box fill.
+  final Color scrim;
+
+  @override
+  Widget build(BuildContext context) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+    if (hasFile) {
+      // A frosted plate (theme-aware) so the green check reads on the weak
+      // right side of the scrim in either mode.
+      final Color plate = hasArt ? onArt : cs.tertiary;
+      return Container(
+        width: 30,
+        height: 30,
+        alignment: Alignment.center,
+        decoration: BoxDecoration(
+          color: plate.withValues(alpha: hasArt ? 0.22 : 0.16),
+          shape: BoxShape.circle,
+        ),
+        child: Icon(Icons.check_rounded, size: 18, color: cs.tertiary),
+      );
+    }
+    if (airTime != null) {
+      // Inverted, low-opacity plate: the box takes the scrim tone (opposite of
+      // the text) at a light alpha, keeping the on-art tone for icon + label.
+      final Color fg = hasArt ? onArt : cs.onSurfaceVariant;
+      final Color box = hasArt ? scrim : cs.surface;
+      return Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          color: box.withValues(alpha: hasArt ? 0.14 : 0.55),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            Icon(Icons.schedule_rounded, size: 12, color: fg),
+            const SizedBox(width: 3),
+            Text(
+              airTime!,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    color: fg,
+                  ),
+            ),
+          ],
+        ),
+      );
+    }
+    return const SizedBox.shrink();
   }
 }

--- a/app/lib/src/dashboard/widgets/upcoming_widget.dart
+++ b/app/lib/src/dashboard/widgets/upcoming_widget.dart
@@ -1,0 +1,295 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+
+import '../../screens/calendar_screen.dart';
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+/// First-of-month keys for every month the [now, now+7d] window touches.
+List<DateTime> upcomingWindowMonths(DateTime now) {
+  final DateTime start = DateTime(now.year, now.month, 1);
+  final DateTime end =
+      DateTime(now.year, now.month, now.day).add(const Duration(days: 8));
+  final DateTime endMonth = DateTime(end.year, end.month, 1);
+  return <DateTime>[start, if (endMonth != start) endMonth];
+}
+
+/// The next 7 days of Sonarr/Radarr releases as day-grouped artwork banners:
+/// poster thumb, backdrop background, and a downloaded/pending status icon.
+class DashboardUpcomingWidget extends ConsumerWidget {
+  const DashboardUpcomingWidget({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    final DateTime now = DateTime.now();
+    final DateTime windowStart = DateTime(now.year, now.month, now.day);
+    final DateTime windowEnd = windowStart.add(const Duration(days: 8));
+    final List<DateTime> months = upcomingWindowMonths(now);
+
+    final List<CalendarEvent> events = <CalendarEvent>[];
+    final Set<CalendarEvent> seen = <CalendarEvent>{};
+    bool anyLoading = false;
+    bool anyError = false;
+    for (final DateTime month in months) {
+      final AsyncValue<List<CalendarEvent>> value =
+          ref.watch(globalCalendarProvider(month));
+      anyLoading |= value.isLoading && !value.hasValue;
+      anyError |= value.hasError;
+      for (final CalendarEvent e in value.valueOrNull ?? const <CalendarEvent>[]) {
+        if (seen.add(e)) {
+          events.add(e);
+        }
+      }
+    }
+
+    final List<CalendarEvent> upcoming = events
+        .where((CalendarEvent e) {
+          final DateTime d = e.date.toLocal();
+          return !d.isBefore(windowStart) && d.isBefore(windowEnd);
+        })
+        .toList()
+      ..sort((CalendarEvent a, CalendarEvent b) => a.date.compareTo(b.date));
+    final List<CalendarEvent> top = upcoming.take(5).toList();
+
+    Widget body;
+    if (upcoming.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (upcoming.isEmpty && anyError) {
+      body = DashboardErrorRow(
+        onRetry: () {
+          for (final DateTime m in months) {
+            ref.invalidate(globalCalendarProvider(m));
+          }
+        },
+      );
+    } else if (upcoming.isEmpty) {
+      body = const DashboardIdleRow(text: 'Nothing airing in the next 7 days');
+    } else {
+      final List<Widget> rows = <Widget>[];
+      DateTime? lastDay;
+      for (final CalendarEvent e in top) {
+        final DateTime d = e.date.toLocal();
+        final DateTime day = DateTime(d.year, d.month, d.day);
+        if (lastDay == null || day != lastDay) {
+          lastDay = day;
+          rows.add(Padding(
+            padding: EdgeInsets.only(
+              top: rows.isEmpty ? 0 : Insets.md,
+              bottom: Insets.xs,
+              left: 2,
+            ),
+            child: Text(
+              _dayLabel(day, windowStart),
+              style: theme.textTheme.labelMedium?.copyWith(
+                fontWeight: FontWeight.w700,
+                color: day == windowStart ? cs.primary : cs.onSurfaceVariant,
+              ),
+            ),
+          ));
+        } else {
+          rows.add(const SizedBox(height: Insets.sm));
+        }
+        rows.add(_ReleaseBanner(event: e));
+      }
+      if (upcoming.length > top.length) {
+        rows.add(Padding(
+          padding: const EdgeInsets.only(top: Insets.sm),
+          child: DashboardIdleRow(text: '+${upcoming.length - top.length} more'),
+        ));
+      }
+      body = Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: rows,
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.upcoming,
+      accent: cs.secondary,
+      onTap: () => context.goNamed(AtriumRoutes.calendarName),
+      trailing: upcoming.isNotEmpty
+          ? DashboardPill(
+              icon: Icons.calendar_today_outlined,
+              label:
+                  '${upcoming.length} release${upcoming.length == 1 ? '' : 's'}',
+              color: cs.primary,
+            )
+          : null,
+      child: body,
+    );
+  }
+
+  static String _dayLabel(DateTime day, DateTime today) {
+    if (day == today) {
+      return 'Today';
+    }
+    if (day == today.add(const Duration(days: 1))) {
+      return 'Tomorrow';
+    }
+    return DateFormat('EEE, MMM d').format(day);
+  }
+}
+
+/// One release as an artwork banner: fanart background with a scrim, poster
+/// thumb, title + episode line, and a downloaded/pending badge.
+class _ReleaseBanner extends StatelessWidget {
+  const _ReleaseBanner({required this.event});
+
+  final CalendarEvent event;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final String? backdrop = event.backdropUrl;
+    final String? poster = event.posterUrl;
+    final bool hasArt = backdrop != null;
+    final Color titleColor = hasArt ? Colors.white : cs.onSurface;
+    final Color subColor =
+        hasArt ? Colors.white.withValues(alpha: 0.75) : cs.onSurfaceVariant;
+    final Color edge = event.hasFile ? cs.tertiary : cs.primary;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(14),
+      child: SizedBox(
+        height: 72,
+        child: Stack(
+          fit: StackFit.expand,
+          children: <Widget>[
+            if (hasArt)
+              CachedNetworkImage(
+                imageUrl: backdrop,
+                fit: BoxFit.cover,
+                memCacheWidth: 600,
+                errorWidget: (BuildContext context, String url, Object error) =>
+                    Container(color: cs.surfaceContainerHighest),
+              )
+            else
+              Container(color: cs.surfaceContainerHighest),
+            if (hasArt)
+              DecoratedBox(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: <Color>[
+                      Colors.black.withValues(alpha: 0.78),
+                      Colors.black.withValues(alpha: 0.35),
+                    ],
+                  ),
+                ),
+              ),
+            Positioned(
+              left: 0,
+              top: 0,
+              bottom: 0,
+              child: Container(width: 4, color: edge),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(
+                horizontal: Insets.md,
+                vertical: Insets.sm,
+              ),
+              child: Row(
+                children: <Widget>[
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(8),
+                    child: SizedBox(
+                      width: 38,
+                      height: 56,
+                      child: poster == null
+                          ? Container(
+                              color: cs.surfaceContainerHigh,
+                              alignment: Alignment.center,
+                              child: Icon(
+                                Icons.movie_outlined,
+                                size: 18,
+                                color: cs.onSurfaceVariant,
+                              ),
+                            )
+                          : CachedNetworkImage(
+                              imageUrl: poster,
+                              fit: BoxFit.cover,
+                              memCacheWidth: 120,
+                              errorWidget: (BuildContext context, String url,
+                                      Object error) =>
+                                  Container(
+                                color: cs.surfaceContainerHigh,
+                                alignment: Alignment.center,
+                                child: Icon(
+                                  Icons.movie_outlined,
+                                  size: 18,
+                                  color: cs.onSurfaceVariant,
+                                ),
+                              ),
+                            ),
+                    ),
+                  ),
+                  const SizedBox(width: Insets.md),
+                  Expanded(
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          event.primaryTitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.titleSmall?.copyWith(
+                            fontWeight: FontWeight.w700,
+                            color: titleColor,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          event.subtitle,
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
+                          style: theme.textTheme.bodySmall
+                              ?.copyWith(color: subColor),
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (event.hasFile) ...<Widget>[
+                    const SizedBox(width: Insets.sm),
+                    Container(
+                      width: 34,
+                      height: 34,
+                      alignment: Alignment.center,
+                      decoration: BoxDecoration(
+                        color: (hasArt ? Colors.white : cs.onSurface)
+                            .withValues(alpha: 0.12),
+                        shape: BoxShape.circle,
+                      ),
+                      child: Icon(
+                        Icons.check_rounded,
+                        size: 18,
+                        color: cs.tertiary,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -18,6 +18,17 @@ sealed class CalendarEvent {
   DateTime get date;
   bool get hasFile;
   bool get monitored;
+
+  /// Series/movie name, for artwork-rich rows (the dashboard upcoming widget).
+  String get primaryTitle;
+
+  /// Episode code + name (or year marker), for artwork-rich rows.
+  String get subtitle;
+
+  /// Public artwork URLs (TMDB/fanart CDN remote urls), when the API included
+  /// them; null renders a plain fallback.
+  String? get posterUrl;
+  String? get backdropUrl;
 }
 
 class RadarrCalendarEvent extends CalendarEvent {
@@ -58,6 +69,23 @@ class RadarrCalendarEvent extends CalendarEvent {
   @override
   bool get monitored => movie.monitored;
 
+  @override
+  String get primaryTitle => movie.title;
+
+  @override
+  String get subtitle =>
+      movie.year == null ? 'Movie' : '${movie.year} - Movie';
+
+  @override
+  String? get posterUrl => _image('poster');
+
+  @override
+  String? get backdropUrl => _image('fanart');
+
+  String? _image(String type) => movie.images
+      .firstWhereOrNull((RadarrImage i) => i.coverType == type)
+      ?.remoteUrl;
+
   static DateTime? _parseDate(String? s) {
     if (s == null || s.isEmpty) return null;
     return DateTime.tryParse(s)?.toLocal();
@@ -86,6 +114,26 @@ class SonarrCalendarEvent extends CalendarEvent {
 
   @override
   bool get monitored => episode.monitored;
+
+  @override
+  String get primaryTitle => episode.series?.title ?? 'Unknown Series';
+
+  @override
+  String get subtitle {
+    final String s = episode.seasonNumber.toString().padLeft(2, '0');
+    final String e = episode.episodeNumber.toString().padLeft(2, '0');
+    return episode.title.isEmpty ? 'S${s}E$e' : 'S${s}E$e - ${episode.title}';
+  }
+
+  @override
+  String? get posterUrl => _image('poster');
+
+  @override
+  String? get backdropUrl => _image('fanart');
+
+  String? _image(String type) => episode.series?.images
+      .firstWhereOrNull((SonarrImage i) => i.coverType == type)
+      ?.remoteUrl;
 }
 
 

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -7,11 +7,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
+import '../dashboard/dashboard_board.dart';
 import '../health_providers.dart';
 
 /// Home screen. Services live in the navigation drawer (the sidebar); the
-/// dashboard body is reserved for at-a-glance widgets (in progress on a
-/// feature branch). Until a service exists, the body onboards the user.
+/// dashboard body is the at-a-glance widget board. Until a service exists,
+/// the body onboards the user to add their first one.
 class DashboardScreen extends ConsumerWidget {
   const DashboardScreen({super.key});
 
@@ -33,6 +34,21 @@ class DashboardScreen extends ConsumerWidget {
           },
         ),
         title: Text(profile == null ? 'Atrium' : profile.name),
+        actions: <Widget>[
+          if (instances.isNotEmpty)
+            Consumer(
+              builder: (BuildContext context, WidgetRef ref, Widget? _) {
+                final bool editing = ref.watch(dashboardEditModeProvider);
+                return IconButton(
+                  tooltip: editing ? 'Done' : 'Customize dashboard',
+                  icon: Icon(editing ? Icons.check : Icons.tune),
+                  onPressed: () => ref
+                      .read(dashboardEditModeProvider.notifier)
+                      .update((bool v) => !v),
+                );
+              },
+            ),
+        ],
       ),
       body: instances.isEmpty
           ? EmptyView(
@@ -47,23 +63,7 @@ class DashboardScreen extends ConsumerWidget {
                 label: const Text('Add service'),
               ),
             )
-          : const _DashboardWidgets(),
-    );
-  }
-}
-
-/// Placeholder for the widget board (being built on a feature branch).
-class _DashboardWidgets extends StatelessWidget {
-  const _DashboardWidgets();
-
-  @override
-  Widget build(BuildContext context) {
-    return const EmptyView(
-      icon: Icons.dashboard_customize_outlined,
-      title: 'Dashboard widgets coming soon',
-      message:
-          'At-a-glance widgets will live here. Open the menu (top left) to jump '
-          'to a service.',
+          : const DashboardBoard(),
     );
   }
 }

--- a/app/lib/src/screens/instance_form_screen.dart
+++ b/app/lib/src/screens/instance_form_screen.dart
@@ -28,6 +28,10 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
   final TextEditingController _apiKey = TextEditingController();
   final TextEditingController _username = TextEditingController();
   final TextEditingController _password = TextEditingController();
+
+  /// qBittorrent 5.2+ supports both username/password and API-key auth; this
+  /// tracks which the user picked (qBit only).
+  bool _qbitUseApiKey = false;
   final TextEditingController _pollingInterval = TextEditingController(text: '5');
 
   ServiceKind _kind = ServiceKind.sonarr;
@@ -73,6 +77,9 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
         _username.text = username;
         _password.text = password;
     }
+    // A qBittorrent instance saved with key auth reopens on the API-key tab.
+    _qbitUseApiKey = instance.kind == ServiceKind.qbittorrent &&
+        instance.auth is InstanceAuthApiKey;
   }
 
   InstanceAuth _buildAuth() {
@@ -84,10 +91,13 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
           username: _username.text.trim(),
           password: _password.text,
         ),
-      AuthStyle.cookieLogin => InstanceAuth.cookieLogin(
-          username: _username.text.trim(),
-          password: _password.text,
-        ),
+      AuthStyle.cookieLogin =>
+        (_kind == ServiceKind.qbittorrent && _qbitUseApiKey)
+            ? InstanceAuth.apiKey(apiKey: _apiKey.text.trim())
+            : InstanceAuth.cookieLogin(
+                username: _username.text.trim(),
+                password: _password.text,
+              ),
       AuthStyle.none => const InstanceAuth.apiKey(apiKey: ''),
     };
   }
@@ -329,7 +339,7 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
         // empty submission guarantees a failed login.
         final bool passwordOptional =
             _kind == ServiceKind.emby || _kind == ServiceKind.jellyfin;
-        return <Widget>[
+        final List<Widget> userPass = <Widget>[
           TextFormField(
             controller: _username,
             decoration: const InputDecoration(
@@ -354,6 +364,46 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
                 : (String? v) =>
                     (v == null || v.trim().isEmpty) ? 'Required' : null,
           ),
+        ];
+        if (_kind != ServiceKind.qbittorrent) {
+          return userPass;
+        }
+        // qBittorrent 5.2+ accepts either username/password or a stateless
+        // API key, so offer both.
+        return <Widget>[
+          SegmentedButton<bool>(
+            segments: const <ButtonSegment<bool>>[
+              ButtonSegment<bool>(
+                value: false,
+                label: Text('Password'),
+                icon: Icon(Icons.password),
+              ),
+              ButtonSegment<bool>(
+                value: true,
+                label: Text('API key'),
+                icon: Icon(Icons.key),
+              ),
+            ],
+            selected: <bool>{_qbitUseApiKey},
+            onSelectionChanged: (Set<bool> s) =>
+                setState(() => _qbitUseApiKey = s.first),
+          ),
+          const SizedBox(height: Insets.md),
+          if (_qbitUseApiKey)
+            TextFormField(
+              controller: _apiKey,
+              decoration: const InputDecoration(
+                border: OutlineInputBorder(),
+                labelText: 'API key',
+                helperText: 'qBittorrent 5.2+ Web UI setting; '
+                    'sent as Authorization: Bearer',
+              ),
+              autocorrect: false,
+              validator: (String? v) =>
+                  (v == null || v.trim().isEmpty) ? 'Required' : null,
+            )
+          else
+            ...userPass,
         ];
       case AuthStyle.none:
         return const <Widget>[];

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -30,6 +30,10 @@ dependencies:
   flutter_riverpod: ^3.3.2
   go_router: ^17.3.0
   hive_ce: ^2.10.1
+  # M3 Expressive determinate circular/linear gauges (progress_indicator_m3e
+  # is path-overridden to packages/progress_indicator_m3e_fixed at the root).
+  m3e_design: 0.2.1
+  progress_indicator_m3e: ^0.1.1
   service_bazarr:
   service_emby:
   service_jellyfin:

--- a/app/test/dashboard_layout_test.dart
+++ b/app/test/dashboard_layout_test.dart
@@ -68,7 +68,10 @@ void main() {
     test('build returns defaults; setEnabled flips one kind', () {
       final ProviderContainer container = ProviderContainer();
       addTearDown(container.dispose);
-      expect(container.read(dashboardLayoutProvider), hasLength(6));
+      expect(
+        container.read(dashboardLayoutProvider),
+        hasLength(DashboardWidgetKind.values.length),
+      );
       container
           .read(dashboardLayoutProvider.notifier)
           .setEnabled(DashboardWidgetKind.requests, false);
@@ -85,8 +88,9 @@ void main() {
           container.read(dashboardLayoutProvider.notifier);
       // Hide one widget so enabled != full list.
       controller.setEnabled(DashboardWidgetKind.streams, false);
-      // Enabled order is now: downloads, upcoming, health, requests, diskSpace.
-      controller.moveEnabled(0, 3); // drag downloads below health
+      // Enabled order is now: downloads, upcoming, recentlyAdded, health,
+      // requests, serverInfo, diskSpace.
+      controller.moveEnabled(0, 3); // drag downloads down two slots
       final List<DashboardWidgetKind> enabled = container
           .read(dashboardLayoutProvider)
           .where((DashboardWidgetConfig c) => c.enabled)
@@ -94,9 +98,11 @@ void main() {
           .toList();
       expect(enabled, <DashboardWidgetKind>[
         DashboardWidgetKind.upcoming,
-        DashboardWidgetKind.health,
+        DashboardWidgetKind.recentlyAdded,
         DashboardWidgetKind.downloads,
+        DashboardWidgetKind.health,
         DashboardWidgetKind.requests,
+        DashboardWidgetKind.serverInfo,
         DashboardWidgetKind.diskSpace,
       ]);
       // The disabled widget is still present, at the end.

--- a/app/test/dashboard_layout_test.dart
+++ b/app/test/dashboard_layout_test.dart
@@ -1,0 +1,108 @@
+import 'package:atrium/src/dashboard/dashboard_layout.dart';
+import 'package:atrium/src/dashboard/dashboard_widget_kind.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('decodeLayout', () {
+    test('null / empty / corrupt input decodes to empty list', () {
+      expect(decodeLayout(null), isEmpty);
+      expect(decodeLayout(''), isEmpty);
+      expect(decodeLayout('not json'), isEmpty);
+      expect(decodeLayout('{"kind":"downloads"}'), isEmpty); // not a list
+    });
+
+    test('unknown kinds are dropped, enabled defaults to true', () {
+      final List<DashboardWidgetConfig> out = decodeLayout(
+        '[{"kind":"streams","enabled":false},'
+        '{"kind":"someFutureWidget","enabled":true},'
+        '{"kind":"downloads"}]',
+      );
+      expect(out, hasLength(2));
+      expect(out[0].kind, DashboardWidgetKind.streams);
+      expect(out[0].enabled, isFalse);
+      expect(out[1].kind, DashboardWidgetKind.downloads);
+      expect(out[1].enabled, isTrue);
+    });
+  });
+
+  group('mergeLayout', () {
+    test('keeps stored order, appends missing kinds enabled, drops dupes', () {
+      final List<DashboardWidgetConfig> merged = mergeLayout(<DashboardWidgetConfig>[
+        const DashboardWidgetConfig(kind: DashboardWidgetKind.health, enabled: false),
+        const DashboardWidgetConfig(kind: DashboardWidgetKind.downloads, enabled: true),
+        const DashboardWidgetConfig(kind: DashboardWidgetKind.health, enabled: true), // dupe
+      ]);
+      expect(merged, hasLength(DashboardWidgetKind.values.length));
+      expect(merged[0].kind, DashboardWidgetKind.health);
+      expect(merged[0].enabled, isFalse); // first occurrence wins
+      expect(merged[1].kind, DashboardWidgetKind.downloads);
+      // The remaining kinds follow in enum order, enabled.
+      expect(merged[2].kind, DashboardWidgetKind.streams);
+      expect(merged.skip(2).every((DashboardWidgetConfig c) => c.enabled), isTrue);
+    });
+
+    test('empty stored input yields the default layout', () {
+      final List<DashboardWidgetConfig> merged = mergeLayout(const <DashboardWidgetConfig>[]);
+      expect(
+        merged.map((DashboardWidgetConfig c) => c.kind).toList(),
+        DashboardWidgetKind.values,
+      );
+      expect(merged.every((DashboardWidgetConfig c) => c.enabled), isTrue);
+    });
+  });
+
+  test('encodeLayout round-trips through decodeLayout', () {
+    final List<DashboardWidgetConfig> layout = <DashboardWidgetConfig>[
+      const DashboardWidgetConfig(kind: DashboardWidgetKind.diskSpace, enabled: false),
+      const DashboardWidgetConfig(kind: DashboardWidgetKind.upcoming, enabled: true),
+    ];
+    final List<DashboardWidgetConfig> back = decodeLayout(encodeLayout(layout));
+    expect(back, hasLength(2));
+    expect(back[0].kind, DashboardWidgetKind.diskSpace);
+    expect(back[0].enabled, isFalse);
+    expect(back[1].kind, DashboardWidgetKind.upcoming);
+  });
+
+  group('DashboardLayoutController (no Hive booted - in-memory)', () {
+    test('build returns defaults; setEnabled flips one kind', () {
+      final ProviderContainer container = ProviderContainer();
+      addTearDown(container.dispose);
+      expect(container.read(dashboardLayoutProvider), hasLength(6));
+      container
+          .read(dashboardLayoutProvider.notifier)
+          .setEnabled(DashboardWidgetKind.requests, false);
+      final DashboardWidgetConfig requests = container
+          .read(dashboardLayoutProvider)
+          .firstWhere((DashboardWidgetConfig c) => c.kind == DashboardWidgetKind.requests);
+      expect(requests.enabled, isFalse);
+    });
+
+    test('moveEnabled reorders within the enabled subset', () {
+      final ProviderContainer container = ProviderContainer();
+      addTearDown(container.dispose);
+      final DashboardLayoutController controller =
+          container.read(dashboardLayoutProvider.notifier);
+      // Hide one widget so enabled != full list.
+      controller.setEnabled(DashboardWidgetKind.streams, false);
+      // Enabled order is now: downloads, upcoming, health, requests, diskSpace.
+      controller.moveEnabled(0, 3); // drag downloads below health
+      final List<DashboardWidgetKind> enabled = container
+          .read(dashboardLayoutProvider)
+          .where((DashboardWidgetConfig c) => c.enabled)
+          .map((DashboardWidgetConfig c) => c.kind)
+          .toList();
+      expect(enabled, <DashboardWidgetKind>[
+        DashboardWidgetKind.upcoming,
+        DashboardWidgetKind.health,
+        DashboardWidgetKind.downloads,
+        DashboardWidgetKind.requests,
+        DashboardWidgetKind.diskSpace,
+      ]);
+      // The disabled widget is still present, at the end.
+      final List<DashboardWidgetConfig> all = container.read(dashboardLayoutProvider);
+      expect(all.last.kind, DashboardWidgetKind.streams);
+      expect(all.last.enabled, isFalse);
+    });
+  });
+}

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -1,0 +1,353 @@
+import 'package:atrium/src/dashboard/dashboard_board.dart';
+import 'package:atrium/src/dashboard/dashboard_widget_card.dart';
+import 'package:atrium/src/dashboard/dashboard_widget_kind.dart';
+import 'package:atrium/src/dashboard/widgets/disk_widget.dart';
+import 'package:atrium/src/dashboard/widgets/downloads_widget.dart';
+import 'package:atrium/src/dashboard/widgets/health_widget.dart';
+import 'package:atrium/src/dashboard/widgets/requests_widget.dart';
+import 'package:atrium/src/dashboard/widgets/streams_widget.dart';
+import 'package:atrium/src/dashboard/widgets/upcoming_widget.dart';
+import 'package:atrium/src/health_providers.dart';
+import 'package:atrium/src/screens/calendar_screen.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_jellyfin/service_jellyfin.dart' as jf;
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+import 'package:service_seerr/service_seerr.dart';
+import 'package:service_sabnzbd/service_sabnzbd.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+import 'package:service_tautulli/service_tautulli.dart';
+
+/// Render tests for the dashboard widget board: each widget pumped with its
+/// leaf providers overridden to fixed data, mirroring
+/// new_services_render_test.dart's approach.
+Instance makeInstance(ServiceKind kind) => Instance(
+      id: 'test-${kind.name}',
+      name: 'Test ${kind.displayName}',
+      kind: kind,
+      localUrl: 'http://localhost',
+      externalUrl: '',
+      urlMode: UrlMode.auto,
+      auth: const InstanceAuth.apiKey(apiKey: 'k'),
+    );
+
+Future<void> pumpBody(
+  WidgetTester tester,
+  List<Override> overrides,
+  Widget body, {
+  int pumps = 2,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+        theme: AtriumTheme.light(null),
+        home: Scaffold(body: body),
+      ),
+    ),
+  );
+  for (int i = 0; i < pumps; i++) {
+    await tester.pump();
+  }
+}
+
+void main() {
+  testWidgets('DashboardWidgetCard renders header, trailing and child',
+      (WidgetTester tester) async {
+    await pumpBody(
+      tester,
+      const <Override>[],
+      Builder(
+        builder: (BuildContext context) => DashboardWidgetCard(
+          kind: DashboardWidgetKind.downloads,
+          accent: Theme.of(context).colorScheme.primary,
+          trailing: const Text('9 active'),
+          child: const Text('card body'),
+        ),
+      ),
+    );
+    expect(find.text('Active downloads'), findsOneWidget);
+    expect(find.text('9 active'), findsOneWidget);
+    expect(find.text('card body'), findsOneWidget);
+    expect(find.byIcon(Icons.download_rounded), findsOneWidget);
+  });
+
+  testWidgets('DashboardDownloadsWidget shows combined qBit + SAB items',
+      (WidgetTester tester) async {
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+    final Instance sab = makeInstance(ServiceKind.sabnzbd);
+    await pumpBody(
+      tester,
+      <Override>[
+        qbitRawTorrentsProvider(qbit).overrideWith(
+          (Ref ref) async => const <QbitTorrent>[
+            QbitTorrent(
+              hash: 'h1',
+              name: 'Ubuntu ISO',
+              state: 'downloading',
+              progress: 0.45,
+              dlspeed: 1048576,
+            ),
+          ],
+        ),
+        qbitTransferProvider(qbit).overrideWith(
+          (Ref ref) async => const QbitTransferInfo(dlSpeed: 1048576),
+        ),
+        sabQueueProvider(sab).overrideWith(
+          (Ref ref) async => const SabQueue(
+            status: 'Downloading',
+            speed: '2.0 M',
+            slots: <SabSlot>[
+              SabSlot(
+                nzoId: 'n1',
+                filename: 'Show.S01E01.mkv',
+                percentage: '80',
+                status: 'Downloading',
+              ),
+            ],
+          ),
+        ),
+      ],
+      DashboardDownloadsWidget(
+        qbitInstances: <Instance>[qbit],
+        sabInstances: <Instance>[sab],
+      ),
+    );
+    expect(find.text('Ubuntu ISO'), findsOneWidget);
+    expect(find.text('Show.S01E01.mkv'), findsOneWidget);
+    expect(find.text('Active downloads'), findsOneWidget);
+  });
+
+  test('parseSabSpeed handles K/M/G suffixes and bare bytes', () {
+    expect(parseSabSpeed('2.0 M'), 2 * 1024 * 1024);
+    expect(parseSabSpeed('512 K'), 512 * 1024);
+    expect(parseSabSpeed('100'), 100);
+    expect(parseSabSpeed(''), 0);
+    expect(parseSabSpeed('junk'), 0);
+  });
+
+  testWidgets('DashboardStreamsWidget shows Tautulli and Jellyfin sessions',
+      (WidgetTester tester) async {
+    final Instance tau = makeInstance(ServiceKind.tautulli);
+    final Instance jelly = makeInstance(ServiceKind.jellyfin);
+    await pumpBody(
+      tester,
+      <Override>[
+        tautulliActivityProvider(tau).overrideWith(
+          (Ref ref) async => const TautulliActivity(
+            streamCount: 1,
+            sessions: <TautulliSession>[
+              TautulliSession(
+                friendlyName: 'Alice',
+                fullTitle: 'The Matrix',
+                progressPercent: 30,
+                state: 'playing',
+              ),
+            ],
+          ),
+        ),
+        jf.jellyfinSessionsProvider(jelly).overrideWith(
+          (Ref ref) => Stream<List<jf.ActiveSession>>.value(<jf.ActiveSession>[
+            const jf.ActiveSession(
+              id: 's1',
+              user: 'Bob',
+              device: 'Web',
+              status: 'Playing',
+              showTitle: 'Breaking Bad',
+              episodeName: 'Pilot',
+              progressPercent: 55,
+              timePosition: '0:10:00',
+              timeDuration: '0:45:00',
+              positionTicks: 0,
+              durationTicks: 0,
+            ),
+          ]),
+        ),
+      ],
+      DashboardStreamsWidget(
+        tautulliInstances: <Instance>[tau],
+        jellyfinInstances: <Instance>[jelly],
+        embyInstances: const <Instance>[],
+      ),
+    );
+    expect(find.text('Now streaming'), findsOneWidget);
+    expect(find.textContaining('The Matrix'), findsOneWidget);
+    expect(find.textContaining('Breaking Bad'), findsOneWidget);
+  });
+
+  testWidgets('DashboardUpcomingWidget lists events inside the 7-day window',
+      (WidgetTester tester) async {
+    final Instance sonarr = makeInstance(ServiceKind.sonarr);
+    final DateTime tomorrow = DateTime.now().add(const Duration(days: 1));
+    final List<CalendarEvent> events = <CalendarEvent>[
+      SonarrCalendarEvent(
+        SonarrCalendarEntry(
+          id: 1,
+          seriesId: 10,
+          title: 'Pilot',
+          seasonNumber: 1,
+          episodeNumber: 1,
+          airDateUtc: tomorrow.toUtc(),
+          hasFile: false,
+          monitored: true,
+          series: const SonarrSeries(id: 10, title: 'Test Show'),
+        ),
+        sonarr,
+      ),
+    ];
+    await pumpBody(
+      tester,
+      <Override>[
+        for (final DateTime m in upcomingWindowMonths(DateTime.now()))
+          globalCalendarProvider(m).overrideWith((Ref ref) async => events),
+      ],
+      const DashboardUpcomingWidget(),
+    );
+    expect(find.text('Upcoming releases'), findsOneWidget);
+    expect(find.textContaining('Test Show'), findsOneWidget);
+  });
+
+  testWidgets('DashboardHealthWidget shows per-instance chips and counts',
+      (WidgetTester tester) async {
+    final Instance ok = makeInstance(ServiceKind.sonarr);
+    final Instance down = makeInstance(ServiceKind.radarr);
+    await pumpBody(
+      tester,
+      <Override>[
+        instanceHealthProvider(ok).overrideWith((Ref ref) async => Health.ok),
+        instanceHealthProvider(down)
+            .overrideWith((Ref ref) async => Health.error),
+      ],
+      DashboardHealthWidget(instances: <Instance>[ok, down]),
+    );
+    expect(find.text('Service health'), findsOneWidget);
+    expect(find.text('Test Sonarr'), findsOneWidget);
+    expect(find.text('Test Radarr'), findsOneWidget);
+    expect(find.text('1 issue'), findsOneWidget);
+  });
+
+  testWidgets('DashboardRequestsWidget shows pending count and newest title',
+      (WidgetTester tester) async {
+    final Instance seerr = makeInstance(ServiceKind.seerr);
+    await pumpBody(
+      tester,
+      <Override>[
+        seerrRequestCountsProvider(seerr).overrideWith(
+          (Ref ref) async => const SeerrCounts(total: 3, pending: 2),
+        ),
+        seerrRequestsProvider(seerr).overrideWith(
+          (Ref ref) async => const <SeerrRequest>[
+            SeerrRequest(
+              id: 1,
+              status: 1,
+              type: 'movie',
+              media: SeerrMedia(mediaType: 'movie', tmdbId: 603),
+              requestedBy: SeerrUser(displayName: 'Bob'),
+              createdAt: '2026-07-01T00:00:00Z',
+            ),
+          ],
+        ),
+        seerrMediaDetailsProvider(
+          (instance: seerr, mediaType: 'movie', tmdbId: 603),
+        ).overrideWith(
+          (Ref ref) async =>
+              const SeerrDiscoverResult(id: 603, title: 'The Matrix'),
+        ),
+      ],
+      DashboardRequestsWidget(instances: <Instance>[seerr]),
+      pumps: 3,
+    );
+    expect(find.text('Pending requests'), findsOneWidget);
+    expect(find.text('2 pending'), findsOneWidget);
+    expect(find.textContaining('The Matrix'), findsOneWidget);
+    expect(find.textContaining('Bob'), findsOneWidget);
+  });
+
+  testWidgets('DashboardDiskWidget shows SAB free space',
+      (WidgetTester tester) async {
+    final Instance sab = makeInstance(ServiceKind.sabnzbd);
+    await pumpBody(
+      tester,
+      <Override>[
+        sabQueueProvider(sab).overrideWith(
+          (Ref ref) async => const SabQueue(
+            diskspace1: '250.0',
+            diskspacetotal1: '1000.0',
+          ),
+        ),
+      ],
+      DashboardDiskWidget(
+        sabInstances: <Instance>[sab],
+        glancesInstances: const <Instance>[],
+      ),
+    );
+    expect(find.text('Disk space'), findsOneWidget);
+    expect(find.textContaining('250'), findsOneWidget);
+  });
+
+  testWidgets('DashboardBoard renders configured widgets and hides others',
+      (WidgetTester tester) async {
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+    final Instance tau = makeInstance(ServiceKind.tautulli);
+    await pumpBody(
+      tester,
+      <Override>[
+        activeInstancesProvider.overrideWithValue(<Instance>[qbit, tau]),
+        qbitRawTorrentsProvider(qbit).overrideWith(
+          (Ref ref) async => const <QbitTorrent>[
+            QbitTorrent(
+              hash: 'h1',
+              name: 'Ubuntu ISO',
+              state: 'downloading',
+              progress: 0.45,
+            ),
+          ],
+        ),
+        qbitTransferProvider(qbit).overrideWith(
+          (Ref ref) async => const QbitTransferInfo(dlSpeed: 0),
+        ),
+        tautulliActivityProvider(tau).overrideWith(
+          (Ref ref) async => const TautulliActivity(streamCount: 0),
+        ),
+        instanceHealthProvider(qbit).overrideWith((Ref ref) async => Health.ok),
+        instanceHealthProvider(tau).overrideWith((Ref ref) async => Health.ok),
+      ],
+      const DashboardBoard(),
+      pumps: 3,
+    );
+    expect(find.text('Active downloads'), findsOneWidget);
+    expect(find.text('Ubuntu ISO'), findsOneWidget);
+    expect(find.text('Now streaming'), findsOneWidget);
+    expect(find.text('Service health'), findsOneWidget);
+    // No sonarr/radarr, seerr, sab or glances configured:
+    expect(find.text('Upcoming releases'), findsNothing);
+    expect(find.text('Pending requests'), findsNothing);
+    expect(find.text('Disk space'), findsNothing);
+  });
+
+  testWidgets('DashboardBoard edit mode reorders and hides widgets',
+      (WidgetTester tester) async {
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+    await pumpBody(
+      tester,
+      <Override>[
+        activeInstancesProvider.overrideWithValue(<Instance>[qbit]),
+        dashboardEditModeProvider.overrideWith((Ref ref) => true),
+      ],
+      const DashboardBoard(),
+    );
+    // All six widgets are arrangeable in edit mode, configured or not.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(6));
+    expect(find.text('Hidden'), findsNothing);
+    // Hide the first widget -> it moves to the Hidden section.
+    await tester.tap(find.byIcon(Icons.visibility_off_outlined).first);
+    await tester.pump();
+    expect(find.text('Hidden'), findsOneWidget);
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(5));
+    expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+  });
+}

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -4,7 +4,9 @@ import 'package:atrium/src/dashboard/dashboard_widget_kind.dart';
 import 'package:atrium/src/dashboard/widgets/disk_widget.dart';
 import 'package:atrium/src/dashboard/widgets/downloads_widget.dart';
 import 'package:atrium/src/dashboard/widgets/health_widget.dart';
+import 'package:atrium/src/dashboard/widgets/recently_added_widget.dart';
 import 'package:atrium/src/dashboard/widgets/requests_widget.dart';
+import 'package:atrium/src/dashboard/widgets/server_info_widget.dart';
 import 'package:atrium/src/dashboard/widgets/streams_widget.dart';
 import 'package:atrium/src/dashboard/widgets/upcoming_widget.dart';
 import 'package:atrium/src/health_providers.dart';
@@ -14,9 +16,12 @@ import 'package:core_profile/core_profile.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:service_jellyfin/service_jellyfin.dart' as jf;
+import 'package:service_glances/service_glances.dart';
 import 'package:service_qbittorrent/service_qbittorrent.dart';
+import 'package:service_radarr/service_radarr.dart';
 import 'package:service_seerr/service_seerr.dart';
 import 'package:service_sabnzbd/service_sabnzbd.dart';
 import 'package:service_sonarr/service_sonarr.dart';
@@ -146,6 +151,9 @@ void main() {
                 fullTitle: 'The Matrix',
                 progressPercent: 30,
                 state: 'playing',
+                player: 'Plex Web',
+                videoResolution: '1080p',
+                transcodeDecision: 'transcode',
               ),
             ],
           ),
@@ -164,6 +172,8 @@ void main() {
               timeDuration: '0:45:00',
               positionTicks: 0,
               durationTicks: 0,
+              volumeLevel: 100,
+              isMuted: false,
             ),
           ]),
         ),
@@ -177,6 +187,12 @@ void main() {
     expect(find.text('Now streaming'), findsOneWidget);
     expect(find.textContaining('The Matrix'), findsOneWidget);
     expect(find.textContaining('Breaking Bad'), findsOneWidget);
+    // Enriched session info: device on the meta line, the resolution chip,
+    // and Jellyfin's elapsed / total time.
+    expect(find.textContaining('Plex Web'), findsOneWidget);
+    expect(find.text('1080p'), findsOneWidget);
+    expect(find.textContaining('Web'), findsWidgets);
+    expect(find.text('0:10:00 / 0:45:00'), findsOneWidget);
   });
 
   testWidgets('DashboardUpcomingWidget lists events inside the 7-day window',
@@ -185,13 +201,13 @@ void main() {
     final DateTime tomorrow = DateTime.now().add(const Duration(days: 1));
     final List<CalendarEvent> events = <CalendarEvent>[
       SonarrCalendarEvent(
-        SonarrCalendarEntry(
+        SonarrEpisode(
           id: 1,
           seriesId: 10,
           title: 'Pilot',
           seasonNumber: 1,
           episodeNumber: 1,
-          airDateUtc: tomorrow.toUtc(),
+          airDateUtc: tomorrow.toUtc().toIso8601String(),
           hasFile: false,
           monitored: true,
           series: const SonarrSeries(id: 10, title: 'Test Show'),
@@ -209,6 +225,49 @@ void main() {
     );
     expect(find.text('Upcoming releases'), findsOneWidget);
     expect(find.textContaining('Test Show'), findsOneWidget);
+  });
+
+  testWidgets('DashboardRecentlyAddedWidget shows newest series and movies',
+      (WidgetTester tester) async {
+    final Instance sonarr = makeInstance(ServiceKind.sonarr);
+    final Instance radarr = makeInstance(ServiceKind.radarr);
+    await pumpBody(
+      tester,
+      <Override>[
+        sonarrSeriesProvider(sonarr).overrideWith(
+          (Ref ref) async => const <SonarrSeries>[
+            SonarrSeries(
+              title: 'New Show',
+              year: 2024,
+              added: '2026-07-10T00:00:00Z',
+            ),
+            SonarrSeries(
+              title: 'Old Show',
+              year: 2010,
+              added: '2020-01-01T00:00:00Z',
+            ),
+          ],
+        ),
+        radarrMoviesProvider(radarr).overrideWith(
+          (Ref ref) async => const <RadarrMovie>[
+            RadarrMovie(
+              title: 'New Movie',
+              year: 2025,
+              added: '2026-07-12T00:00:00Z',
+            ),
+          ],
+        ),
+      ],
+      DashboardRecentlyAddedWidget(
+        sonarrInstances: <Instance>[sonarr],
+        radarrInstances: <Instance>[radarr],
+      ),
+      pumps: 3,
+    );
+    expect(find.text('Recently added'), findsOneWidget);
+    expect(find.text('New Movie'), findsOneWidget);
+    expect(find.text('New Show'), findsOneWidget);
+    expect(find.text('Movie · 2025'), findsOneWidget);
   });
 
   testWidgets('DashboardHealthWidget shows per-instance chips and counts',
@@ -261,10 +320,62 @@ void main() {
       DashboardRequestsWidget(instances: <Instance>[seerr]),
       pumps: 3,
     );
-    expect(find.text('Pending requests'), findsOneWidget);
-    expect(find.text('2 pending'), findsOneWidget);
+    expect(find.text('Requests'), findsOneWidget);
+    expect(find.text('3 requested'), findsOneWidget);
+    expect(find.text('Needs approval'), findsOneWidget);
     expect(find.textContaining('The Matrix'), findsOneWidget);
     expect(find.textContaining('Bob'), findsOneWidget);
+  });
+
+  testWidgets('DashboardServerInfoWidget shows CPU, memory, GPU and disks',
+      (WidgetTester tester) async {
+    final Instance glances = makeInstance(ServiceKind.glances);
+    await pumpBody(
+      tester,
+      <Override>[
+        glancesStatsProvider(glances).overrideWith(
+          (Ref ref) async => const GlancesStats(
+            cpu: GlancesCpu(
+              physicalCores: 4,
+              logicalCores: 8,
+              totalUsage: 42,
+              packageTemp: 55,
+              cores: <GlancesCpuCore>[],
+            ),
+            memory:
+                GlancesMemory(percentage: 63, used: 8000000000, total: 16000000000),
+            swap: GlancesSwap(percentage: 0, used: 0, total: 0),
+            network: <GlancesNetwork>[],
+            disks: <GlancesDisk>[
+              GlancesDisk(
+                path: '/data',
+                percentage: 71,
+                used: 500000000000,
+                total: 1000000000000,
+              ),
+            ],
+            uptime: GlancesUptime(
+              days: 1,
+              hours: 2,
+              minutes: 3,
+              seconds: 4,
+              totalSeconds: 93784,
+            ),
+            gpus: <GlancesGpu>[
+              GlancesGpu(name: 'RTX', proc: 30, mem: 40, temp: 60),
+            ],
+          ),
+        ),
+      ],
+      DashboardServerInfoWidget(instances: <Instance>[glances]),
+      pumps: 3,
+    );
+    expect(find.text('Server info'), findsOneWidget);
+    expect(find.text('CPU'), findsOneWidget);
+    expect(find.text('Memory'), findsOneWidget);
+    expect(find.text('GPU'), findsOneWidget);
+    expect(find.text('42%'), findsOneWidget);
+    expect(find.text('/data'), findsOneWidget);
   });
 
   testWidgets('DashboardDiskWidget shows SAB free space',
@@ -321,12 +432,59 @@ void main() {
     );
     expect(find.text('Active downloads'), findsOneWidget);
     expect(find.text('Ubuntu ISO'), findsOneWidget);
-    expect(find.text('Now streaming'), findsOneWidget);
+    // Streams is activity-gated: tautulli is configured but nobody is
+    // streaming (streamCount 0), so the widget stays hidden.
+    expect(find.text('Now streaming'), findsNothing);
     expect(find.text('Service health'), findsOneWidget);
     // No sonarr/radarr, seerr, sab or glances configured:
     expect(find.text('Upcoming releases'), findsNothing);
-    expect(find.text('Pending requests'), findsNothing);
+    expect(find.text('Requests'), findsNothing);
     expect(find.text('Disk space'), findsNothing);
+  });
+
+  testWidgets('DashboardBoard activity-gates downloads and streams',
+      (WidgetTester tester) async {
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+    final Instance tau = makeInstance(ServiceKind.tautulli);
+    await pumpBody(
+      tester,
+      <Override>[
+        activeInstancesProvider.overrideWithValue(<Instance>[qbit, tau]),
+        // Only a seeding torrent -> no active download -> widget hidden.
+        qbitRawTorrentsProvider(qbit).overrideWith(
+          (Ref ref) async => const <QbitTorrent>[
+            QbitTorrent(
+              hash: 'h1',
+              name: 'Seeded ISO',
+              state: 'uploading',
+              progress: 1.0,
+            ),
+          ],
+        ),
+        // One active session -> streams widget shown.
+        tautulliActivityProvider(tau).overrideWith(
+          (Ref ref) async => const TautulliActivity(
+            streamCount: 1,
+            sessions: <TautulliSession>[
+              TautulliSession(
+                friendlyName: 'Alice',
+                fullTitle: 'The Matrix',
+                progressPercent: 30,
+                state: 'playing',
+              ),
+            ],
+          ),
+        ),
+        instanceHealthProvider(qbit).overrideWith((Ref ref) async => Health.ok),
+        instanceHealthProvider(tau).overrideWith((Ref ref) async => Health.ok),
+      ],
+      const DashboardBoard(),
+      pumps: 3,
+    );
+    expect(find.text('Active downloads'), findsNothing);
+    expect(find.text('Now streaming'), findsOneWidget);
+    expect(find.textContaining('The Matrix'), findsOneWidget);
+    expect(find.text('Service health'), findsOneWidget);
   });
 
   testWidgets('DashboardBoard edit mode reorders and hides widgets',
@@ -340,14 +498,14 @@ void main() {
       ],
       const DashboardBoard(),
     );
-    // All six widgets are arrangeable in edit mode, configured or not.
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(6));
+    // All eight widgets are arrangeable in edit mode, configured or not.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(8));
     expect(find.text('Hidden'), findsNothing);
     // Hide the first widget -> it moves to the Hidden section.
     await tester.tap(find.byIcon(Icons.visibility_off_outlined).first);
     await tester.pump();
     expect(find.text('Hidden'), findsOneWidget);
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(5));
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(7));
     expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
   });
 }

--- a/services/service_glances/lib/src/glances_api.dart
+++ b/services/service_glances/lib/src/glances_api.dart
@@ -126,6 +126,11 @@ class GlancesApi {
         totalSeconds: totalSeconds,
       );
 
+      // GPU is optional: many servers have no GPU and the plugin may be
+      // absent (a 404). Fetch it on its own so a missing endpoint can never
+      // break the core stats above.
+      final List<GlancesGpu> gpus = await _getGpus();
+
       return GlancesStats(
         cpu: GlancesCpu(
           physicalCores: physCores,
@@ -139,9 +144,34 @@ class GlancesApi {
         network: network,
         disks: disks,
         uptime: uptime,
+        gpus: gpus,
       );
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
+    }
+  }
+
+  /// Glances `/gpu` returns a list of GPUs with `proc` (utilisation %), `mem`
+  /// (memory %), `temperature` and `name`. Returns an empty list on any error
+  /// (no GPU, plugin disabled, older server) so the core stats never fail.
+  Future<List<GlancesGpu>> _getGpus() async {
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>('api/4/gpu');
+      final dynamic data = resp.data;
+      if (data is! List) {
+        return const <GlancesGpu>[];
+      }
+      return data.map((dynamic g) {
+        final Map<String, dynamic> map = g as Map<String, dynamic>;
+        return GlancesGpu(
+          name: map['name'] as String? ?? 'GPU',
+          proc: (map['proc'] as num?)?.toDouble() ?? 0.0,
+          mem: (map['mem'] as num?)?.toDouble() ?? 0.0,
+          temp: (map['temperature'] as num?)?.toDouble() ?? 0.0,
+        );
+      }).toList();
+    } catch (_) {
+      return const <GlancesGpu>[];
     }
   }
 }

--- a/services/service_glances/lib/src/models/glances_stats.dart
+++ b/services/service_glances/lib/src/models/glances_stats.dart
@@ -12,6 +12,7 @@ abstract class GlancesStats with _$GlancesStats {
     required List<GlancesNetwork> network,
     required List<GlancesDisk> disks,
     required GlancesUptime uptime,
+    @Default(<GlancesGpu>[]) List<GlancesGpu> gpus,
   }) = _GlancesStats;
 
   factory GlancesStats.fromJson(Map<String, dynamic> json) =>
@@ -92,6 +93,19 @@ abstract class GlancesNetwork with _$GlancesNetwork {
 
   factory GlancesNetwork.fromJson(Map<String, dynamic> json) =>
       _$GlancesNetworkFromJson(json);
+}
+
+@freezed
+abstract class GlancesGpu with _$GlancesGpu {
+  const factory GlancesGpu({
+    required String name,
+    required double proc,
+    required double mem,
+    required double temp,
+  }) = _GlancesGpu;
+
+  factory GlancesGpu.fromJson(Map<String, dynamic> json) =>
+      _$GlancesGpuFromJson(json);
 }
 
 @freezed

--- a/services/service_qbittorrent/lib/src/qbittorrent_client.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_client.dart
@@ -28,6 +28,7 @@ class QbittorrentClient {
     required CookieJar cookies,
     required this.username,
     required this.password,
+    this.apiKey,
   })  : _dio = dio,
         _cookies = cookies;
 
@@ -35,6 +36,13 @@ class QbittorrentClient {
   final CookieJar _cookies;
   final String username;
   final String password;
+
+  /// qBittorrent 5.2+ API key (`qbt_…`). When set it is sent as
+  /// `Authorization: Bearer <key>` and the cookie login flow is skipped
+  /// entirely (the key is stateless and cannot use the auth endpoints).
+  final String? apiKey;
+
+  bool get _usesApiKey => apiKey != null && apiKey!.isNotEmpty;
   bool _loggedIn = false;
 
   /// Builds a client with a cookie-aware Dio pointed at [baseUrl].
@@ -43,17 +51,22 @@ class QbittorrentClient {
     required String username,
     required String password,
     required bool allowSelfSigned,
+    String? apiKey,
     Map<String, String> customHeaders = const <String, String>{},
   }) {
     final String baseUrlStr = baseUrl.toString();
     final String normalizedBaseUrl = baseUrlStr.endsWith('/') ? baseUrlStr : '$baseUrlStr/';
     final CookieJar cookies = CookieJar();
+    final Map<String, dynamic> headers = <String, dynamic>{
+      'Referer': normalizedBaseUrl,
+      if (apiKey != null && apiKey.isNotEmpty) 'Authorization': 'Bearer $apiKey',
+    };
     final Dio dio = Dio(
       BaseOptions(
         baseUrl: normalizedBaseUrl,
         connectTimeout: const Duration(seconds: 10),
         receiveTimeout: const Duration(seconds: 30),
-        headers: <String, dynamic>{'Referer': normalizedBaseUrl},
+        headers: headers,
       ),
     );
     // User-configured headers ride alongside the Referer above (a user
@@ -72,6 +85,7 @@ class QbittorrentClient {
       cookies: cookies,
       username: username,
       password: password,
+      apiKey: apiKey,
     );
   }
 
@@ -448,13 +462,23 @@ class QbittorrentClient {
 
   /// Ensures a session exists, runs [call], and re-logins once on a 403.
   Future<T> _guarded<T>(Future<T> Function() call) async {
-    if (!_loggedIn) {
+    // API-key auth is stateless: no login round-trip, and a 403 means the key
+    // itself was rejected (re-login is impossible - keys can't use the auth
+    // endpoints), so surface a clear error instead of retrying.
+    if (!_usesApiKey && !_loggedIn) {
       await login();
     }
     try {
       return await call();
     } on DioException catch (e) {
       if (e.response?.statusCode == 403) {
+        if (_usesApiKey) {
+          throw const NetworkAuthException(
+            'qBittorrent rejected the API key. Check it in qBittorrent 5.2+ '
+            'Web UI settings (sent as Authorization: Bearer), or rotate the '
+            'key and re-enter it.',
+          );
+        }
         _loggedIn = false;
         await login();
         try {

--- a/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
@@ -34,12 +34,16 @@ final qbittorrentClientProvider =
       final ConnectionResolver resolver =
           ref.watch(connectionResolverProvider);
       final Uri baseUrl = await resolver.resolve(instance);
-      final (String username, String password) = switch (instance.auth) {
+      final (String username, String password, String? apiKey) =
+          switch (instance.auth) {
         InstanceAuthCookie(:final String username, :final String password) => (
             username,
             password,
+            null,
           ),
-        _ => ('', ''),
+        // qBittorrent 5.2+ stateless key auth (Authorization: Bearer).
+        InstanceAuthApiKey(:final String apiKey) => ('', '', apiKey),
+        _ => ('', '', null),
       };
       final Map<String, String> customHeaders = mergeHeaders(
         ref.watch(globalHeadersProvider),
@@ -49,6 +53,7 @@ final qbittorrentClientProvider =
         baseUrl: baseUrl,
         username: username,
         password: password,
+        apiKey: apiKey,
         allowSelfSigned: instance.allowSelfSignedCerts,
         customHeaders: customHeaders,
       );

--- a/services/service_seerr/lib/service_seerr.dart
+++ b/services/service_seerr/lib/service_seerr.dart
@@ -5,6 +5,7 @@
 /// with approve / decline).
 library;
 
+export 'src/models/seerr_counts.dart';
 export 'src/models/seerr_discover.dart';
 export 'src/models/seerr_issue.dart';
 export 'src/models/seerr_request.dart';


### PR DESCRIPTION
## Summary

Adds the dashboard widget board to the home screen, plus two supporting service changes.

**Dashboard board** (app): a customisable board of at-a-glance cards - active downloads, now streaming, upcoming releases, recently added, service health, requests, server info, and disk usage. Every card is one calm surface tone with an accent icon. Downloads and now-streaming appear only while there is live activity; the media cards (upcoming, streams, requests, recently added) carry poster and backdrop artwork; server info shows CPU, memory and GPU as circular gauges over the filesystems. An inline edit mode reorders and hides widgets with a layout persisted in the settings box, and it auto-appears for existing users without wiping saved layouts.

**Glances** (service_glances): parses GPU stats from the /gpu endpoint (utilisation, memory, temperature), fetched on its own so servers without a GPU, or an older Glances, are unaffected.

**qBittorrent** (service_qbittorrent + app): supports qBittorrent 5.2 stateless API keys - sent as Authorization: Bearer with the cookie login skipped - selectable via a Password / API key toggle in the add/edit form.

## Testing

- flutter analyze: No issues found
- app test suite: 52 tests pass (dashboard widget, board, and layout tests added or updated)
- Built and installed on device across iterations (build 4113)