### PR TITLE
Redesign "Now Streaming" dashboard widget & refine progress indicator styling

### DIFF
--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -52,16 +52,19 @@ class AtriumApp extends ConsumerWidget {
       } catch (_) {}
     }
 
-    final ThemeSource themeSource = ref
-        .watch(preferencesProvider.select((Preferences p) => p.themeSource));
-    final (ColorScheme customLight, ColorScheme customDark) = ref.watch(customColorSchemeProvider);
+    final ThemeSource themeSource =
+        ref.watch(preferencesProvider.select((Preferences p) => p.themeSource));
+    final (ColorScheme customLight, ColorScheme customDark) =
+        ref.watch(customColorSchemeProvider);
 
     return AtriumTheme.withDynamicColor(
       builder: (ColorScheme? lightScheme, ColorScheme? darkScheme) {
         final systemNotifier = ref.read(systemColorSchemeProvider.notifier);
-        if (systemNotifier.state.light != lightScheme || systemNotifier.state.dark != darkScheme) {
+        if (systemNotifier.state.light != lightScheme ||
+            systemNotifier.state.dark != darkScheme) {
           WidgetsBinding.instance.addPostFrameCallback((_) {
-            systemNotifier.state = SystemColorSchemeState(lightScheme, darkScheme);
+            systemNotifier.state =
+                SystemColorSchemeState(lightScheme, darkScheme);
           });
         }
 
@@ -69,14 +72,17 @@ class AtriumApp extends ConsumerWidget {
             ? (lightScheme ?? ColorScheme.fromSeed(seedColor: AtriumTheme.seed))
             : customLight;
         final ColorScheme activeDark = themeSource == ThemeSource.system
-            ? (darkScheme ?? ColorScheme.fromSeed(seedColor: AtriumTheme.seed, brightness: Brightness.dark))
+            ? (darkScheme ??
+                ColorScheme.fromSeed(
+                    seedColor: AtriumTheme.seed, brightness: Brightness.dark))
             : customDark;
 
         return MaterialApp.router(
           title: 'Atrium',
           debugShowCheckedModeBanner: false,
           theme: AtriumTheme.light(activeLight, fontFamily: resolvedFontFamily),
-          darkTheme: AtriumTheme.dark(activeDark, fontFamily: resolvedFontFamily),
+          darkTheme:
+              AtriumTheme.dark(activeDark, fontFamily: resolvedFontFamily),
           themeMode: themeMode,
           routerConfig: router,
           // Overlay the opt-in biometric lock above every route.
@@ -198,7 +204,8 @@ class _LockScreen extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
-            Icon(Icons.lock_outline, size: 64, color: theme.colorScheme.primary),
+            Icon(Icons.lock_outline,
+                size: 64, color: theme.colorScheme.primary),
             const SizedBox(height: 16),
             Text('Atrium is locked', style: theme.textTheme.titleLarge),
             const SizedBox(height: 8),

--- a/app/lib/src/activity/activity_cards.dart
+++ b/app/lib/src/activity/activity_cards.dart
@@ -4,6 +4,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
 import 'activity_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Backdrop card for one active stream: session art under a bottom-heavy
 /// scrim, the watching user top-left, the source service (and transcode
@@ -51,13 +52,25 @@ class ActivityStreamCard extends StatelessWidget {
                 CachedNetworkImage(
                   imageUrl: imageUrl,
                   fit: BoxFit.cover,
+                  alignment: Alignment.center,
                   placeholder: (BuildContext context, String _) => ColoredBox(
                     color: theme.colorScheme.surfaceContainerHighest,
                   ),
                   errorWidget: (BuildContext context, String _, Object __) =>
-                      ColoredBox(
-                    color: theme.colorScheme.surfaceContainerHighest,
-                  ),
+                      (stream.posterUrl != null &&
+                              stream.posterUrl!.trim().isNotEmpty &&
+                              stream.posterUrl != imageUrl)
+                          ? CachedNetworkImage(
+                              imageUrl: stream.posterUrl!,
+                              fit: BoxFit.cover,
+                              alignment: Alignment.center,
+                              errorWidget: (_, __, ___) => ColoredBox(
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                              ),
+                            )
+                          : ColoredBox(
+                              color: theme.colorScheme.surfaceContainerHighest),
                 )
               else
                 ColoredBox(color: theme.colorScheme.surfaceContainerHighest),
@@ -147,13 +160,13 @@ class ActivityStreamCard extends StatelessWidget {
                 bottom: 0,
                 left: 0,
                 right: 0,
-                child: LinearProgressIndicator(
+                child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
                   value: stream.progress.clamp(0.0, 1.0),
-                  minHeight: 5,
-                  color: stream.paused
+                  activeColor: stream.paused
                       ? theme.colorScheme.outline
                       : theme.colorScheme.primary,
-                  backgroundColor: Colors.white.withValues(alpha: 0.15),
+                  trackColor: Colors.white.withValues(alpha: 0.15),
                 ),
               ),
             ],
@@ -267,8 +280,7 @@ class ActivityDownloadCard extends StatelessWidget {
     final String meta = <String>[
       '${(download.progress * 100).round()}%',
       if (download.speedBps != null) '↓ ${fmtSpeedBps(download.speedBps!)}',
-      if (download.upSpeedBps != null)
-        '↑ ${fmtSpeedBps(download.upSpeedBps!)}',
+      if (download.upSpeedBps != null) '↑ ${fmtSpeedBps(download.upSpeedBps!)}',
       if (download.eta != null) download.eta!,
       if (instanceLabel != null) instanceLabel!,
     ].join(' · ');
@@ -316,11 +328,10 @@ class ActivityDownloadCard extends StatelessWidget {
                     const SizedBox(height: Insets.sm),
                     ClipRRect(
                       borderRadius: BorderRadius.circular(6),
-                      child: LinearProgressIndicator(
+                      child: LinearProgressIndicatorM3E(
+                        shape: ProgressM3EShape.flat,
                         value: download.progress.clamp(0.0, 1.0),
-                        minHeight: 6,
-                        backgroundColor:
-                            theme.colorScheme.surfaceContainerHighest,
+                        trackColor: theme.colorScheme.surfaceContainerHighest,
                       ),
                     ),
                     const SizedBox(height: 6),

--- a/app/lib/src/activity/activity_providers.dart
+++ b/app/lib/src/activity/activity_providers.dart
@@ -26,6 +26,7 @@ class ActivityStream {
     this.userName,
     this.userAvatarUrl,
     this.imageUrl,
+    this.posterUrl,
     this.detailChip,
     this.onOpenBuilder,
   });
@@ -43,6 +44,7 @@ class ActivityStream {
 
   /// Backdrop preferred, poster fallback.
   final String? imageUrl;
+  final String? posterUrl;
 
   /// Playback progress, 0-1.
   final double progress;
@@ -146,8 +148,7 @@ final activityStreamsProvider =
         collect(
           instance,
           ref.watch(plexSessionsProvider(instance)),
-          (List<PlexSession> sessions) =>
-              _plexStreams(ref, instance, sessions),
+          (List<PlexSession> sessions) => _plexStreams(ref, instance, sessions),
         );
       case ServiceKind.jellyfin:
         collect(
@@ -309,6 +310,7 @@ List<ActivityStream> _plexStreams(
         userName: (s.user?.title ?? '').isEmpty ? null : s.user!.title,
         userAvatarUrl: api?.imageUrl(s.user?.thumb),
         imageUrl: api?.imageUrl(s.art ?? s.thumb),
+        posterUrl: api?.imageUrl(s.thumb),
         progress: s.progress,
         paused: s.player?.state == 'paused',
         detailChip: s.decisionLabel,
@@ -342,6 +344,7 @@ List<ActivityStream> _jellyfinStreams(
             : (s.device.isEmpty ? null : s.device),
         userName: s.user.isEmpty ? null : s.user,
         imageUrl: s.backdropUrl ?? s.posterUrl,
+        posterUrl: s.posterUrl,
         progress: (s.progressPercent / 100).clamp(0.0, 1.0),
         paused: s.status.toLowerCase() == 'paused',
         onOpenBuilder: (BuildContext _) => jf.JellyfinSessionDetailScreen(
@@ -368,6 +371,7 @@ List<ActivityStream> _embyStreams(
             : (s.device.isEmpty ? null : s.device),
         userName: s.user.isEmpty ? null : s.user,
         imageUrl: s.backdropUrl ?? s.posterUrl,
+        posterUrl: s.posterUrl,
         progress: (s.progressPercent / 100).clamp(0.0, 1.0),
         paused: s.status.toLowerCase() == 'paused',
         onOpenBuilder: (BuildContext _) => emby.EmbySessionDetailScreen(
@@ -398,6 +402,7 @@ List<ActivityStream> _tautulliStreams(
         userAvatarUrl: api?.imageUrl(s.userThumb, fallback: 'art'),
         imageUrl: api?.imageUrl(s.art, width: 800, fallback: 'art') ??
             api?.imageUrl(s.posterThumb),
+        posterUrl: api?.imageUrl(s.posterThumb),
         progress: (s.progressPercent / 100).clamp(0.0, 1.0),
         paused: s.state.toLowerCase() == 'paused',
         detailChip: _decisionLabel(s.transcodeDecision),
@@ -498,8 +503,7 @@ List<ActivityDownload> _sabDownloads(Instance instance, SabQueue queue) {
         instance: instance,
         sourceKind: instance.kind,
         title: slot.filename,
-        progress:
-            ((int.tryParse(slot.percentage) ?? 0) / 100).clamp(0.0, 1.0),
+        progress: ((int.tryParse(slot.percentage) ?? 0) / 100).clamp(0.0, 1.0),
         eta: slot.timeleft.isEmpty ? null : slot.timeleft,
         status: slot.status.isEmpty ? 'Queued' : _capitalized(slot.status),
       ),

--- a/app/lib/src/custom_theme_providers.dart
+++ b/app/lib/src/custom_theme_providers.dart
@@ -11,7 +11,8 @@ class SystemColorSchemeState {
 }
 
 /// Stores the platform-detected system color schemes.
-final systemColorSchemeProvider = StateProvider<SystemColorSchemeState>((ref) => const SystemColorSchemeState(null, null));
+final systemColorSchemeProvider = StateProvider<SystemColorSchemeState>(
+    (ref) => const SystemColorSchemeState(null, null));
 
 DynamicScheme _createDynamicScheme({
   required Color seedColor,
@@ -21,7 +22,7 @@ DynamicScheme _createDynamicScheme({
   final Hct sourceColorHct = Hct.fromInt(seedColor.toARGB32());
   final bool isDark = brightness == Brightness.dark;
   const double contrastLevel = 0.0;
-  
+
   switch (style) {
     case PaletteStyle.content:
       return SchemeContent(
@@ -74,13 +75,14 @@ DynamicScheme _createDynamicScheme({
   }
 }
 
-ColorScheme colorSchemeFromSeedAndStyle(Color seedColor, PaletteStyle style, Brightness brightness) {
+ColorScheme colorSchemeFromSeedAndStyle(
+    Color seedColor, PaletteStyle style, Brightness brightness) {
   final DynamicScheme dynamicScheme = _createDynamicScheme(
     seedColor: seedColor,
     brightness: brightness,
     style: style,
   );
-  
+
   final isLight = brightness == Brightness.light;
   if (isLight) {
     return ColorScheme(
@@ -158,11 +160,12 @@ ColorScheme colorSchemeFromSeedAndStyle(Color seedColor, PaletteStyle style, Bri
 /// Provider for custom ColorScheme pair generated from preferences seed color.
 final customColorSchemeProvider = Provider<(ColorScheme, ColorScheme)>((ref) {
   final prefs = ref.watch(preferencesProvider);
-  
+
   // Default fallback seed color (AtriumTheme violet)
   Color seed = const Color(0xFF6750A4);
-  
-  if (prefs.customSeedColorHex != null && prefs.customSeedColorHex!.isNotEmpty) {
+
+  if (prefs.customSeedColorHex != null &&
+      prefs.customSeedColorHex!.isNotEmpty) {
     try {
       final int? val = int.tryParse(prefs.customSeedColorHex!, radix: 16);
       if (val != null) {
@@ -170,7 +173,7 @@ final customColorSchemeProvider = Provider<(ColorScheme, ColorScheme)>((ref) {
       }
     } catch (_) {}
   }
-  
+
   return (
     colorSchemeFromSeedAndStyle(seed, prefs.paletteStyle, Brightness.light),
     colorSchemeFromSeedAndStyle(seed, prefs.paletteStyle, Brightness.dark),

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -89,7 +89,8 @@ class DashboardBoard extends ConsumerWidget {
   /// configured.
   static bool _hasLiveContent(WidgetRef ref, DashboardWidgetKind kind) {
     return switch (kind) {
-      DashboardWidgetKind.downloads => ref.watch(activeDownloadCountProvider) > 0,
+      DashboardWidgetKind.downloads =>
+        ref.watch(activeDownloadCountProvider) > 0,
       DashboardWidgetKind.streams => ref.watch(activeStreamCountProvider) > 0,
       _ => true,
     };

--- a/app/lib/src/dashboard/dashboard_layout.dart
+++ b/app/lib/src/dashboard/dashboard_layout.dart
@@ -41,7 +41,8 @@ List<DashboardWidgetConfig> decodeLayout(String? raw) {
     if (kind == null) {
       continue;
     }
-    out.add(DashboardWidgetConfig(kind: kind, enabled: item['enabled'] != false));
+    out.add(
+        DashboardWidgetConfig(kind: kind, enabled: item['enabled'] != false));
   }
   return out;
 }

--- a/app/lib/src/dashboard/dashboard_widget_kind.dart
+++ b/app/lib/src/dashboard/dashboard_widget_kind.dart
@@ -39,22 +39,31 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
   /// Service kinds whose presence makes this widget "configured". The health
   /// widget is configured whenever ANY instance exists.
   List<ServiceKind> get serviceKinds => switch (this) {
-        DashboardWidgetKind.downloads =>
-          const <ServiceKind>[ServiceKind.qbittorrent, ServiceKind.sabnzbd],
+        DashboardWidgetKind.downloads => const <ServiceKind>[
+            ServiceKind.qbittorrent,
+            ServiceKind.sabnzbd
+          ],
         DashboardWidgetKind.streams => const <ServiceKind>[
             ServiceKind.tautulli,
             ServiceKind.jellyfin,
             ServiceKind.emby,
           ],
-        DashboardWidgetKind.upcoming =>
-          const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
-        DashboardWidgetKind.recentlyAdded =>
-          const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
+        DashboardWidgetKind.upcoming => const <ServiceKind>[
+            ServiceKind.sonarr,
+            ServiceKind.radarr
+          ],
+        DashboardWidgetKind.recentlyAdded => const <ServiceKind>[
+            ServiceKind.sonarr,
+            ServiceKind.radarr
+          ],
         DashboardWidgetKind.health => ServiceKind.values,
         DashboardWidgetKind.requests => const <ServiceKind>[ServiceKind.seerr],
-        DashboardWidgetKind.serverInfo =>
-          const <ServiceKind>[ServiceKind.glances],
-        DashboardWidgetKind.diskSpace =>
-          const <ServiceKind>[ServiceKind.sabnzbd, ServiceKind.glances],
+        DashboardWidgetKind.serverInfo => const <ServiceKind>[
+            ServiceKind.glances
+          ],
+        DashboardWidgetKind.diskSpace => const <ServiceKind>[
+            ServiceKind.sabnzbd,
+            ServiceKind.glances
+          ],
       };
 }

--- a/app/lib/src/dashboard/widgets/disk_widget.dart
+++ b/app/lib/src/dashboard/widgets/disk_widget.dart
@@ -7,6 +7,7 @@ import 'package:service_sabnzbd/service_sabnzbd.dart';
 
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class _DiskRow {
   const _DiskRow({
@@ -74,8 +75,7 @@ class DashboardDiskWidget extends ConsumerWidget {
       final AsyncValue<GlancesStats> stats = ref.watch(glancesStatsProvider(i));
       anyLoading |= stats.isLoading && !stats.hasValue;
       anyError |= stats.hasError;
-      for (final GlancesDisk d
-          in stats.value?.disks ?? const <GlancesDisk>[]) {
+      for (final GlancesDisk d in stats.value?.disks ?? const <GlancesDisk>[]) {
         if (d.total > 0) {
           rows.add(_DiskRow(
             label: '${i.name} ${d.path}',
@@ -169,11 +169,12 @@ class _BarRow extends StatelessWidget {
           const SizedBox(height: 4),
           ClipRRect(
             borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
+            child: LinearProgressIndicatorM3E(
+              size: LinearProgressM3ESize.s,
+              shape: ProgressM3EShape.flat,
               value: row.fraction,
-              minHeight: 5,
-              color: barColor,
-              backgroundColor: cs.surfaceContainerHighest,
+              activeColor: barColor,
+              trackColor: cs.surfaceContainerHighest,
             ),
           ),
         ],

--- a/app/lib/src/dashboard/widgets/downloads_widget.dart
+++ b/app/lib/src/dashboard/widgets/downloads_widget.dart
@@ -10,6 +10,7 @@ import 'package:service_sabnzbd/service_sabnzbd.dart';
 
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// qBittorrent states that count as actively downloading.
 const Set<String> _activeDlStates = <String>{
@@ -31,8 +32,7 @@ final activeDownloadCountProvider = Provider.autoDispose<int>((Ref ref) {
   for (final Instance i in instances) {
     if (i.kind == ServiceKind.qbittorrent) {
       final List<QbitTorrent> torrents =
-          ref.watch(qbitRawTorrentsProvider(i)).value ??
-              const <QbitTorrent>[];
+          ref.watch(qbitRawTorrentsProvider(i)).value ?? const <QbitTorrent>[];
       for (final QbitTorrent t in torrents) {
         if (_activeDlStates.contains(t.state)) {
           count++;
@@ -131,7 +131,8 @@ class DashboardDownloadsWidget extends ConsumerWidget {
       }
     }
 
-    rows.sort((_DownloadRow a, _DownloadRow b) => b.progress.compareTo(a.progress));
+    rows.sort(
+        (_DownloadRow a, _DownloadRow b) => b.progress.compareTo(a.progress));
     final List<_DownloadRow> top = rows.take(3).toList();
 
     Widget body;
@@ -226,11 +227,12 @@ class _ItemRow extends StatelessWidget {
             const SizedBox(height: 4),
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
+              child: LinearProgressIndicatorM3E(
+                size: LinearProgressM3ESize.s,
+                shape: ProgressM3EShape.flat,
                 value: row.progress,
-                minHeight: 5,
-                color: cs.primary,
-                backgroundColor: cs.surfaceContainerHighest,
+                activeColor: cs.primary,
+                trackColor: cs.surfaceContainerHighest,
               ),
             ),
           ],

--- a/app/lib/src/dashboard/widgets/health_widget.dart
+++ b/app/lib/src/dashboard/widgets/health_widget.dart
@@ -35,8 +35,9 @@ class DashboardHealthWidget extends ConsumerWidget {
       accent: issues > 0 ? cs.error : cs.tertiary,
       trailing: DashboardPill(
         icon: issues > 0 ? Icons.warning_amber_rounded : Icons.check_rounded,
-        label:
-            issues > 0 ? '$issues issue${issues == 1 ? '' : 's'}' : 'All online',
+        label: issues > 0
+            ? '$issues issue${issues == 1 ? '' : 's'}'
+            : 'All online',
         color: issues > 0 ? cs.error : cs.tertiary,
       ),
       child: Wrap(

--- a/app/lib/src/dashboard/widgets/requests_widget.dart
+++ b/app/lib/src/dashboard/widgets/requests_widget.dart
@@ -93,8 +93,8 @@ class DashboardRequestsWidget extends ConsumerWidget {
           if (requests.length > top.length)
             Padding(
               padding: const EdgeInsets.only(top: Insets.sm),
-              child:
-                  DashboardIdleRow(text: '+${requests.length - top.length} more'),
+              child: DashboardIdleRow(
+                  text: '+${requests.length - top.length} more'),
             ),
         ],
       );

--- a/app/lib/src/dashboard/widgets/server_info_widget.dart
+++ b/app/lib/src/dashboard/widgets/server_info_widget.dart
@@ -231,7 +231,8 @@ class _MetricTile extends StatelessWidget {
           detail,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
+          style:
+              theme.textTheme.bodySmall?.copyWith(color: cs.onSurfaceVariant),
         ),
       ],
     );

--- a/app/lib/src/dashboard/widgets/server_info_widget.dart
+++ b/app/lib/src/dashboard/widgets/server_info_widget.dart
@@ -274,11 +274,13 @@ class _DiskBar extends StatelessWidget {
           const SizedBox(height: 4),
           ClipRRect(
             borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
+            child: LinearProgressIndicatorM3E(
               value: fraction,
-              minHeight: 5,
-              color: _loadColor(disk.percentage, cs),
-              backgroundColor: cs.surfaceContainerHighest,
+              shape: ProgressM3EShape.flat,
+              size: LinearProgressM3ESize.s,
+              activeColor: _loadColor(disk.percentage, cs),
+              trackColor: cs.surfaceContainerHighest,
+              inset: 0.0,
             ),
           ),
         ],

--- a/app/lib/src/dashboard/widgets/streams_widget.dart
+++ b/app/lib/src/dashboard/widgets/streams_widget.dart
@@ -12,6 +12,8 @@ import 'package:service_tautulli/service_tautulli.dart';
 
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
+import 'package:palette_generator/palette_generator.dart';
 
 /// Live count of active sessions across every Tautulli, Jellyfin and Emby
 /// instance. Instances still loading or in error contribute 0, so the
@@ -45,6 +47,7 @@ class _StreamRow {
     required this.instance,
     this.device = '',
     this.posterUrl,
+    this.backdropUrl,
     this.quality,
     this.transcoding = false,
     this.timeLabel,
@@ -59,6 +62,7 @@ class _StreamRow {
   /// Player / client the session is on (e.g. "Chrome", "Apple TV").
   final String device;
   final String? posterUrl;
+  final String? backdropUrl;
 
   /// Stream resolution (e.g. "1080p"), when the backend reports it.
   final String? quality;
@@ -113,6 +117,7 @@ class DashboardStreamsWidget extends ConsumerWidget {
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
           paused: s.state.toLowerCase() == 'paused',
           posterUrl: api?.imageUrl(s.posterThumb),
+          backdropUrl: api?.imageUrl(s.art),
           device: s.player,
           quality: s.videoResolution.isEmpty ? null : s.videoResolution,
           transcoding: s.transcodeDecision.toLowerCase() == 'transcode',
@@ -135,6 +140,7 @@ class DashboardStreamsWidget extends ConsumerWidget {
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
           paused: s.status.toLowerCase() == 'paused',
           posterUrl: s.posterUrl,
+          backdropUrl: s.backdropUrl,
           device: s.device,
           timeLabel: _timeLabel(s.timePosition, s.timeDuration),
           instance: i,
@@ -156,6 +162,7 @@ class DashboardStreamsWidget extends ConsumerWidget {
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
           paused: s.status.toLowerCase() == 'paused',
           posterUrl: s.posterUrl,
+          backdropUrl: s.backdropUrl,
           device: s.device,
           timeLabel: _timeLabel(s.timePosition, s.timeDuration),
           instance: i,
@@ -187,12 +194,13 @@ class DashboardStreamsWidget extends ConsumerWidget {
         children: <Widget>[
           for (int j = 0; j < top.length; j++) ...<Widget>[
             if (j > 0) const SizedBox(height: Insets.sm),
-            _SessionRow(row: top[j]),
+            _StreamBanner(row: top[j]),
           ],
           if (rows.length > top.length)
             Padding(
               padding: const EdgeInsets.only(top: Insets.sm),
-              child: DashboardIdleRow(text: '+${rows.length - top.length} more'),
+              child:
+                  DashboardIdleRow(text: '+${rows.length - top.length} more'),
             ),
         ],
       );
@@ -225,121 +233,259 @@ class DashboardStreamsWidget extends ConsumerWidget {
   }
 }
 
-class _SessionRow extends StatelessWidget {
-  const _SessionRow({required this.row});
+class _StreamBanner extends StatefulWidget {
+  const _StreamBanner({required this.row});
 
   final _StreamRow row;
 
   @override
+  State<_StreamBanner> createState() => _StreamBannerState();
+}
+
+class _StreamBannerState extends State<_StreamBanner> {
+  PaletteGenerator? _palette;
+  String? _lastPosterUrl;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updateColorScheme();
+  }
+
+  @override
+  void didUpdateWidget(covariant _StreamBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.row.posterUrl != widget.row.posterUrl) {
+      _updateColorScheme();
+    }
+  }
+
+  void _updateColorScheme() {
+    final String? posterUrl = widget.row.posterUrl;
+    if (posterUrl == null || posterUrl == _lastPosterUrl) return;
+    _lastPosterUrl = posterUrl;
+
+    PaletteGenerator.fromImageProvider(
+      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      size: const Size(200, 300),
+    ).then((PaletteGenerator palette) {
+      if (mounted) {
+        setState(() {
+          _palette = palette;
+        });
+      }
+    }).catchError((_) {});
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
+    ThemeData theme = Theme.of(context);
+
+    if (_palette != null) {
+      final Color dominant =
+          _palette!.dominantColor?.color ?? theme.colorScheme.surface;
+      final Color vibrant = _palette!.vibrantColor?.color ??
+          _palette!.lightVibrantColor?.color ??
+          dominant;
+      theme = theme.copyWith(
+        colorScheme: theme.colorScheme.copyWith(
+          primary: vibrant,
+        ),
+      );
+    }
     final ColorScheme cs = theme.colorScheme;
+    final _StreamRow row = widget.row;
+
     final String? poster = row.posterUrl;
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: () => context.go(
-        AtriumRoutes.servicePath(row.instance.kind.name, row.instance.id),
-      ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: SizedBox(
-              width: 40,
-              height: 56,
-              child: (poster == null || poster.isEmpty)
-                  ? _posterFallback(cs)
-                  : CachedNetworkImage(
-                      imageUrl: poster,
-                      fit: BoxFit.cover,
-                      memCacheWidth: 120,
-                      errorWidget: (_, __, ___) => _posterFallback(cs),
+    final String? backdrop =
+        (row.backdropUrl != null && row.backdropUrl!.trim().isNotEmpty)
+            ? row.backdropUrl
+            : poster;
+    final bool hasArt = backdrop != null && backdrop.trim().isNotEmpty;
+
+    final bool isLight = theme.brightness == Brightness.light;
+    final Color scrim = isLight ? Colors.white : Colors.black;
+    final Color onArt = isLight ? const Color(0xFF141414) : Colors.white;
+    final Color titleColor = hasArt ? onArt : cs.onSurface;
+    final Color subColor =
+        hasArt ? onArt.withValues(alpha: 0.78) : cs.onSurfaceVariant;
+
+    return Theme(
+      data: theme,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: SizedBox(
+          height: 78,
+          child: Stack(
+            fit: StackFit.expand,
+            children: <Widget>[
+              if (hasArt)
+                CachedNetworkImage(
+                  imageUrl: backdrop,
+                  fit: BoxFit.cover,
+                  alignment: Alignment.center,
+                  memCacheWidth: 600,
+                  errorWidget: (_, __, ___) => (backdrop != poster &&
+                          poster != null &&
+                          poster.trim().isNotEmpty)
+                      ? CachedNetworkImage(
+                          imageUrl: poster,
+                          fit: BoxFit.cover,
+                          alignment: Alignment.center,
+                          memCacheWidth: 600,
+                          errorWidget: (_, __, ___) =>
+                              Container(color: cs.surfaceContainerHighest),
+                        )
+                      : Container(color: cs.surfaceContainerHighest),
+                )
+              else
+                Container(color: cs.surfaceContainerHighest),
+              if (hasArt)
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: <Color>[
+                        scrim.withValues(alpha: 0.88),
+                        scrim.withValues(alpha: 0.60),
+                        scrim.withValues(alpha: 0.20),
+                      ],
+                      stops: const <double>[0.0, 0.55, 1.0],
                     ),
-            ),
-          ),
-          const SizedBox(width: Insets.md),
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: Text(
-                        row.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleSmall
-                            ?.copyWith(fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                    if (row.quality != null) ...<Widget>[
-                      const SizedBox(width: Insets.sm),
-                      _QualityChip(
-                        label: row.quality!,
-                        transcoding: row.transcoding,
-                      ),
-                    ],
-                  ],
+                  ),
                 ),
-                const SizedBox(height: 2),
-                Row(
-                  children: <Widget>[
-                    Icon(
-                      row.paused
-                          ? Icons.pause_rounded
-                          : Icons.play_arrow_rounded,
-                      size: 14,
-                      color: cs.onSurfaceVariant,
-                    ),
-                    const SizedBox(width: 2),
-                    Expanded(
-                      child: Text(
-                        row.device.isEmpty
-                            ? row.user
-                            : '${row.user} · ${row.device}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall
-                            ?.copyWith(color: cs.onSurfaceVariant),
-                      ),
-                    ),
-                  ],
+              InkWell(
+                onTap: () => context.go(
+                  AtriumRoutes.servicePath(
+                      row.instance.kind.name, row.instance.id),
                 ),
-                const SizedBox(height: 6),
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: LinearProgressIndicator(
-                          value: row.progress,
-                          minHeight: 5,
-                          color: cs.tertiary,
-                          backgroundColor: cs.surfaceContainerHighest,
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  child: Row(
+                    children: <Widget>[
+                      SizedBox(
+                        width: 66,
+                        height: 66,
+                        child: Center(
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                minWidth: 44,
+                                maxWidth: 66,
+                              ),
+                              child: SizedBox(
+                                height: 66,
+                                child: (poster == null || poster.isEmpty)
+                                    ? _posterFallback(cs)
+                                    : CachedNetworkImage(
+                                        imageUrl: poster,
+                                        fit: BoxFit.cover,
+                                        memCacheWidth: 132,
+                                        errorWidget: (_, __, ___) =>
+                                            _posterFallback(cs),
+                                      ),
+                              ),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: Insets.sm),
-                    Text(
-                      row.timeLabel ??
-                          '${(row.progress * 100).toStringAsFixed(0)}%',
-                      style: theme.textTheme.labelSmall
-                          ?.copyWith(color: cs.onSurfaceVariant),
-                    ),
-                  ],
+                      const SizedBox(width: Insets.md),
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Row(
+                              children: <Widget>[
+                                Expanded(
+                                  child: Text(
+                                    row.title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: theme.textTheme.titleSmall?.copyWith(
+                                      fontWeight: FontWeight.w700,
+                                      color: titleColor,
+                                    ),
+                                  ),
+                                ),
+                                if (row.quality != null) ...<Widget>[
+                                  const SizedBox(width: Insets.sm),
+                                  _QualityChip(
+                                    label: row.quality!,
+                                    transcoding: row.transcoding,
+                                  ),
+                                ],
+                              ],
+                            ),
+                            const SizedBox(height: 3),
+                            Row(
+                              children: <Widget>[
+                                Icon(
+                                  row.paused
+                                      ? Icons.pause_rounded
+                                      : Icons.play_arrow_rounded,
+                                  size: 14,
+                                  color: subColor,
+                                ),
+                                const SizedBox(width: 2),
+                                Expanded(
+                                  child: Text(
+                                    row.device.isEmpty
+                                        ? row.user
+                                        : '${row.user} • ${row.device}',
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: theme.textTheme.bodySmall
+                                        ?.copyWith(color: subColor),
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+                            Row(
+                              children: <Widget>[
+                                Expanded(
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(4),
+                                    child: LinearProgressIndicatorM3E(
+                                      size: LinearProgressM3ESize.s,
+                                      shape: ProgressM3EShape.flat,
+                                      value: row.progress.clamp(0, 1),
+                                      activeColor: !row.paused
+                                          ? theme.colorScheme.primary
+                                          : theme.colorScheme.outline,
+                                      trackColor: hasArt
+                                          ? scrim.withValues(alpha: 0.15)
+                                          : cs.surfaceContainerHighest,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: Insets.sm),
+                                Text(
+                                  row.timeLabel ??
+                                      '${(row.progress * 100).toStringAsFixed(0)}%',
+                                  style: theme.textTheme.labelSmall
+                                      ?.copyWith(color: subColor),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
   Widget _posterFallback(ColorScheme cs) => Container(
-        color: cs.surfaceContainerHighest,
+        color: cs.surfaceContainerHigh,
         alignment: Alignment.center,
         child: Icon(
           Icons.play_circle_outline,

--- a/app/lib/src/dashboard/widgets/upcoming_widget.dart
+++ b/app/lib/src/dashboard/widgets/upcoming_widget.dart
@@ -50,12 +50,10 @@ class DashboardUpcomingWidget extends ConsumerWidget {
       }
     }
 
-    final List<CalendarEvent> upcoming = events
-        .where((CalendarEvent e) {
-          final DateTime d = e.date.toLocal();
-          return !d.isBefore(windowStart) && d.isBefore(windowEnd);
-        })
-        .toList()
+    final List<CalendarEvent> upcoming = events.where((CalendarEvent e) {
+      final DateTime d = e.date.toLocal();
+      return !d.isBefore(windowStart) && d.isBefore(windowEnd);
+    }).toList()
       ..sort((CalendarEvent a, CalendarEvent b) => a.date.compareTo(b.date));
     final List<CalendarEvent> top = upcoming.take(5).toList();
 
@@ -126,7 +124,8 @@ class DashboardUpcomingWidget extends ConsumerWidget {
       if (upcoming.length > top.length) {
         rows.add(Padding(
           padding: const EdgeInsets.only(top: Insets.sm),
-          child: DashboardIdleRow(text: '+${upcoming.length - top.length} more'),
+          child:
+              DashboardIdleRow(text: '+${upcoming.length - top.length} more'),
         ));
       }
       body = Column(

--- a/app/lib/src/health_providers.dart
+++ b/app/lib/src/health_providers.dart
@@ -16,5 +16,5 @@ final Provider<HealthProbe> healthProbeProvider = Provider<HealthProbe>((
 /// (unreachable) - far more meaningful than a blind `GET /`.
 final instanceHealthProvider =
     FutureProvider.family<Health, Instance>((Ref ref, Instance instance) {
-      return ref.watch(healthProbeProvider).check(instance);
-    });
+  return ref.watch(healthProbeProvider).check(instance);
+});

--- a/app/lib/src/preferences.dart
+++ b/app/lib/src/preferences.dart
@@ -58,9 +58,14 @@ class Preferences {
         fontFamily: fontFamily != null ? fontFamily() : this.fontFamily,
         themeSource: themeSource ?? this.themeSource,
         paletteStyle: paletteStyle ?? this.paletteStyle,
-        customSeedColorHex: customSeedColorHex != null ? customSeedColorHex() : this.customSeedColorHex,
-        customImagePath: customImagePath != null ? customImagePath() : this.customImagePath,
-        customImageColorsCsv: customImageColorsCsv != null ? customImageColorsCsv() : this.customImageColorsCsv,
+        customSeedColorHex: customSeedColorHex != null
+            ? customSeedColorHex()
+            : this.customSeedColorHex,
+        customImagePath:
+            customImagePath != null ? customImagePath() : this.customImagePath,
+        customImageColorsCsv: customImageColorsCsv != null
+            ? customImageColorsCsv()
+            : this.customImageColorsCsv,
       );
 }
 

--- a/app/lib/src/profile_io.dart
+++ b/app/lib/src/profile_io.dart
@@ -33,8 +33,7 @@ class ProfileIo {
 
     final bool? includeSecrets = await showDialog<bool>(
       context: context,
-      builder: (BuildContext context) =>
-          _ExportOptionsDialog(profile: profile),
+      builder: (BuildContext context) => _ExportOptionsDialog(profile: profile),
     );
     if (includeSecrets == null) {
       return;
@@ -125,8 +124,7 @@ class ProfileIo {
     }
     final bool? confirmed = await showDialog<bool>(
       context: context,
-      builder: (BuildContext context) =>
-          _ImportConfirmDialog(profile: preview),
+      builder: (BuildContext context) => _ImportConfirmDialog(profile: preview),
     );
     if (confirmed != true) {
       return;
@@ -191,7 +189,8 @@ class _ExportOptionsDialogState extends State<_ExportOptionsDialog> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: <Widget>[
-          Text('"${widget.profile.name}" - $n ${n == 1 ? 'instance' : 'instances'}'),
+          Text(
+              '"${widget.profile.name}" - $n ${n == 1 ? 'instance' : 'instances'}'),
           const SizedBox(height: 16),
           SwitchListTile(
             contentPadding: EdgeInsets.zero,

--- a/app/lib/src/router.dart
+++ b/app/lib/src/router.dart
@@ -44,15 +44,15 @@ final Provider<GoRouter> routerProvider = Provider<GoRouter>((Ref ref) {
           StatefulNavigationShell shell,
         ) =>
             Consumer(
-              builder: (BuildContext context, WidgetRef ref, Widget? child) {
-                final List<Instance> instances = ref.watch(activeInstancesProvider);
-                final Profile? profile = ref.watch(activeProfileProvider);
-                return ScaffoldWithNavBar(
-                  navigationShell: shell,
-                  drawer: ServicesDrawer(instances: instances, profile: profile),
-                );
-              },
-            ),
+          builder: (BuildContext context, WidgetRef ref, Widget? child) {
+            final List<Instance> instances = ref.watch(activeInstancesProvider);
+            final Profile? profile = ref.watch(activeProfileProvider);
+            return ScaffoldWithNavBar(
+              navigationShell: shell,
+              drawer: ServicesDrawer(instances: instances, profile: profile),
+            );
+          },
+        ),
         branches: <StatefulShellBranch>[
           StatefulShellBranch(
             routes: <RouteBase>[

--- a/app/lib/src/screens/activity_screen.dart
+++ b/app/lib/src/screens/activity_screen.dart
@@ -49,8 +49,8 @@ class ActivityScreen extends ConsumerWidget {
         message: 'Active streams and transfers will show up here.',
       );
     } else {
-      final bool showStreams = streamsState.streams.isNotEmpty ||
-          streamsState.errors.isNotEmpty;
+      final bool showStreams =
+          streamsState.streams.isNotEmpty || streamsState.errors.isNotEmpty;
       final bool showDownloads = downloadsState.downloads.isNotEmpty ||
           downloadsState.errors.isNotEmpty;
       body = M3RefreshIndicator(
@@ -74,8 +74,7 @@ class ActivityScreen extends ConsumerWidget {
                   onTap: () => _openStream(context, stream),
                 ),
             ],
-            if (showStreams && showDownloads)
-              const SizedBox(height: Insets.sm),
+            if (showStreams && showDownloads) const SizedBox(height: Insets.sm),
             if (showDownloads) ...<Widget>[
               _SectionHeader(
                 title: 'Transfers',
@@ -89,8 +88,7 @@ class ActivityScreen extends ConsumerWidget {
               ),
               if (downloadsState.errors.isNotEmpty)
                 ActivitySourceErrorChips(errors: downloadsState.errors),
-              for (final ActivityDownload download
-                  in downloadsState.downloads)
+              for (final ActivityDownload download in downloadsState.downloads)
                 ActivityDownloadCard(
                   key: ValueKey<String>(download.key),
                   download: download,

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -42,7 +42,8 @@ class RadarrCalendarEvent extends CalendarEvent {
   @override
   DateTime get date {
     final DateTime start = DateTime(month.year, month.month, 1);
-    final DateTime end = DateTime(month.year, month.month + 1, 1).subtract(const Duration(seconds: 1));
+    final DateTime end = DateTime(month.year, month.month + 1, 1)
+        .subtract(const Duration(seconds: 1));
 
     final DateTime? digital = _parseDate(movie.digitalRelease);
     if (digital != null && digital.isAfter(start) && digital.isBefore(end)) {
@@ -73,8 +74,7 @@ class RadarrCalendarEvent extends CalendarEvent {
   String get primaryTitle => movie.title;
 
   @override
-  String get subtitle =>
-      movie.year == null ? 'Movie' : '${movie.year} - Movie';
+  String get subtitle => movie.year == null ? 'Movie' : '${movie.year} - Movie';
 
   @override
   String? get posterUrl => _image('poster');
@@ -136,7 +136,6 @@ class SonarrCalendarEvent extends CalendarEvent {
       ?.remoteUrl;
 }
 
-
 /// Aggregated calendar provider for all active Sonarr and Radarr instances.
 final globalCalendarProvider =
     FutureProvider.autoDispose.family<List<CalendarEvent>, DateTime>((
@@ -151,7 +150,8 @@ final globalCalendarProvider =
       futures.add(
         ref.watch(radarrCalendarProvider((instance, month)).future).then(
               (List<RadarrMovie> movies) => movies
-                  .map((RadarrMovie m) => RadarrCalendarEvent(m, instance, month))
+                  .map((RadarrMovie m) =>
+                      RadarrCalendarEvent(m, instance, month))
                   .toList(),
             ),
       );
@@ -240,7 +240,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
           builder: (BuildContext context, StateSetter setModalState) {
             final ThemeData theme = Theme.of(context);
             return Container(
-              padding: const EdgeInsets.fromLTRB(Insets.md, 0, Insets.md, Insets.md),
+              padding:
+                  const EdgeInsets.fromLTRB(Insets.md, 0, Insets.md, Insets.md),
               height: 320,
               child: Column(
                 children: <Widget>[
@@ -252,7 +253,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                         icon: const Icon(Icons.chevron_left),
                         onPressed: () {
                           setModalState(() {
-                            _visibleMonth = DateTime(_visibleMonth.year - 1, _visibleMonth.month);
+                            _visibleMonth = DateTime(
+                                _visibleMonth.year - 1, _visibleMonth.month);
                           });
                           setState(() {});
                         },
@@ -267,7 +269,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                         icon: const Icon(Icons.chevron_right),
                         onPressed: () {
                           setModalState(() {
-                            _visibleMonth = DateTime(_visibleMonth.year + 1, _visibleMonth.month);
+                            _visibleMonth = DateTime(
+                                _visibleMonth.year + 1, _visibleMonth.month);
                           });
                           setState(() {});
                         },
@@ -278,7 +281,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                   // Month Grid (3x4)
                   Expanded(
                     child: GridView.builder(
-                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
                         crossAxisCount: 4,
                         childAspectRatio: 1.6,
                         crossAxisSpacing: Insets.sm,
@@ -288,11 +292,13 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                       itemBuilder: (BuildContext context, int index) {
                         final int monthNum = index + 1;
                         final bool isCurrent = _visibleMonth.month == monthNum;
-                        final String monthName = DateFormat('MMMM').format(DateTime(2000, monthNum));
+                        final String monthName =
+                            DateFormat('MMMM').format(DateTime(2000, monthNum));
                         return InkWell(
                           onTap: () {
                             setState(() {
-                              _visibleMonth = DateTime(_visibleMonth.year, monthNum);
+                              _visibleMonth =
+                                  DateTime(_visibleMonth.year, monthNum);
                             });
                             Navigator.pop(context);
                           },
@@ -343,15 +349,17 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
         ref.watch(globalCalendarProvider(_visibleMonth));
 
     // Prefetch and cache adjacent months to ensure instant navigation transitions
-    final DateTime nextMonth = DateTime(_visibleMonth.year, _visibleMonth.month + 1);
-    final DateTime prevMonth = DateTime(_visibleMonth.year, _visibleMonth.month - 1);
+    final DateTime nextMonth =
+        DateTime(_visibleMonth.year, _visibleMonth.month + 1);
+    final DateTime prevMonth =
+        DateTime(_visibleMonth.year, _visibleMonth.month - 1);
     ref.watch(globalCalendarProvider(nextMonth));
     ref.watch(globalCalendarProvider(prevMonth));
 
     final bool hasCalendarServices = ref.watch(activeInstancesProvider).any(
-      (Instance i) =>
-          i.kind == ServiceKind.radarr || i.kind == ServiceKind.sonarr,
-    );
+          (Instance i) =>
+              i.kind == ServiceKind.radarr || i.kind == ServiceKind.sonarr,
+        );
 
     if (!hasCalendarServices) {
       return Scaffold(
@@ -392,7 +400,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
         title: const Text('Calendar'),
       ),
       body: M3RefreshIndicator(
-        onRefresh: () async => ref.invalidate(globalCalendarProvider(_visibleMonth)),
+        onRefresh: () async =>
+            ref.invalidate(globalCalendarProvider(_visibleMonth)),
         child: AsyncValueView<List<CalendarEvent>>(
           value: calendar,
           onRetry: () => ref.invalidate(globalCalendarProvider(_visibleMonth)),
@@ -408,8 +417,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
             }
 
             // Selected day entries
-            final DateTime selectedDayKey =
-                DateTime(_selectedDay.year, _selectedDay.month, _selectedDay.day);
+            final DateTime selectedDayKey = DateTime(
+                _selectedDay.year, _selectedDay.month, _selectedDay.day);
             final List<CalendarEvent> selectedDayEntries =
                 entriesMap[selectedDayKey] ?? [];
 
@@ -450,7 +459,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                                   Flexible(
                                     child: Text(
                                       DateFormat('MMMM').format(_visibleMonth),
-                                      style: theme.textTheme.titleLarge?.copyWith(
+                                      style:
+                                          theme.textTheme.titleLarge?.copyWith(
                                         fontWeight: FontWeight.bold,
                                       ),
                                       maxLines: 1,
@@ -475,7 +485,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                       onPressed: _goToToday,
                       style: TextButton.styleFrom(
                         visualDensity: VisualDensity.compact,
-                        padding: const EdgeInsets.symmetric(horizontal: Insets.sm),
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: Insets.sm),
                       ),
                       icon: const Icon(Icons.today, size: 16),
                       label: const Text('Today'),
@@ -528,22 +539,27 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                   child: GridView.builder(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
-                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 7,
                       childAspectRatio: 0.82,
                     ),
                     itemCount: gridDays.length,
                     itemBuilder: (BuildContext context, int index) {
                       final DateTime day = gridDays[index];
-                      final bool isCurrentMonth = day.month == _visibleMonth.month;
-                      final DateTime dayKey = DateTime(day.year, day.month, day.day);
+                      final bool isCurrentMonth =
+                          day.month == _visibleMonth.month;
+                      final DateTime dayKey =
+                          DateTime(day.year, day.month, day.day);
                       final bool isSelected = dayKey == selectedDayKey;
                       final bool isToday = dayKey == todayKey;
 
-                      final List<CalendarEvent> dayEntries = entriesMap[dayKey] ?? [];
+                      final List<CalendarEvent> dayEntries =
+                          entriesMap[dayKey] ?? [];
 
                       // Dots calculations
-                      final bool hasDownloaded = dayEntries.any((CalendarEvent e) => e.hasFile);
+                      final bool hasDownloaded =
+                          dayEntries.any((CalendarEvent e) => e.hasFile);
                       final bool hasUpcoming = dayEntries.any(
                         (CalendarEvent e) => !e.hasFile && e.date.isAfter(now),
                       );
@@ -565,7 +581,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                                 color: isSelected
                                     ? theme.colorScheme.primary
                                     : isToday
-                                        ? theme.colorScheme.primaryContainer.withValues(alpha: 0.45)
+                                        ? theme.colorScheme.primaryContainer
+                                            .withValues(alpha: 0.45)
                                         : Colors.transparent,
                                 shape: BoxShape.circle,
                                 border: isToday && !isSelected
@@ -582,8 +599,11 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                                       ? theme.colorScheme.onPrimary
                                       : isCurrentMonth
                                           ? theme.colorScheme.onSurface
-                                          : theme.colorScheme.onSurface.withValues(alpha: 0.35),
-                                  fontWeight: isSelected || isToday ? FontWeight.bold : FontWeight.normal,
+                                          : theme.colorScheme.onSurface
+                                              .withValues(alpha: 0.35),
+                                  fontWeight: isSelected || isToday
+                                      ? FontWeight.bold
+                                      : FontWeight.normal,
                                 ),
                               ),
                             ),
@@ -593,9 +613,12 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                               child: Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 children: <Widget>[
-                                  if (hasDownloaded) const _Dot(color: Colors.green),
-                                  if (hasUpcoming) _Dot(color: theme.colorScheme.primary),
-                                  if (hasMissing) _Dot(color: theme.colorScheme.error),
+                                  if (hasDownloaded)
+                                    const _Dot(color: Colors.green),
+                                  if (hasUpcoming)
+                                    _Dot(color: theme.colorScheme.primary),
+                                  if (hasMissing)
+                                    _Dot(color: theme.colorScheme.error),
                                 ],
                               ),
                             ),
@@ -621,7 +644,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                           Icon(
                             Icons.calendar_today_outlined,
                             size: 40,
-                            color: theme.colorScheme.outline.withValues(alpha: 0.5),
+                            color: theme.colorScheme.outline
+                                .withValues(alpha: 0.5),
                           ),
                           const SizedBox(height: Insets.sm),
                           Text(
@@ -726,14 +750,18 @@ class _EventTile extends ConsumerWidget {
     if (event is RadarrCalendarEvent) {
       final RadarrMovie movie = (event as RadarrCalendarEvent).movie;
       final RadarrApi? api = ref.watch(radarrApiProvider(instance)).value;
-      final RadarrImage? poster =
-          movie.images.firstWhereOrNull((RadarrImage i) => i.coverType == 'poster');
+      final RadarrImage? poster = movie.images
+          .firstWhereOrNull((RadarrImage i) => i.coverType == 'poster');
       final String? imageUrl = poster == null ? null : api?.posterUrl(poster);
 
       final DateTime eventDate = event.date;
-      if (movie.digitalRelease != null && DateTime.tryParse(movie.digitalRelease!)?.toLocal().day == eventDate.day) {
+      if (movie.digitalRelease != null &&
+          DateTime.tryParse(movie.digitalRelease!)?.toLocal().day ==
+              eventDate.day) {
         releaseType = 'Digital Release';
-      } else if (movie.physicalRelease != null && DateTime.tryParse(movie.physicalRelease!)?.toLocal().day == eventDate.day) {
+      } else if (movie.physicalRelease != null &&
+          DateTime.tryParse(movie.physicalRelease!)?.toLocal().day ==
+              eventDate.day) {
         releaseType = 'Physical Release';
       } else {
         releaseType = 'Cinema Release';
@@ -752,17 +780,19 @@ class _EventTile extends ConsumerWidget {
     } else if (event is SonarrCalendarEvent) {
       final SonarrEpisode episode = (event as SonarrCalendarEvent).episode;
       final SonarrApi? api = ref.watch(sonarrApiProvider(instance)).value;
-      final SonarrImage? poster =
-          episode.series?.images.firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
+      final SonarrImage? poster = episode.series?.images
+          .firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
       final String? imageUrl = poster == null ? null : api?.posterUrl(poster);
 
-      releaseType = 'S${episode.seasonNumber.toString().padLeft(2, '0')}E${episode.episodeNumber.toString().padLeft(2, '0')}';
+      releaseType =
+          'S${episode.seasonNumber.toString().padLeft(2, '0')}E${episode.episodeNumber.toString().padLeft(2, '0')}';
 
       onTap = () => Navigator.of(context, rootNavigator: true).push(
             MaterialPageRoute<void>(
               builder: (_) => SeriesDetailScreen(
                 instance: instance,
-                series: episode.series ?? SonarrSeries(id: episode.seriesId, title: ''),
+                series: episode.series ??
+                    SonarrSeries(id: episode.seriesId, title: ''),
               ),
             ),
           );
@@ -846,7 +876,8 @@ class _EventTile extends ConsumerWidget {
                       crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
                         Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 8, vertical: 2),
                           decoration: BoxDecoration(
                             color: theme.colorScheme.surfaceContainerHighest,
                             borderRadius: BorderRadius.circular(6),
@@ -890,7 +921,9 @@ class _EventTile extends ConsumerWidget {
                         ),
                         const SizedBox(width: Insets.md),
                         Icon(
-                          event.monitored ? Icons.bookmark : Icons.bookmark_border,
+                          event.monitored
+                              ? Icons.bookmark
+                              : Icons.bookmark_border,
                           size: 14,
                           color: theme.colorScheme.outline,
                         ),
@@ -908,7 +941,8 @@ class _EventTile extends ConsumerWidget {
               ),
               const SizedBox(width: Insets.sm),
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                 decoration: BoxDecoration(
                   color: bg,
                   borderRadius: BorderRadius.circular(12),
@@ -952,7 +986,8 @@ class _Poster extends StatelessWidget {
       fit: BoxFit.cover,
       memCacheWidth: 100,
       memCacheHeight: 150,
-      placeholder: (_, __) => Container(color: theme.colorScheme.surfaceContainerHighest),
+      placeholder: (_, __) =>
+          Container(color: theme.colorScheme.surfaceContainerHighest),
       errorWidget: (_, __, ___) => fallback,
     );
   }

--- a/app/lib/src/screens/custom_headers_screen.dart
+++ b/app/lib/src/screens/custom_headers_screen.dart
@@ -207,8 +207,7 @@ class _InstanceHeadersScreenState
     if (result == null || !mounted) {
       return;
     }
-    final Instance? current =
-        ref.read(instanceByIdProvider(widget.instanceId));
+    final Instance? current = ref.read(instanceByIdProvider(widget.instanceId));
     if (current == null) {
       return;
     }
@@ -471,8 +470,7 @@ class _HeaderDialog extends StatefulWidget {
 
 class _HeaderDialogState extends State<_HeaderDialog> {
   /// RFC 7230 token characters - the set allowed in an HTTP header name.
-  static final RegExp _tokenPattern =
-      RegExp(r'^[!#$%&*+.^_|~0-9A-Za-z-]+$');
+  static final RegExp _tokenPattern = RegExp(r'^[!#$%&*+.^_|~0-9A-Za-z-]+$');
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   late final TextEditingController _name =

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -85,7 +85,8 @@ class ServicesDrawer extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
-    final List<Profile> profiles = ref.watch(profileListProvider).value ?? <Profile>[];
+    final List<Profile> profiles =
+        ref.watch(profileListProvider).value ?? <Profile>[];
 
     return Drawer(
       child: SafeArea(
@@ -170,12 +171,20 @@ class ServicesDrawer extends ConsumerWidget {
                         return _ProfilePill(
                           label: profile?.name ?? 'Default',
                           onTap: () async {
-                            final RenderBox button = pillContext.findRenderObject()! as RenderBox;
-                            final RenderBox overlay = Navigator.of(context, rootNavigator: true).overlay!.context.findRenderObject()! as RenderBox;
+                            final RenderBox button =
+                                pillContext.findRenderObject()! as RenderBox;
+                            final RenderBox overlay =
+                                Navigator.of(context, rootNavigator: true)
+                                    .overlay!
+                                    .context
+                                    .findRenderObject()! as RenderBox;
                             final RelativeRect position = RelativeRect.fromRect(
                               Rect.fromPoints(
-                                button.localToGlobal(const Offset(0, -100), ancestor: overlay),
-                                button.localToGlobal(button.size.bottomRight(Offset.zero), ancestor: overlay),
+                                button.localToGlobal(const Offset(0, -100),
+                                    ancestor: overlay),
+                                button.localToGlobal(
+                                    button.size.bottomRight(Offset.zero),
+                                    ancestor: overlay),
                               ),
                               Offset.zero & overlay.size,
                             );
@@ -222,7 +231,8 @@ class ServicesDrawer extends ConsumerWidget {
                                   value: 'manage',
                                   child: Row(
                                     children: <Widget>[
-                                      Icon(Icons.manage_accounts_outlined, size: 16),
+                                      Icon(Icons.manage_accounts_outlined,
+                                          size: 16),
                                       SizedBox(width: Insets.sm),
                                       Text('Manage profiles'),
                                     ],
@@ -237,7 +247,8 @@ class ServicesDrawer extends ConsumerWidget {
                               } else {
                                 // Capture before the await: switching profiles
                                 // rebuilds the tree under this context.
-                                final GoRouter router = GoRouter.of(pillContext);
+                                final GoRouter router =
+                                    GoRouter.of(pillContext);
                                 final ScaffoldState? scaffold =
                                     Scaffold.maybeOf(pillContext);
                                 await ref

--- a/app/lib/src/screens/instance_form_screen.dart
+++ b/app/lib/src/screens/instance_form_screen.dart
@@ -32,7 +32,8 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
   /// qBittorrent 5.2+ supports both username/password and API-key auth; this
   /// tracks which the user picked (qBit only).
   bool _qbitUseApiKey = false;
-  final TextEditingController _pollingInterval = TextEditingController(text: '5');
+  final TextEditingController _pollingInterval =
+      TextEditingController(text: '5');
 
   ServiceKind _kind = ServiceKind.sonarr;
   UrlMode _urlMode = UrlMode.auto;
@@ -85,8 +86,7 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
   InstanceAuth _buildAuth() {
     return switch (_kind.authStyle) {
       AuthStyle.apiKey => InstanceAuth.apiKey(apiKey: _apiKey.text.trim()),
-      AuthStyle.plexToken =>
-        InstanceAuth.plexToken(token: _apiKey.text.trim()),
+      AuthStyle.plexToken => InstanceAuth.plexToken(token: _apiKey.text.trim()),
       AuthStyle.userPass => InstanceAuth.userPass(
           username: _username.text.trim(),
           password: _password.text,
@@ -113,8 +113,8 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
     // After creating, make it active.
     await ref.read(activeProfileIdProvider.notifier).select(profile.id);
 
-    final String id =
-        widget.instanceId ?? ref.read(profileRepositoryProvider).newInstanceId();
+    final String id = widget.instanceId ??
+        ref.read(profileRepositoryProvider).newInstanceId();
     final Instance instance = Instance(
       id: id,
       name: _name.text.trim(),
@@ -287,7 +287,8 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
                 keyboardType: TextInputType.number,
                 validator: (String? v) {
                   final int? val = int.tryParse(v?.trim() ?? '');
-                  if (val == null || val < 1) return 'Must be at least 1 second';
+                  if (val == null || val < 1)
+                    return 'Must be at least 1 second';
                   return null;
                 },
               ),

--- a/app/lib/src/screens/service_detail_screen.dart
+++ b/app/lib/src/screens/service_detail_screen.dart
@@ -66,159 +66,166 @@ class _ServiceDetailScreenState extends ConsumerState<ServiceDetailScreen> {
       );
     }
     return PopScope<Object?>(
-      canPop: false,
-      onPopInvokedWithResult: (bool didPop, Object? result) {
-        if (didPop) return;
-        // A back press while a drawer is open only closes that drawer.
-        final ScaffoldState? scaffold = _scaffoldKey.currentState;
-        if (scaffold?.isDrawerOpen ?? false) {
-          scaffold!.closeDrawer();
-          return;
-        }
-        if (scaffold?.isEndDrawerOpen ?? false) {
-          scaffold!.closeEndDrawer();
-          return;
-        }
-        context.goNamed(AtriumRoutes.dashboardName);
-      },
-      child: Scaffold(
-        key: _scaffoldKey,
-        // Fixed narrow edge zone so it does not eat the horizontal-scroll
-        // gesture on the media-server poster/resume rows hosted here.
-        drawerEdgeDragWidth: 32,
-        drawer: ServicesDrawer(
-          instances: ref.watch(activeInstancesProvider),
-          profile: ref.watch(activeProfileProvider),
-        ),
-        endDrawer: instance.kind == ServiceKind.qbittorrent
-            ? QbittorrentFilterDrawer(instance: instance)
-            : null,
-      appBar: AppBar(
-        leading: Builder(
-          builder: (BuildContext context) {
-            return IconButton(
-              icon: const Icon(Icons.menu),
-              onPressed: () {
-                Scaffold.of(context).openDrawer();
-              },
-            );
-          },
-        ),
-        title: instance.kind == ServiceKind.emby
-            ? TextField(
-                readOnly: true,
-                onTap: () {
-                  showSearch<void>(
-                    context: context,
-                    useRootNavigator: true,
-                    delegate: EmbySearchDelegate(instance: instance),
-                  );
-                },
-                style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                      fontSize: 16,
-                      color: Theme.of(context).colorScheme.onSecondaryContainer,
-                    ),
-                decoration: InputDecoration(
-                  hintText: 'Search Emby...',
-                  hintStyle: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                        fontSize: 16,
-                        color: Theme.of(context)
-                            .colorScheme
-                            .onSecondaryContainer
-                            .withValues(alpha: 0.7),
-                      ),
-                  prefixIcon: Icon(
-                    Icons.search,
-                    color: Theme.of(context).colorScheme.onSecondaryContainer,
-                  ),
-                  contentPadding: const EdgeInsets.symmetric(
-                    vertical: 10.0,
-                    horizontal: 20.0,
-                  ),
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(32),
-                    borderSide: BorderSide.none,
-                  ),
-                  enabledBorder: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(32),
-                    borderSide: BorderSide.none,
-                  ),
-                  filled: true,
-                  fillColor: Theme.of(context).colorScheme.secondaryContainer,
-                ),
-              )
-            : Text(instance.name),
-        actions: <Widget>[
-          if (instance.kind == ServiceKind.jellyfin ||
-              instance.kind == ServiceKind.plex ||
-              instance.kind == ServiceKind.seerr)
-            IconButton(
-              tooltip: 'Search',
-              icon: const Icon(Icons.search),
-              onPressed: () {
-                showSearch<void>(
-                  context: context,
-                  // Root navigator: the search page is pushed imperatively,
-                  // so it must not ride the branch navigator (GoRouter shell
-                  // rebuilds sweep it).
-                  useRootNavigator: true,
-                  delegate: switch (instance.kind) {
-                    ServiceKind.emby => EmbySearchDelegate(instance: instance),
-                    ServiceKind.plex => PlexSearchDelegate(instance: instance),
-                    ServiceKind.seerr =>
-                      SeerrSearchDelegate(instance: instance),
-                    _ => JellyfinSearchDelegate(instance: instance),
-                  },
-                );
-              },
-            ),
-          if (instance.kind == ServiceKind.emby)
-            Consumer(
-              builder: (BuildContext context, WidgetRef ref, Widget? child) {
-                final int activeTab =
-                    ref.watch(embyActiveTabBarIndexProvider(instance));
-                if (activeTab == 0) {
-                  return const SizedBox.shrink();
-                }
-                final EmbyViewMode viewMode =
-                    ref.watch(embyViewModeProvider(instance));
+        canPop: false,
+        onPopInvokedWithResult: (bool didPop, Object? result) {
+          if (didPop) return;
+          // A back press while a drawer is open only closes that drawer.
+          final ScaffoldState? scaffold = _scaffoldKey.currentState;
+          if (scaffold?.isDrawerOpen ?? false) {
+            scaffold!.closeDrawer();
+            return;
+          }
+          if (scaffold?.isEndDrawerOpen ?? false) {
+            scaffold!.closeEndDrawer();
+            return;
+          }
+          context.goNamed(AtriumRoutes.dashboardName);
+        },
+        child: Scaffold(
+          key: _scaffoldKey,
+          // Fixed narrow edge zone so it does not eat the horizontal-scroll
+          // gesture on the media-server poster/resume rows hosted here.
+          drawerEdgeDragWidth: 32,
+          drawer: ServicesDrawer(
+            instances: ref.watch(activeInstancesProvider),
+            profile: ref.watch(activeProfileProvider),
+          ),
+          endDrawer: instance.kind == ServiceKind.qbittorrent
+              ? QbittorrentFilterDrawer(instance: instance)
+              : null,
+          appBar: AppBar(
+            leading: Builder(
+              builder: (BuildContext context) {
                 return IconButton(
-                  tooltip: viewMode == EmbyViewMode.grid
-                      ? 'Switch to List View'
-                      : 'Switch to Grid View',
-                  icon: Icon(viewMode == EmbyViewMode.grid
-                      ? Icons.view_headline
-                      : Icons.grid_view),
+                  icon: const Icon(Icons.menu),
                   onPressed: () {
-                    ref.read(embyViewModeProvider(instance).notifier).state =
-                        viewMode == EmbyViewMode.grid
-                            ? EmbyViewMode.list
-                            : EmbyViewMode.grid;
+                    Scaffold.of(context).openDrawer();
                   },
                 );
               },
             ),
-          if (instance.kind == ServiceKind.qbittorrent)
-            QbittorrentAppBarActions(instance: instance),
-
-          if (instance.kind == ServiceKind.emby ||
-              instance.kind == ServiceKind.jellyfin)
-            IconButton(
-              tooltip: 'Settings',
-              icon: const Icon(Icons.settings),
-              onPressed: () => pushScreen<void>(
-                context,
-                instance.kind == ServiceKind.emby
-                    ? EmbySettingsScreen(instance: instance)
-                    : JellyfinSettingsScreen(instance: instance),
-              ),
-            ),
-
-
-        ],
-      ),
-      body: _bodyFor(instance),
-    ));
+            title: instance.kind == ServiceKind.emby
+                ? TextField(
+                    readOnly: true,
+                    onTap: () {
+                      showSearch<void>(
+                        context: context,
+                        useRootNavigator: true,
+                        delegate: EmbySearchDelegate(instance: instance),
+                      );
+                    },
+                    style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                          fontSize: 16,
+                          color: Theme.of(context)
+                              .colorScheme
+                              .onSecondaryContainer,
+                        ),
+                    decoration: InputDecoration(
+                      hintText: 'Search Emby...',
+                      hintStyle:
+                          Theme.of(context).textTheme.bodyLarge?.copyWith(
+                                fontSize: 16,
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .onSecondaryContainer
+                                    .withValues(alpha: 0.7),
+                              ),
+                      prefixIcon: Icon(
+                        Icons.search,
+                        color:
+                            Theme.of(context).colorScheme.onSecondaryContainer,
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                        vertical: 10.0,
+                        horizontal: 20.0,
+                      ),
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(32),
+                        borderSide: BorderSide.none,
+                      ),
+                      enabledBorder: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(32),
+                        borderSide: BorderSide.none,
+                      ),
+                      filled: true,
+                      fillColor:
+                          Theme.of(context).colorScheme.secondaryContainer,
+                    ),
+                  )
+                : Text(instance.name),
+            actions: <Widget>[
+              if (instance.kind == ServiceKind.jellyfin ||
+                  instance.kind == ServiceKind.plex ||
+                  instance.kind == ServiceKind.seerr)
+                IconButton(
+                  tooltip: 'Search',
+                  icon: const Icon(Icons.search),
+                  onPressed: () {
+                    showSearch<void>(
+                      context: context,
+                      // Root navigator: the search page is pushed imperatively,
+                      // so it must not ride the branch navigator (GoRouter shell
+                      // rebuilds sweep it).
+                      useRootNavigator: true,
+                      delegate: switch (instance.kind) {
+                        ServiceKind.emby =>
+                          EmbySearchDelegate(instance: instance),
+                        ServiceKind.plex =>
+                          PlexSearchDelegate(instance: instance),
+                        ServiceKind.seerr =>
+                          SeerrSearchDelegate(instance: instance),
+                        _ => JellyfinSearchDelegate(instance: instance),
+                      },
+                    );
+                  },
+                ),
+              if (instance.kind == ServiceKind.emby)
+                Consumer(
+                  builder:
+                      (BuildContext context, WidgetRef ref, Widget? child) {
+                    final int activeTab =
+                        ref.watch(embyActiveTabBarIndexProvider(instance));
+                    if (activeTab == 0) {
+                      return const SizedBox.shrink();
+                    }
+                    final EmbyViewMode viewMode =
+                        ref.watch(embyViewModeProvider(instance));
+                    return IconButton(
+                      tooltip: viewMode == EmbyViewMode.grid
+                          ? 'Switch to List View'
+                          : 'Switch to Grid View',
+                      icon: Icon(viewMode == EmbyViewMode.grid
+                          ? Icons.view_headline
+                          : Icons.grid_view),
+                      onPressed: () {
+                        ref
+                                .read(embyViewModeProvider(instance).notifier)
+                                .state =
+                            viewMode == EmbyViewMode.grid
+                                ? EmbyViewMode.list
+                                : EmbyViewMode.grid;
+                      },
+                    );
+                  },
+                ),
+              if (instance.kind == ServiceKind.qbittorrent)
+                QbittorrentAppBarActions(instance: instance),
+              if (instance.kind == ServiceKind.emby ||
+                  instance.kind == ServiceKind.jellyfin)
+                IconButton(
+                  tooltip: 'Settings',
+                  icon: const Icon(Icons.settings),
+                  onPressed: () => pushScreen<void>(
+                    context,
+                    instance.kind == ServiceKind.emby
+                        ? EmbySettingsScreen(instance: instance)
+                        : JellyfinSettingsScreen(instance: instance),
+                  ),
+                ),
+            ],
+          ),
+          body: _bodyFor(instance),
+        ));
   }
 
   Widget _bodyFor(Instance instance) {

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -78,13 +78,17 @@ class SettingsScreen extends ConsumerWidget {
           const Divider(),
           const _SectionHeader('Font'),
           Padding(
-            padding: const EdgeInsets.symmetric(horizontal: Insets.lg, vertical: Insets.xs),
+            padding: const EdgeInsets.symmetric(
+                horizontal: Insets.lg, vertical: Insets.xs),
             child: DropdownMenu<String?>(
               initialSelection: prefs.fontFamily,
               expandedInsets: EdgeInsets.zero,
               inputDecorationTheme: InputDecorationTheme(
                 filled: true,
-                fillColor: Theme.of(context).colorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+                fillColor: Theme.of(context)
+                    .colorScheme
+                    .surfaceContainerHighest
+                    .withValues(alpha: 0.3),
                 border: OutlineInputBorder(
                   borderRadius: BorderRadius.circular(12),
                   borderSide: BorderSide(
@@ -136,8 +140,7 @@ class SettingsScreen extends ConsumerWidget {
             leading: const Icon(Icons.language_outlined),
             title: const Text('Custom Headers'),
             subtitle: const Text('Add headers for reverse-proxy auth'),
-            onTap: () =>
-                pushScreen<void>(context, const CustomHeadersScreen()),
+            onTap: () => pushScreen<void>(context, const CustomHeadersScreen()),
           ),
           const Divider(),
           const _SectionHeader('Data'),
@@ -269,7 +272,7 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
   void initState() {
     super.initState();
     final prefs = ref.read(preferencesProvider);
-    
+
     _localSource = prefs.themeSource;
     _localSeedColorHex = prefs.customSeedColorHex ?? '6750A4';
     _localImagePath = prefs.customImagePath;
@@ -282,9 +285,10 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
     } else {
       _activeTab = 2;
     }
-    
+
     // Load stored dynamic colors if available, preventing recalculation
-    if (prefs.customImageColorsCsv != null && prefs.customImageColorsCsv!.isNotEmpty) {
+    if (prefs.customImageColorsCsv != null &&
+        prefs.customImageColorsCsv!.isNotEmpty) {
       try {
         _extractedColors = prefs.customImageColorsCsv!
             .split(',')
@@ -315,11 +319,15 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
       );
       final List<Color> rawColors = <Color>{
         if (palette.vibrantColor?.color != null) palette.vibrantColor!.color,
-        if (palette.lightVibrantColor?.color != null) palette.lightVibrantColor!.color,
-        if (palette.darkVibrantColor?.color != null) palette.darkVibrantColor!.color,
+        if (palette.lightVibrantColor?.color != null)
+          palette.lightVibrantColor!.color,
+        if (palette.darkVibrantColor?.color != null)
+          palette.darkVibrantColor!.color,
         if (palette.mutedColor?.color != null) palette.mutedColor!.color,
-        if (palette.lightMutedColor?.color != null) palette.lightMutedColor!.color,
-        if (palette.darkMutedColor?.color != null) palette.darkMutedColor!.color,
+        if (palette.lightMutedColor?.color != null)
+          palette.lightMutedColor!.color,
+        if (palette.darkMutedColor?.color != null)
+          palette.darkMutedColor!.color,
         if (palette.dominantColor?.color != null) palette.dominantColor!.color,
       }.toList();
 
@@ -347,7 +355,8 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
 
       // Store colors to prevent recalculation when reloading page
       final csv = distinctColors
-          .map((c) => c.toARGB32().toRadixString(16).padLeft(8, '0').substring(2))
+          .map((c) =>
+              c.toARGB32().toRadixString(16).padLeft(8, '0').substring(2))
           .join(',');
 
       if (!mounted) return;
@@ -414,7 +423,8 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
       if (!mounted) return;
       if (_extractedColors.isNotEmpty) {
         final Color seed = _extractedColors.first;
-        final String hex = seed.toARGB32().toRadixString(16).padLeft(8, '0').substring(2);
+        final String hex =
+            seed.toARGB32().toRadixString(16).padLeft(8, '0').substring(2);
         setState(() {
           _localSeedColorHex = hex;
         });
@@ -430,7 +440,7 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
 
   Widget _buildTabButton(int index, String label, ColorScheme cs) {
     final isSelected = _activeTab == index;
-    
+
     return Expanded(
       child: GestureDetector(
         onTap: () async {
@@ -491,8 +501,8 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
           color: c,
           shape: BoxShape.circle,
           border: Border.all(
-            color: isSelected 
-                ? Theme.of(context).colorScheme.primary 
+            color: isSelected
+                ? Theme.of(context).colorScheme.primary
                 : Colors.transparent,
             width: 3,
           ),
@@ -509,7 +519,8 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
 
   @override
   Widget build(BuildContext context) {
-    final PreferencesController controller = ref.read(preferencesProvider.notifier);
+    final PreferencesController controller =
+        ref.read(preferencesProvider.notifier);
     final systemColorScheme = ref.watch(systemColorSchemeProvider);
     final systemLight = systemColorScheme.light;
     final theme = Theme.of(context);
@@ -517,16 +528,17 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
     // Compute preview color scheme
     final ColorScheme previewColorScheme;
     Color seedColor = const Color(0xFF6750A4);
-    
+
     if (_activeTab == 0) {
       final systemScheme = theme.brightness == Brightness.dark
           ? systemColorScheme.dark
           : systemColorScheme.light;
-      previewColorScheme = systemScheme ?? colorSchemeFromSeedAndStyle(
-        seedColor,
-        _localPaletteStyle,
-        theme.brightness,
-      );
+      previewColorScheme = systemScheme ??
+          colorSchemeFromSeedAndStyle(
+            seedColor,
+            _localPaletteStyle,
+            theme.brightness,
+          );
     } else {
       if (_localSeedColorHex != null) {
         final int? val = int.tryParse(_localSeedColorHex!, radix: 16);
@@ -546,7 +558,6 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
       children: <Widget>[
         _ThemePalettePreviewGrid(colorScheme: previewColorScheme),
         const SizedBox(height: Insets.md),
-        
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
@@ -558,25 +569,28 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
           ],
         ),
         const SizedBox(height: Insets.md),
-
         if (_activeTab != 0) ...[
           DropdownButtonFormField<PaletteStyle>(
             initialValue: _localPaletteStyle,
             decoration: InputDecoration(
               labelText: 'Palette style',
               filled: true,
-              fillColor: previewColorScheme.surfaceContainerHighest.withValues(alpha: 0.3),
+              fillColor: previewColorScheme.surfaceContainerHighest
+                  .withValues(alpha: 0.3),
               border: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: previewColorScheme.outlineVariant),
+                borderSide:
+                    BorderSide(color: previewColorScheme.outlineVariant),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: previewColorScheme.outlineVariant),
+                borderSide:
+                    BorderSide(color: previewColorScheme.outlineVariant),
               ),
               focusedBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.circular(12),
-                borderSide: BorderSide(color: previewColorScheme.primary, width: 2),
+                borderSide:
+                    BorderSide(color: previewColorScheme.primary, width: 2),
               ),
               labelStyle: TextStyle(color: previewColorScheme.onSurfaceVariant),
             ),
@@ -607,7 +621,6 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
           ),
           const SizedBox(height: Insets.md),
         ],
-        
         AnimatedSize(
           duration: const Duration(milliseconds: 300),
           curve: Curves.easeInOut,
@@ -622,7 +635,8 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                     padding: const EdgeInsets.all(Insets.md),
                     child: Row(
                       children: [
-                        Icon(Icons.android, color: previewColorScheme.primary, size: 28),
+                        Icon(Icons.android,
+                            color: previewColorScheme.primary, size: 28),
                         const SizedBox(width: Insets.md),
                         Expanded(
                           child: Column(
@@ -630,12 +644,14 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                             children: [
                               Text(
                                 'System Wallpaper Colors',
-                                style: TextStyle(fontWeight: FontWeight.bold, color: previewColorScheme.onSurface),
+                                style: TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    color: previewColorScheme.onSurface),
                               ),
                               const SizedBox(height: 2),
                               Text(
-                                systemLight != null 
-                                    ? 'Using platform dynamic color matching (Android 12+).' 
+                                systemLight != null
+                                    ? 'Using platform dynamic color matching (Android 12+).'
                                     : 'Dynamic colors unavailable. Using default theme.',
                                 style: TextStyle(
                                   fontSize: 11,
@@ -649,7 +665,6 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                     ),
                   ),
                 ),
-              
               if (_activeTab == 2) ...[
                 if (_localImagePath != null) ...[
                   Row(
@@ -675,7 +690,8 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                             child: Image.file(
                               File(_localImagePath!),
                               fit: BoxFit.contain,
-                              errorBuilder: (context, error, stackTrace) => Center(
+                              errorBuilder: (context, error, stackTrace) =>
+                                  Center(
                                 child: Icon(
                                   Icons.broken_image_outlined,
                                   color: previewColorScheme.onSurfaceVariant,
@@ -701,7 +717,9 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                             ),
                             const SizedBox(height: 4),
                             Text(
-                              _localImagePath!.split(Platform.pathSeparator).last,
+                              _localImagePath!
+                                  .split(Platform.pathSeparator)
+                                  .last,
                               maxLines: 2,
                               overflow: TextOverflow.ellipsis,
                               style: TextStyle(
@@ -716,12 +734,17 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                               style: FilledButton.styleFrom(
                                 backgroundColor: previewColorScheme.primary,
                                 foregroundColor: previewColorScheme.onPrimary,
-                                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                                padding: const EdgeInsets.symmetric(
+                                    horizontal: 16, vertical: 8),
                                 minimumSize: Size.zero,
                                 tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                               ),
-                              icon: const Icon(Icons.change_circle_outlined, size: 16),
-                              label: const Text('Change', style: TextStyle(fontSize: 12, fontWeight: FontWeight.bold)),
+                              icon: const Icon(Icons.change_circle_outlined,
+                                  size: 16),
+                              label: const Text('Change',
+                                  style: TextStyle(
+                                      fontSize: 12,
+                                      fontWeight: FontWeight.bold)),
                             ),
                           ],
                         ),
@@ -730,7 +753,6 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                   ),
                   const SizedBox(height: Insets.md),
                 ],
-                
                 if (_isExtracting) ...[
                   const Center(
                     child: Padding(
@@ -745,16 +767,23 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                       padding: const EdgeInsets.symmetric(vertical: 4.0),
                       child: Row(
                         children: _extractedColors.map((Color seed) {
-                          final String hex = seed.toARGB32().toRadixString(16).padLeft(8, '0').substring(2);
-                          final bool isSelected = _localSource == ThemeSource.customImage &&
-                              _localSeedColorHex?.toLowerCase() == hex.toLowerCase();
-                          
-                          final ColorScheme previewScheme = colorSchemeFromSeedAndStyle(
+                          final String hex = seed
+                              .toARGB32()
+                              .toRadixString(16)
+                              .padLeft(8, '0')
+                              .substring(2);
+                          final bool isSelected =
+                              _localSource == ThemeSource.customImage &&
+                                  _localSeedColorHex?.toLowerCase() ==
+                                      hex.toLowerCase();
+
+                          final ColorScheme previewScheme =
+                              colorSchemeFromSeedAndStyle(
                             seed,
                             _localPaletteStyle,
                             theme.brightness,
                           );
-                          
+
                           // Include two tertiary colors in the 6-band dynamic pill stack
                           final List<Color> pillColors = [
                             previewScheme.primary,
@@ -764,7 +793,7 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                             previewScheme.tertiaryContainer,
                             previewScheme.surfaceContainerHigh,
                           ];
-                          
+
                           return Padding(
                             padding: const EdgeInsets.only(right: 14.0),
                             child: _ColorPillStack(
@@ -776,9 +805,11 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                                   _localSource = ThemeSource.customImage;
                                   _localSeedColorHex = hex;
                                 });
-                                await controller.setThemeSource(ThemeSource.customImage);
+                                await controller
+                                    .setThemeSource(ThemeSource.customImage);
                                 await controller.setCustomSeedColorHex(hex);
-                                await controller.setCustomImagePath(_localImagePath);
+                                await controller
+                                    .setCustomImagePath(_localImagePath);
                               },
                             ),
                           );
@@ -793,21 +824,28 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                     decoration: BoxDecoration(
                       color: previewColorScheme.surfaceContainerHigh,
                       borderRadius: BorderRadius.circular(16),
-                      border: Border.all(color: previewColorScheme.outlineVariant),
+                      border:
+                          Border.all(color: previewColorScheme.outlineVariant),
                     ),
                     child: Column(
                       children: [
-                        Icon(Icons.wallpaper_outlined, size: 40, color: previewColorScheme.onSurfaceVariant),
+                        Icon(Icons.wallpaper_outlined,
+                            size: 40,
+                            color: previewColorScheme.onSurfaceVariant),
                         const SizedBox(height: Insets.sm),
                         Text(
                           'No custom wallpaper loaded',
-                          style: TextStyle(fontWeight: FontWeight.w600, color: previewColorScheme.onSurface),
+                          style: TextStyle(
+                              fontWeight: FontWeight.w600,
+                              color: previewColorScheme.onSurface),
                         ),
                         const SizedBox(height: Insets.xs),
                         Text(
                           'Upload an image to generate dynamic color palettes',
                           textAlign: TextAlign.center,
-                          style: TextStyle(fontSize: 12, color: previewColorScheme.onSurfaceVariant),
+                          style: TextStyle(
+                              fontSize: 12,
+                              color: previewColorScheme.onSurfaceVariant),
                         ),
                         const SizedBox(height: Insets.md),
                         FilledButton.icon(
@@ -824,17 +862,22 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                   ),
                 ],
               ],
-              
               if (_activeTab == 1) ...[
                 Wrap(
                   spacing: 12,
                   runSpacing: 12,
                   children: [
                     ..._presets.map((Color c) {
-                      final String hex = c.toARGB32().toRadixString(16).padLeft(8, '0').substring(2);
-                      final bool isSelected = _localSource == ThemeSource.preset &&
-                          _localSeedColorHex?.toLowerCase() == hex.toLowerCase();
-                      
+                      final String hex = c
+                          .toARGB32()
+                          .toRadixString(16)
+                          .padLeft(8, '0')
+                          .substring(2);
+                      final bool isSelected =
+                          _localSource == ThemeSource.preset &&
+                              _localSeedColorHex?.toLowerCase() ==
+                                  hex.toLowerCase();
+
                       return _buildColorCircle(c, isSelected, () async {
                         setState(() {
                           _localSource = ThemeSource.preset;
@@ -844,12 +887,18 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                         await controller.setCustomSeedColorHex(hex);
                       });
                     }),
-                    
-                    if (_localSeedColorHex != null && !_presets.any((c) => 
-                        c.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toLowerCase() == 
-                        _localSeedColorHex!.toLowerCase())) ...[
+                    if (_localSeedColorHex != null &&
+                        !_presets.any((c) =>
+                            c
+                                .toARGB32()
+                                .toRadixString(16)
+                                .padLeft(8, '0')
+                                .substring(2)
+                                .toLowerCase() ==
+                            _localSeedColorHex!.toLowerCase())) ...[
                       _buildColorCircle(
-                        Color(int.parse(_localSeedColorHex!, radix: 16) | 0xFF000000),
+                        Color(int.parse(_localSeedColorHex!, radix: 16) |
+                            0xFF000000),
                         _localSource == ThemeSource.preset,
                         () async {
                           setState(() {
@@ -859,20 +908,25 @@ class _ThemeSettingsSectionState extends ConsumerState<_ThemeSettingsSection> {
                         },
                       ),
                     ],
-                    
                     GestureDetector(
                       onTap: () async {
                         final Color current = _localSeedColorHex != null
-                            ? Color(int.parse(_localSeedColorHex!, radix: 16) | 0xFF000000)
+                            ? Color(int.parse(_localSeedColorHex!, radix: 16) |
+                                0xFF000000)
                             : const Color(0xFF6750A4);
-                        
+
                         final Color? picked = await showDialog<Color>(
                           context: context,
-                          builder: (context) => _ColorPickerDialog(initialColor: current),
+                          builder: (context) =>
+                              _ColorPickerDialog(initialColor: current),
                         );
-                        
+
                         if (picked != null) {
-                          final String hex = picked.toARGB32().toRadixString(16).padLeft(8, '0').substring(2);
+                          final String hex = picked
+                              .toARGB32()
+                              .toRadixString(16)
+                              .padLeft(8, '0')
+                              .substring(2);
                           setState(() {
                             _localSource = ThemeSource.preset;
                             _localSeedColorHex = hex;
@@ -987,13 +1041,17 @@ class _ThemePalettePreviewGrid extends StatelessWidget {
             childAspectRatio: 2.3,
             children: [
               _buildSwatch('Primary', cs.primary, cs.onPrimary),
-              _buildSwatch('Primary Container', cs.primaryContainer, cs.onPrimaryContainer),
+              _buildSwatch('Primary Container', cs.primaryContainer,
+                  cs.onPrimaryContainer),
               _buildSwatch('Secondary', cs.secondary, cs.onSecondary),
-              _buildSwatch('Secondary Container', cs.secondaryContainer, cs.onSecondaryContainer),
+              _buildSwatch('Secondary Container', cs.secondaryContainer,
+                  cs.onSecondaryContainer),
               _buildSwatch('Tertiary', cs.tertiary, cs.onTertiary),
-              _buildSwatch('Tertiary Container', cs.tertiaryContainer, cs.onTertiaryContainer),
+              _buildSwatch('Tertiary Container', cs.tertiaryContainer,
+                  cs.onTertiaryContainer),
               _buildSwatch('Surface', cs.surface, cs.onSurface),
-              _buildSwatch('Surface Container High', cs.surfaceContainerHigh, cs.onSurfaceVariant),
+              _buildSwatch('Surface Container High', cs.surfaceContainerHigh,
+                  cs.onSurfaceVariant),
               _buildSwatch('Outline', cs.outline, cs.surface),
               _buildSwatch('Inverse Primary', cs.inversePrimary, cs.primary),
             ],
@@ -1030,9 +1088,8 @@ class _ColorPillStack extends StatelessWidget {
             decoration: BoxDecoration(
               borderRadius: BorderRadius.circular(27),
               border: Border.all(
-                color: isSelected
-                    ? activeColorScheme.primary
-                    : Colors.transparent,
+                color:
+                    isSelected ? activeColorScheme.primary : Colors.transparent,
                 width: 3.5,
               ),
             ),
@@ -1100,7 +1157,12 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
     _saturation = hsl.saturation;
     _lightness = hsl.lightness;
     _hexController = TextEditingController(
-      text: _currentColor.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toUpperCase(),
+      text: _currentColor
+          .toARGB32()
+          .toRadixString(16)
+          .padLeft(8, '0')
+          .substring(2)
+          .toUpperCase(),
     );
   }
 
@@ -1112,8 +1174,14 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
 
   void _updateColor() {
     setState(() {
-      _currentColor = HSLColor.fromAHSL(1.0, _hue, _saturation, _lightness).toColor();
-      _hexController.text = _currentColor.toARGB32().toRadixString(16).padLeft(8, '0').substring(2).toUpperCase();
+      _currentColor =
+          HSLColor.fromAHSL(1.0, _hue, _saturation, _lightness).toColor();
+      _hexController.text = _currentColor
+          .toARGB32()
+          .toRadixString(16)
+          .padLeft(8, '0')
+          .substring(2)
+          .toUpperCase();
     });
   }
 
@@ -1141,7 +1209,6 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
               ),
             ),
             const SizedBox(height: Insets.lg),
-            
             const Align(
               alignment: Alignment.centerLeft,
               child: Text('Hue', style: TextStyle(fontWeight: FontWeight.w500)),
@@ -1166,10 +1233,10 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
                 },
               ),
             ),
-            
             const Align(
               alignment: Alignment.centerLeft,
-              child: Text('Saturation', style: TextStyle(fontWeight: FontWeight.w500)),
+              child: Text('Saturation',
+                  style: TextStyle(fontWeight: FontWeight.w500)),
             ),
             Slider(
               value: _saturation,
@@ -1183,10 +1250,10 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
                 });
               },
             ),
-            
             const Align(
               alignment: Alignment.centerLeft,
-              child: Text('Lightness', style: TextStyle(fontWeight: FontWeight.w500)),
+              child: Text('Lightness',
+                  style: TextStyle(fontWeight: FontWeight.w500)),
             ),
             Slider(
               value: _lightness,
@@ -1201,7 +1268,6 @@ class _ColorPickerDialogState extends State<_ColorPickerDialog> {
               },
             ),
             const SizedBox(height: Insets.md),
-            
             TextField(
               controller: _hexController,
               decoration: InputDecoration(
@@ -1259,7 +1325,8 @@ class _HueTrackShape extends SliderTrackShape {
   }) {
     final double trackHeight = sliderTheme.trackHeight ?? 12.0;
     final double trackLeft = offset.dx;
-    final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
+    final double trackTop =
+        offset.dy + (parentBox.size.height - trackHeight) / 2;
     final double trackWidth = parentBox.size.width;
     return Rect.fromLTWH(trackLeft, trackTop, trackWidth, trackHeight);
   }
@@ -1283,15 +1350,15 @@ class _HueTrackShape extends SliderTrackShape {
       offset: offset,
       sliderTheme: sliderTheme,
     );
-    
+
     final List<Color> colors = List.generate(360, (index) {
       return HSLColor.fromAHSL(1.0, index.toDouble(), 1.0, 0.5).toColor();
     });
-    
+
     final Paint paint = Paint()
       ..shader = LinearGradient(colors: colors).createShader(rect)
       ..style = PaintingStyle.fill;
-    
+
     canvas.drawRRect(
       RRect.fromRectAndRadius(rect, const Radius.circular(6)),
       paint,

--- a/app/lib/src/screens/wake_on_lan_screen.dart
+++ b/app/lib/src/screens/wake_on_lan_screen.dart
@@ -122,9 +122,8 @@ class _WakeOnLanScreenState extends ConsumerState<WakeOnLanScreen> {
     if (profile == null) {
       return;
     }
-    final List<WolDevice> next = profile.wolDevices
-        .where((WolDevice d) => d.id != device.id)
-        .toList();
+    final List<WolDevice> next =
+        profile.wolDevices.where((WolDevice d) => d.id != device.id).toList();
     await ref
         .read(profileListProvider.notifier)
         .updateProfile(profile.copyWith(wolDevices: next));

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   service_tautulli:
   url_launcher: ^6.3.2
   google_fonts: ^8.1.0
+  palette_generator: ^0.3.3+7
 dev_dependencies:
   flutter_launcher_icons: ^0.14.3
   flutter_lints: ^6.0.0

--- a/app/test/activity_screen_test.dart
+++ b/app/test/activity_screen_test.dart
@@ -82,25 +82,25 @@ void main() {
           ],
         ),
         jf.jellyfinFastSessionsProvider(jellyfin).overrideWith(
-          (Ref ref) => Stream<List<jf.ActiveSession>>.value(
-            const <jf.ActiveSession>[
-              jf.ActiveSession(
-                id: 's1',
-                user: 'bob',
-                device: 'Jellyfin Web',
-                status: 'Playing',
-                showTitle: 'The Wire',
-                progressPercent: 40,
-                timePosition: '0:10:00',
-                timeDuration: '1:00:00',
-                positionTicks: 0,
-                durationTicks: 0,
-                volumeLevel: 100,
-                isMuted: false,
+              (Ref ref) => Stream<List<jf.ActiveSession>>.value(
+                const <jf.ActiveSession>[
+                  jf.ActiveSession(
+                    id: 's1',
+                    user: 'bob',
+                    device: 'Jellyfin Web',
+                    status: 'Playing',
+                    showTitle: 'The Wire',
+                    progressPercent: 40,
+                    timePosition: '0:10:00',
+                    timeDuration: '1:00:00',
+                    positionTicks: 0,
+                    durationTicks: 0,
+                    volumeLevel: 100,
+                    isMuted: false,
+                  ),
+                ],
               ),
-            ],
-          ),
-        ),
+            ),
       ],
     );
     expect(find.text('Now Streaming'), findsOneWidget);

--- a/app/test/dashboard_layout_test.dart
+++ b/app/test/dashboard_layout_test.dart
@@ -28,10 +28,14 @@ void main() {
 
   group('mergeLayout', () {
     test('keeps stored order, appends missing kinds enabled, drops dupes', () {
-      final List<DashboardWidgetConfig> merged = mergeLayout(<DashboardWidgetConfig>[
-        const DashboardWidgetConfig(kind: DashboardWidgetKind.health, enabled: false),
-        const DashboardWidgetConfig(kind: DashboardWidgetKind.downloads, enabled: true),
-        const DashboardWidgetConfig(kind: DashboardWidgetKind.health, enabled: true), // dupe
+      final List<DashboardWidgetConfig> merged =
+          mergeLayout(<DashboardWidgetConfig>[
+        const DashboardWidgetConfig(
+            kind: DashboardWidgetKind.health, enabled: false),
+        const DashboardWidgetConfig(
+            kind: DashboardWidgetKind.downloads, enabled: true),
+        const DashboardWidgetConfig(
+            kind: DashboardWidgetKind.health, enabled: true), // dupe
       ]);
       expect(merged, hasLength(DashboardWidgetKind.values.length));
       expect(merged[0].kind, DashboardWidgetKind.health);
@@ -39,11 +43,13 @@ void main() {
       expect(merged[1].kind, DashboardWidgetKind.downloads);
       // The remaining kinds follow in enum order, enabled.
       expect(merged[2].kind, DashboardWidgetKind.streams);
-      expect(merged.skip(2).every((DashboardWidgetConfig c) => c.enabled), isTrue);
+      expect(
+          merged.skip(2).every((DashboardWidgetConfig c) => c.enabled), isTrue);
     });
 
     test('empty stored input yields the default layout', () {
-      final List<DashboardWidgetConfig> merged = mergeLayout(const <DashboardWidgetConfig>[]);
+      final List<DashboardWidgetConfig> merged =
+          mergeLayout(const <DashboardWidgetConfig>[]);
       expect(
         merged.map((DashboardWidgetConfig c) => c.kind).toList(),
         DashboardWidgetKind.values,
@@ -54,8 +60,10 @@ void main() {
 
   test('encodeLayout round-trips through decodeLayout', () {
     final List<DashboardWidgetConfig> layout = <DashboardWidgetConfig>[
-      const DashboardWidgetConfig(kind: DashboardWidgetKind.diskSpace, enabled: false),
-      const DashboardWidgetConfig(kind: DashboardWidgetKind.upcoming, enabled: true),
+      const DashboardWidgetConfig(
+          kind: DashboardWidgetKind.diskSpace, enabled: false),
+      const DashboardWidgetConfig(
+          kind: DashboardWidgetKind.upcoming, enabled: true),
     ];
     final List<DashboardWidgetConfig> back = decodeLayout(encodeLayout(layout));
     expect(back, hasLength(2));
@@ -77,7 +85,8 @@ void main() {
           .setEnabled(DashboardWidgetKind.requests, false);
       final DashboardWidgetConfig requests = container
           .read(dashboardLayoutProvider)
-          .firstWhere((DashboardWidgetConfig c) => c.kind == DashboardWidgetKind.requests);
+          .firstWhere((DashboardWidgetConfig c) =>
+              c.kind == DashboardWidgetKind.requests);
       expect(requests.enabled, isFalse);
     });
 
@@ -106,7 +115,8 @@ void main() {
         DashboardWidgetKind.diskSpace,
       ]);
       // The disabled widget is still present, at the end.
-      final List<DashboardWidgetConfig> all = container.read(dashboardLayoutProvider);
+      final List<DashboardWidgetConfig> all =
+          container.read(dashboardLayoutProvider);
       expect(all.last.kind, DashboardWidgetKind.streams);
       expect(all.last.enabled, isFalse);
     });

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -159,24 +159,25 @@ void main() {
           ),
         ),
         jf.jellyfinSessionsProvider(jelly).overrideWith(
-          (Ref ref) => Stream<List<jf.ActiveSession>>.value(<jf.ActiveSession>[
-            const jf.ActiveSession(
-              id: 's1',
-              user: 'Bob',
-              device: 'Web',
-              status: 'Playing',
-              showTitle: 'Breaking Bad',
-              episodeName: 'Pilot',
-              progressPercent: 55,
-              timePosition: '0:10:00',
-              timeDuration: '0:45:00',
-              positionTicks: 0,
-              durationTicks: 0,
-              volumeLevel: 100,
-              isMuted: false,
+              (Ref ref) =>
+                  Stream<List<jf.ActiveSession>>.value(<jf.ActiveSession>[
+                const jf.ActiveSession(
+                  id: 's1',
+                  user: 'Bob',
+                  device: 'Web',
+                  status: 'Playing',
+                  showTitle: 'Breaking Bad',
+                  episodeName: 'Pilot',
+                  progressPercent: 55,
+                  timePosition: '0:10:00',
+                  timeDuration: '0:45:00',
+                  positionTicks: 0,
+                  durationTicks: 0,
+                  volumeLevel: 100,
+                  isMuted: false,
+                ),
+              ]),
             ),
-          ]),
-        ),
       ],
       DashboardStreamsWidget(
         tautulliInstances: <Instance>[tau],
@@ -342,8 +343,8 @@ void main() {
               packageTemp: 55,
               cores: <GlancesCpuCore>[],
             ),
-            memory:
-                GlancesMemory(percentage: 63, used: 8000000000, total: 16000000000),
+            memory: GlancesMemory(
+                percentage: 63, used: 8000000000, total: 16000000000),
             swap: GlancesSwap(percentage: 0, used: 0, total: 0),
             network: <GlancesNetwork>[],
             disks: <GlancesDisk>[

--- a/app/test/new_services_render_test.dart
+++ b/app/test/new_services_render_test.dart
@@ -82,7 +82,8 @@ void main() {
     expect(find.text('Ubuntu.24.04.iso'), findsOneWidget);
   });
 
-  testWidgets('TautulliHome renders active streams', (WidgetTester tester) async {
+  testWidgets('TautulliHome renders active streams',
+      (WidgetTester tester) async {
     final Instance instance = _instance(ServiceKind.tautulli);
     await _pump(
       tester,
@@ -144,7 +145,8 @@ void main() {
     expect(find.text('Bob'), findsOneWidget);
   });
 
-  testWidgets('BazarrHome renders wanted-subtitles rows', (WidgetTester tester) async {
+  testWidgets('BazarrHome renders wanted-subtitles rows',
+      (WidgetTester tester) async {
     final Instance instance = _instance(ServiceKind.bazarr);
     await _pump(
       tester,
@@ -158,7 +160,9 @@ void main() {
             BazarrWantedRow(
               title: 'Breaking Bad',
               subtitle: 'S01E01 · Pilot',
-              missing: <BazarrSubtitle>[BazarrSubtitle(name: 'English', code2: 'en')],
+              missing: <BazarrSubtitle>[
+                BazarrSubtitle(name: 'English', code2: 'en')
+              ],
               isMovie: false,
             ),
           ],
@@ -232,7 +236,8 @@ void main() {
     expect(find.text('Movies'), findsOneWidget);
   });
 
-  testWidgets('CalendarScreen renders Radarr aggregated entries', (WidgetTester tester) async {
+  testWidgets('CalendarScreen renders Radarr aggregated entries',
+      (WidgetTester tester) async {
     tester.view.physicalSize = const Size(800, 1200);
     tester.view.devicePixelRatio = 1.0;
     addTearDown(tester.view.resetPhysicalSize);
@@ -270,5 +275,4 @@ void main() {
     expect(find.text('Inception'), findsOneWidget);
     expect(find.text('Missing'), findsOneWidget);
   });
-
 }

--- a/app/test/plex_parity_test.dart
+++ b/app/test/plex_parity_test.dart
@@ -165,8 +165,8 @@ void main() {
         plexApiProvider(instance)
             .overrideWith((Ref ref) async => PlexApi(Dio(), token: 'tok')),
         plexItemDetailProvider((instance, '100')).overrideWith(
-          (Ref ref) async =>
-              const PlexMetadata(ratingKey: '100', title: 'The Wire', type: 'show'),
+          (Ref ref) async => const PlexMetadata(
+              ratingKey: '100', title: 'The Wire', type: 'show'),
         ),
         plexChildrenProvider((instance, '100')).overrideWith(
           (Ref ref) async => const <PlexMetadata>[
@@ -291,8 +291,12 @@ void main() {
         plexOnDeckProvider(instance).overrideWith(
           (Ref ref) async => const <PlexMetadata>[
             PlexMetadata(
-                ratingKey: '10', title: 'Blade Runner', year: 1982,
-                type: 'movie', viewOffset: 600000, duration: 6000000),
+                ratingKey: '10',
+                title: 'Blade Runner',
+                year: 1982,
+                type: 'movie',
+                viewOffset: 600000,
+                duration: 6000000),
           ],
         ),
         plexRecentlyAddedProvider(instance)

--- a/app/test/seerr_rework_test.dart
+++ b/app/test/seerr_rework_test.dart
@@ -205,7 +205,8 @@ void main() {
     );
   });
 
-  testWidgets('Request tile renders color-coded status pills and inline actions',
+  testWidgets(
+      'Request tile renders color-coded status pills and inline actions',
       (WidgetTester tester) async {
     final Instance instance = _instance();
 

--- a/app/test/settings_features_test.dart
+++ b/app/test/settings_features_test.dart
@@ -73,8 +73,7 @@ void main() {
     expect(find.text('AA:BB:CC:DD:EE:FF - 255.255.255.255:9'), findsOneWidget);
   });
 
-  testWidgets(
-      'CustomHeadersScreen renders global headers and the instance row',
+  testWidgets('CustomHeadersScreen renders global headers and the instance row',
       (WidgetTester tester) async {
     await _pump(
       tester,

--- a/app/test/sonarr_features_test.dart
+++ b/app/test/sonarr_features_test.dart
@@ -27,31 +27,41 @@ void main() {
       expect(selection, isEmpty);
 
       // Select items
-      container.read(sonarrQueueSelectionProvider(instance).notifier).state = {1, 2};
+      container.read(sonarrQueueSelectionProvider(instance).notifier).state = {
+        1,
+        2
+      };
       selection = container.read(sonarrQueueSelectionProvider(instance));
       expect(selection, containsAll([1, 2]));
 
       // Clear selection
-      container.read(sonarrQueueSelectionProvider(instance).notifier).state = {};
+      container.read(sonarrQueueSelectionProvider(instance).notifier).state =
+          {};
       selection = container.read(sonarrQueueSelectionProvider(instance));
       expect(selection, isEmpty);
     });
 
-    test('sonarrBlocklistSelectionProvider holds selection state correctly', () {
+    test('sonarrBlocklistSelectionProvider holds selection state correctly',
+        () {
       final container = ProviderContainer();
       final instance = _instance();
 
       // Read initial state
-      var selection = container.read(sonarrBlocklistSelectionProvider(instance));
+      var selection =
+          container.read(sonarrBlocklistSelectionProvider(instance));
       expect(selection, isEmpty);
 
       // Select items
-      container.read(sonarrBlocklistSelectionProvider(instance).notifier).state = {3, 4};
+      container
+          .read(sonarrBlocklistSelectionProvider(instance).notifier)
+          .state = {3, 4};
       selection = container.read(sonarrBlocklistSelectionProvider(instance));
       expect(selection, containsAll([3, 4]));
 
       // Clear selection
-      container.read(sonarrBlocklistSelectionProvider(instance).notifier).state = {};
+      container
+          .read(sonarrBlocklistSelectionProvider(instance).notifier)
+          .state = {};
       selection = container.read(sonarrBlocklistSelectionProvider(instance));
       expect(selection, isEmpty);
     });
@@ -74,7 +84,10 @@ void main() {
 
       // Check title and fields render
       expect(find.text('Parse Release Title'), findsOneWidget);
-      expect(find.text('Paste a release name or torrent title below to see how Sonarr parses season, episode, quality, and matching library details.'), findsOneWidget);
+      expect(
+          find.text(
+              'Paste a release name or torrent title below to see how Sonarr parses season, episode, quality, and matching library details.'),
+          findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
       expect(find.text('Parse'), findsOneWidget);
       expect(find.text('Clear'), findsOneWidget);

--- a/packages/core_models/lib/src/instance.dart
+++ b/packages/core_models/lib/src/instance.dart
@@ -26,8 +26,7 @@ abstract class Instance with _$Instance {
     required String name,
 
     /// What service this instance speaks to.
-    @JsonKey(fromJson: _serviceKindFromJson)
-    required ServiceKind kind,
+    @JsonKey(fromJson: _serviceKindFromJson) required ServiceKind kind,
 
     /// URL reachable from the home LAN (e.g., `http://192.168.1.10:8989`).
     /// May be empty if the user only has remote access.

--- a/packages/core_networking/lib/src/dio_factory.dart
+++ b/packages/core_networking/lib/src/dio_factory.dart
@@ -30,7 +30,8 @@ class DioFactory {
   }) async {
     final Uri resolvedUrl = await _resolver.resolve(instance);
     final String baseUrlStr = resolvedUrl.toString();
-    final String baseUrl = baseUrlStr.endsWith('/') ? baseUrlStr : '$baseUrlStr/';
+    final String baseUrl =
+        baseUrlStr.endsWith('/') ? baseUrlStr : '$baseUrlStr/';
 
     final Dio dio = Dio(
       BaseOptions(
@@ -52,10 +53,11 @@ class DioFactory {
     if (instance.allowSelfSignedCerts) {
       // The user has explicitly chosen to skip cert validation for this
       // instance - common with private IPs on self-signed certs.
-      final IOHttpClientAdapter adapter = dio.httpClientAdapter as IOHttpClientAdapter;
+      final IOHttpClientAdapter adapter =
+          dio.httpClientAdapter as IOHttpClientAdapter;
       adapter.createHttpClient = () => HttpClient()
-        ..badCertificateCallback = (X509Certificate _, String __, int ___) =>
-            true;
+        ..badCertificateCallback =
+            (X509Certificate _, String __, int ___) => true;
     }
 
     dio.interceptors.add(

--- a/packages/core_networking/lib/src/network_exception.dart
+++ b/packages/core_networking/lib/src/network_exception.dart
@@ -15,15 +15,15 @@ sealed class NetworkException implements Exception {
         const NetworkTimeoutException('Server took too long to respond.'),
       DioExceptionType.connectionError =>
         NetworkUnreachableException(e.message ?? 'Could not reach the server.'),
-      DioExceptionType.badCertificate =>
-        const NetworkTlsException(
+      DioExceptionType.badCertificate => const NetworkTlsException(
           'TLS certificate not trusted. Enable "Allow self-signed certs" '
           'in this instance\'s settings if you trust the server.',
         ),
       DioExceptionType.cancel =>
         const NetworkCancelledException('Request was cancelled.'),
       DioExceptionType.badResponse => _fromBadResponse(e),
-      DioExceptionType.unknown || _ =>
+      DioExceptionType.unknown ||
+      _ =>
         NetworkUnknownException(e.message ?? 'Unknown network error.'),
     };
   }

--- a/packages/core_networking/lib/src/network_fingerprint.dart
+++ b/packages/core_networking/lib/src/network_fingerprint.dart
@@ -25,10 +25,8 @@ class NetworkFingerprint {
     if (transports.isEmpty) {
       return 'net:none';
     }
-    final List<String> names = transports
-        .map((ConnectivityResult t) => t.name)
-        .toList()
-      ..sort();
+    final List<String> names =
+        transports.map((ConnectivityResult t) => t.name).toList()..sort();
     return 'net:${names.join(',')}';
   }
 

--- a/packages/core_networking/lib/src/polling.dart
+++ b/packages/core_networking/lib/src/polling.dart
@@ -26,8 +26,7 @@ extension PollingRef on Ref {
   /// spinner.
   void pollEvery(Duration interval) {
     final Timer timer = Timer.periodic(interval, (_) {
-      final AppLifecycleState? state =
-          SchedulerBinding.instance.lifecycleState;
+      final AppLifecycleState? state = SchedulerBinding.instance.lifecycleState;
       if (state == null || state == AppLifecycleState.resumed) {
         invalidateSelf();
       }

--- a/packages/core_router/lib/src/scaffold_with_nav_bar.dart
+++ b/packages/core_router/lib/src/scaffold_with_nav_bar.dart
@@ -21,7 +21,8 @@ class ScaffoldWithNavBar extends StatelessWidget {
     return Scaffold(
       body: navigationShell,
       drawer: drawer,
-      drawerEdgeDragWidth: drawer != null ? MediaQuery.sizeOf(context).width * 0.15 : null,
+      drawerEdgeDragWidth:
+          drawer != null ? MediaQuery.sizeOf(context).width * 0.15 : null,
       bottomNavigationBar: NavigationBar(
         selectedIndex: navigationShell.currentIndex,
         onDestinationSelected: _onTap,

--- a/packages/core_storage/lib/src/secure_storage.dart
+++ b/packages/core_storage/lib/src/secure_storage.dart
@@ -16,8 +16,7 @@ class AtriumSecureStorage {
   /// Creates a storage with a real backing store. Inject a custom
   /// [FlutterSecureStorage] in tests.
   AtriumSecureStorage({FlutterSecureStorage? store})
-      : _store = store ??
-            const FlutterSecureStorage();
+      : _store = store ?? const FlutterSecureStorage();
 
   final FlutterSecureStorage _store;
 

--- a/packages/core_ui/lib/core_ui.dart
+++ b/packages/core_ui/lib/core_ui.dart
@@ -20,4 +20,3 @@ export 'src/widgets/overview_box.dart';
 export 'src/widgets/service_tile.dart';
 export 'src/widgets/state_views.dart';
 export 'src/widgets/status_chip.dart';
-

--- a/packages/core_ui/lib/src/performance_logger.dart
+++ b/packages/core_ui/lib/src/performance_logger.dart
@@ -7,20 +7,24 @@ class PerformanceLogger {
   static void logDecodeStart(String imageUrl) {
     if (kDebugMode || kProfileMode) {
       developer.Timeline.startSync('Image Decode: $imageUrl');
-      developer.log('Started decoding image: $imageUrl', name: 'PerformanceLogger');
+      developer.log('Started decoding image: $imageUrl',
+          name: 'PerformanceLogger');
     }
   }
 
   static void logDecodeEnd(String imageUrl) {
     if (kDebugMode || kProfileMode) {
       developer.Timeline.finishSync();
-      developer.log('Finished decoding image: $imageUrl', name: 'PerformanceLogger');
+      developer.log('Finished decoding image: $imageUrl',
+          name: 'PerformanceLogger');
     }
   }
 
   static void logBuildTime(String widgetName, Duration duration) {
     if (kDebugMode || kProfileMode) {
-      developer.log('Widget $widgetName took ${duration.inMilliseconds}ms to build', name: 'PerformanceLogger');
+      developer.log(
+          'Widget $widgetName took ${duration.inMilliseconds}ms to build',
+          name: 'PerformanceLogger');
     }
   }
 }
@@ -39,7 +43,7 @@ class PerformanceLoggerWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (!kDebugMode && !kProfileMode) return child;
-    
+
     final stopwatch = Stopwatch()..start();
     developer.Timeline.timeSync('Build: $name', () {
       // We don't actually pause execution, we just record the time

--- a/packages/core_ui/lib/src/theme.dart
+++ b/packages/core_ui/lib/src/theme.dart
@@ -114,7 +114,8 @@ class _AtriumDynamicColorBuilderState
 
       if (corePalette != null) {
         if (kDebugMode) {
-          debugPrint('dynamic_color: Core palette detected (bypassed schemes).');
+          debugPrint(
+              'dynamic_color: Core palette detected (bypassed schemes).');
         }
         setState(() {
           _light = corePalette.toColorScheme();

--- a/packages/core_ui/lib/src/widgets/expressive_slider.dart
+++ b/packages/core_ui/lib/src/widgets/expressive_slider.dart
@@ -44,7 +44,7 @@ class ExpressiveSliderThumbShape extends SliderComponentShape {
 
 class ExpressiveSliderTrackShape extends SliderTrackShape {
   const ExpressiveSliderTrackShape({
-    this.gap = 8.0, 
+    this.gap = 8.0,
   });
 
   final double gap;
@@ -57,11 +57,16 @@ class ExpressiveSliderTrackShape extends SliderTrackShape {
     bool isEnabled = false,
     bool isDiscrete = false,
   }) {
-    final double overlayWidth = sliderTheme.overlayShape?.getPreferredSize(isEnabled, isDiscrete).width ?? 32.0;
+    final double overlayWidth = sliderTheme.overlayShape
+            ?.getPreferredSize(isEnabled, isDiscrete)
+            .width ??
+        32.0;
     final double trackHeight = sliderTheme.trackHeight ?? 16.0;
     final double trackLeft = offset.dx + overlayWidth / 2;
-    final double trackTop = offset.dy + (parentBox.size.height - trackHeight) / 2;
-    final double trackWidth = math.max(0.0, parentBox.size.width - overlayWidth);
+    final double trackTop =
+        offset.dy + (parentBox.size.height - trackHeight) / 2;
+    final double trackWidth =
+        math.max(0.0, parentBox.size.width - overlayWidth);
     return Rect.fromLTWH(trackLeft, trackTop, trackWidth, trackHeight);
   }
 
@@ -86,9 +91,11 @@ class ExpressiveSliderTrackShape extends SliderTrackShape {
       isEnabled: isEnabled,
       isDiscrete: isDiscrete,
     );
-    
-    final Paint activePaint = Paint()..color = sliderTheme.activeTrackColor ?? Colors.blue;
-    final Paint inactivePaint = Paint()..color = sliderTheme.inactiveTrackColor ?? Colors.grey;
+
+    final Paint activePaint = Paint()
+      ..color = sliderTheme.activeTrackColor ?? Colors.blue;
+    final Paint inactivePaint = Paint()
+      ..color = sliderTheme.inactiveTrackColor ?? Colors.grey;
     final Radius radius = Radius.circular(trackRect.height / 2);
 
     final double minTrackWidth = trackRect.height;
@@ -114,7 +121,8 @@ class ExpressiveSliderTrackShape extends SliderTrackShape {
         trackRect.bottom,
       );
       context.canvas.drawRRect(
-        RRect.fromRectAndRadius(activeRect, Radius.circular(activeRect.width / 2)),
+        RRect.fromRectAndRadius(
+            activeRect, Radius.circular(activeRect.width / 2)),
         activePaint,
       );
     }
@@ -132,8 +140,9 @@ class ExpressiveSliderTrackShape extends SliderTrackShape {
         RRect.fromRectAndRadius(inactiveRect, radius),
         inactivePaint,
       );
-      
-      final Paint dotPaint = Paint()..color = sliderTheme.thumbColor ?? Colors.white;
+
+      final Paint dotPaint = Paint()
+        ..color = sliderTheme.thumbColor ?? Colors.white;
       final double dotRadius = trackRect.height / 8;
       if (trackRect.right - inactiveTrackLeft > dotRadius * 4) {
         context.canvas.drawCircle(
@@ -150,7 +159,8 @@ class ExpressiveSliderTrackShape extends SliderTrackShape {
         trackRect.bottom,
       );
       context.canvas.drawRRect(
-        RRect.fromRectAndRadius(inactiveRect, Radius.circular(inactiveRect.width / 2)),
+        RRect.fromRectAndRadius(
+            inactiveRect, Radius.circular(inactiveRect.width / 2)),
         inactivePaint,
       );
     }

--- a/packages/core_ui/lib/src/widgets/m3_refresh_indicator.dart
+++ b/packages/core_ui/lib/src/widgets/m3_refresh_indicator.dart
@@ -90,7 +90,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
     end: _kDragSizeFactorLimit,
   );
 
-  static final Animatable<double> _oneToZeroTween = Tween<double>(begin: 1.0, end: 0.0);
+  static final Animatable<double> _oneToZeroTween =
+      Tween<double>(begin: 1.0, end: 0.0);
 
   static final _loadingSequence = <RoundedPolygon>[
     MaterialShapes.verySunny,
@@ -139,7 +140,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
   }
 
   bool _shouldStart(ScrollNotification notification) {
-    return ((notification is ScrollStartNotification && notification.dragDetails != null) ||
+    return ((notification is ScrollStartNotification &&
+                notification.dragDetails != null) ||
             (notification is ScrollUpdateNotification &&
                 notification.dragDetails != null &&
                 widget.triggerMode == RefreshIndicatorTriggerMode.anywhere)) &&
@@ -171,7 +173,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
   }
 
   void _checkDragOffset(double containerExtent) {
-    assert(_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed);
+    assert(_status == RefreshIndicatorStatus.drag ||
+        _status == RefreshIndicatorStatus.armed);
     // Custom trigger distance mapping
     double newValue = _dragOffset! / widget.triggerDistance;
     if (_status == RefreshIndicatorStatus.armed) {
@@ -196,16 +199,19 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
       });
       return false;
     }
-    final bool? indicatorAtTopNow = switch (notification.metrics.axisDirection) {
+    final bool? indicatorAtTopNow =
+        switch (notification.metrics.axisDirection) {
       AxisDirection.down || AxisDirection.up => true,
       AxisDirection.left || AxisDirection.right => null,
     };
     if (indicatorAtTopNow != _isIndicatorAtTop) {
-      if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
+      if (_status == RefreshIndicatorStatus.drag ||
+          _status == RefreshIndicatorStatus.armed) {
         _dismiss(RefreshIndicatorStatus.canceled);
       }
     } else if (notification is ScrollUpdateNotification) {
-      if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
+      if (_status == RefreshIndicatorStatus.drag ||
+          _status == RefreshIndicatorStatus.armed) {
         if (notification.metrics.axisDirection == AxisDirection.down) {
           _dragOffset = _dragOffset! - notification.scrollDelta!;
         } else if (notification.metrics.axisDirection == AxisDirection.up) {
@@ -213,12 +219,14 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
         }
         _checkDragOffset(notification.metrics.viewportDimension);
       }
-      if (_status == RefreshIndicatorStatus.armed && notification.dragDetails == null) {
+      if (_status == RefreshIndicatorStatus.armed &&
+          notification.dragDetails == null) {
         // iOS bounce back release trigger
         _show();
       }
     } else if (notification is OverscrollNotification) {
-      if (_status == RefreshIndicatorStatus.drag || _status == RefreshIndicatorStatus.armed) {
+      if (_status == RefreshIndicatorStatus.drag ||
+          _status == RefreshIndicatorStatus.armed) {
         if (notification.metrics.axisDirection == AxisDirection.down) {
           _dragOffset = _dragOffset! - notification.overscroll;
         } else if (notification.metrics.axisDirection == AxisDirection.up) {
@@ -247,7 +255,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
     return false;
   }
 
-  bool _handleIndicatorNotification(OverscrollIndicatorNotification notification) {
+  bool _handleIndicatorNotification(
+      OverscrollIndicatorNotification notification) {
     if (notification.depth != 0 || !notification.leading) {
       return false;
     }
@@ -260,15 +269,18 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
 
   Future<void> _dismiss(RefreshIndicatorStatus newMode) async {
     await Future<void>.value();
-    assert(newMode == RefreshIndicatorStatus.canceled || newMode == RefreshIndicatorStatus.done);
+    assert(newMode == RefreshIndicatorStatus.canceled ||
+        newMode == RefreshIndicatorStatus.done);
     setState(() {
       _status = newMode;
     });
     switch (_status!) {
       case RefreshIndicatorStatus.done:
-        await _scaleController.animateTo(1.0, duration: _kIndicatorScaleDuration);
+        await _scaleController.animateTo(1.0,
+            duration: _kIndicatorScaleDuration);
       case RefreshIndicatorStatus.canceled:
-        await _positionController.animateTo(0.0, duration: _kIndicatorScaleDuration);
+        await _positionController.animateTo(0.0,
+            duration: _kIndicatorScaleDuration);
       case RefreshIndicatorStatus.armed:
       case RefreshIndicatorStatus.drag:
       case RefreshIndicatorStatus.refresh:
@@ -293,7 +305,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
     _pendingRefreshFuture = completer.future;
     _status = RefreshIndicatorStatus.snap;
     _positionController
-        .animateTo(1.0 / _kDragSizeFactorLimit, duration: _kIndicatorSnapDuration)
+        .animateTo(1.0 / _kDragSizeFactorLimit,
+            duration: _kIndicatorSnapDuration)
         .then<void>((void value) {
       if (mounted && _status == RefreshIndicatorStatus.snap) {
         setState(() {
@@ -312,7 +325,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
   }
 
   Future<void> show({bool atTop = true}) {
-    if (_status != RefreshIndicatorStatus.refresh && _status != RefreshIndicatorStatus.snap) {
+    if (_status != RefreshIndicatorStatus.refresh &&
+        _status != RefreshIndicatorStatus.snap) {
       if (_status == null) {
         _start(atTop ? AxisDirection.down : AxisDirection.up);
       }
@@ -353,7 +367,8 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
     final sz = widget.indicatorSize;
 
     final bool showIndeterminateIndicator =
-        _status == RefreshIndicatorStatus.refresh || _status == RefreshIndicatorStatus.done;
+        _status == RefreshIndicatorStatus.refresh ||
+            _status == RefreshIndicatorStatus.done;
 
     return Stack(
       children: <Widget>[
@@ -372,7 +387,9 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
                     ? EdgeInsets.only(top: widget.displacement)
                     : EdgeInsets.only(bottom: widget.displacement),
                 child: Align(
-                  alignment: _isIndicatorAtTop! ? Alignment.topCenter : Alignment.bottomCenter,
+                  alignment: _isIndicatorAtTop!
+                      ? Alignment.topCenter
+                      : Alignment.bottomCenter,
                   child: ScaleTransition(
                     scale: _scaleFactor,
                     child: AnimatedBuilder(
@@ -384,8 +401,9 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
                         double angle;
 
                         if (!showIndeterminateIndicator) {
-                          final progress =
-                              (_positionController.value * _kDragSizeFactorLimit).clamp(0.0, 1.0);
+                          final progress = (_positionController.value *
+                                  _kDragSizeFactorLimit)
+                              .clamp(0.0, 1.0);
                           final (a, b, t) = _dragBlend(progress);
                           shapeA = a;
                           shapeB = b;
@@ -393,9 +411,13 @@ class _M3RefreshIndicatorState extends State<M3RefreshIndicator>
                           angle = progress * math.pi * 2.2;
                         } else {
                           shapeA = _loadingSequence[_loadIndex];
-                          shapeB = _loadingSequence[(_loadIndex + 1) % _loadingSequence.length];
-                          morphT = Curves.elasticOut.transform(_loadCtrl.value).clamp(0.0, 1.0);
-                          angle = _loadCtrl.value * math.pi * 1.5 + _loadIndex * math.pi * 0.6;
+                          shapeB = _loadingSequence[
+                              (_loadIndex + 1) % _loadingSequence.length];
+                          morphT = Curves.elasticOut
+                              .transform(_loadCtrl.value)
+                              .clamp(0.0, 1.0);
+                          angle = _loadCtrl.value * math.pi * 1.5 +
+                              _loadIndex * math.pi * 0.6;
                         }
 
                         return Container(

--- a/packages/progress_indicator_m3e_fixed/lib/src/circular_progress_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/circular_progress_m3e.dart
@@ -127,19 +127,6 @@ class _CircularFlatPainter extends CustomPainter {
     final radius = (math.min(s.width, s.height) - stroke) / 2;
     final rect = Rect.fromCircle(center: center, radius: radius);
 
-    // gap before active in dp -> angle
-    const gapDp = 8.0;
-    final gapAngle = gapDp / radius; // s = r * angle
-
-    // active sweep
-    final sweep =
-        value == null ? math.pi * 1.5 : (value!.clamp(0.0, 1.0) * math.pi * 2);
-
-    final start = -math.pi / 2 + rotation;
-    final activeStart = start;
-    final activeEnd = start + sweep;
-
-    // TRACK: draw the rest of the ring, leaving a gap ahead of the active arc and no overlap.
     final trackPaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = stroke
@@ -147,23 +134,44 @@ class _CircularFlatPainter extends CustomPainter {
       ..isAntiAlias = true
       ..color = track;
 
-    const total = math.pi * 2;
-    final a1 = activeEnd + gapAngle;
-    final a2 = activeStart - gapAngle;
-    double sweep1 = a2 - a1;
-    while (sweep1 <= 0) {
-      sweep1 += total;
+    if (value == 0.0) {
+      canvas.drawArc(rect, 0, math.pi * 2, false, trackPaint);
+      return;
     }
-    canvas.drawArc(rect, a1, sweep1, false, trackPaint);
 
-    // ACTIVE arc
     final activePaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = stroke
       ..strokeCap = StrokeCap.round
       ..isAntiAlias = true
       ..color = active;
-    canvas.drawArc(rect, activeStart, sweep, false, activePaint);
+
+    final start = -math.pi / 2 + rotation;
+    final sweep =
+        value == null ? math.pi * 1.5 : (value!.clamp(0.0, 1.0) * math.pi * 2);
+
+    if (value == 1.0) {
+      canvas.drawArc(rect, start, sweep, false, activePaint);
+      return;
+    }
+
+    // gap before active in dp -> angle
+    const gapDp = 8.0;
+    final gapAngle = gapDp / radius; // s = r * angle
+    const total = math.pi * 2;
+
+    if (sweep + 2 * gapAngle < total) {
+      final a1 = start + sweep + gapAngle;
+      final a2 = start - gapAngle;
+      double sweep1 = a2 - a1;
+      while (sweep1 <= 0) {
+        sweep1 += total;
+      }
+      canvas.drawArc(rect, a1, sweep1, false, trackPaint);
+    }
+
+    // ACTIVE arc
+    canvas.drawArc(rect, start, sweep, false, activePaint);
   }
 
   @override
@@ -193,6 +201,18 @@ class _CircularWavyPainter extends CustomPainter {
     final center = s.center(Offset.zero);
     final baseRadius = (math.min(s.width, s.height) - stroke) / 2;
 
+    if (value == 0.0) {
+      final trackPaint = Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = stroke
+        ..strokeCap = StrokeCap.round
+        ..isAntiAlias = true
+        ..color = track;
+      canvas.drawArc(Rect.fromCircle(center: center, radius: baseRadius), 0,
+          math.pi * 2, false, trackPaint);
+      return;
+    }
+
     const amp = 2.0; // radial amplitude of squiggle
     const scallopLen = 18.0; // along-arc wavelength proxy (dp)
     // Taper length to fade the wave amplitude to zero near the end so the line ends "closed".
@@ -207,23 +227,26 @@ class _CircularWavyPainter extends CustomPainter {
     // Track ring with gap around active (skip when wave-only: indeterminate or 100%)
     final bool waveOnly = value == null || (value != null && value! >= 1.0);
     if (!waveOnly) {
-      final trackPaint = Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = stroke
-        ..strokeCap = StrokeCap.round
-        ..isAntiAlias = true
-        ..color = track;
-
       final gapAngle = 2.0 / baseRadius;
       final rect = Rect.fromCircle(center: center, radius: baseRadius);
       const total = math.pi * 2;
-      final a1 = end + gapAngle;
-      final a2 = start - gapAngle;
-      double sweep1 = a2 - a1;
-      while (sweep1 <= 0) {
-        sweep1 += total;
+      
+      if (activeSweep + 2 * gapAngle < total) {
+        final trackPaint = Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = stroke
+          ..strokeCap = StrokeCap.round
+          ..isAntiAlias = true
+          ..color = track;
+
+        final a1 = end + gapAngle;
+        final a2 = start - gapAngle;
+        double sweep1 = a2 - a1;
+        while (sweep1 <= 0) {
+          sweep1 += total;
+        }
+        canvas.drawArc(rect, a1, sweep1, false, trackPaint);
       }
-      canvas.drawArc(rect, a1, sweep1, false, trackPaint);
     }
 
     // Active squiggle path

--- a/packages/progress_indicator_m3e_fixed/lib/src/circular_progress_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/circular_progress_m3e.dart
@@ -93,13 +93,15 @@ class _CircularProgressIndicatorM3EState
                   value: widget.value,
                   active: active,
                   track: track,
-                  rotation: rot,)
+                  rotation: rot,
+                )
               : _CircularFlatPainter(
                   value: widget.value,
                   active: active,
                   track: track,
                   rotation: rot,
-                  size: widget.size,),
+                  size: widget.size,
+                ),
         ),
       ),
     );
@@ -107,12 +109,13 @@ class _CircularProgressIndicatorM3EState
 }
 
 class _CircularFlatPainter extends CustomPainter {
-  _CircularFlatPainter(
-      {required this.value,
-      required this.active,
-      required this.track,
-      required this.rotation,
-      required this.size,});
+  _CircularFlatPainter({
+    required this.value,
+    required this.active,
+    required this.track,
+    required this.rotation,
+    required this.size,
+  });
 
   final double? value;
   final Color active;
@@ -135,7 +138,7 @@ class _CircularFlatPainter extends CustomPainter {
       ..color = track;
 
     if (value == 0.0) {
-      canvas.drawArc(rect, 0, math.pi * 2, false, trackPaint);
+      canvas.drawCircle(center, radius, trackPaint);
       return;
     }
 
@@ -184,11 +187,12 @@ class _CircularFlatPainter extends CustomPainter {
 }
 
 class _CircularWavyPainter extends CustomPainter {
-  _CircularWavyPainter(
-      {required this.value,
-      required this.active,
-      required this.track,
-      required this.rotation,});
+  _CircularWavyPainter({
+    required this.value,
+    required this.active,
+    required this.track,
+    required this.rotation,
+  });
 
   final double? value;
   final Color active;
@@ -208,8 +212,7 @@ class _CircularWavyPainter extends CustomPainter {
         ..strokeCap = StrokeCap.round
         ..isAntiAlias = true
         ..color = track;
-      canvas.drawArc(Rect.fromCircle(center: center, radius: baseRadius), 0,
-          math.pi * 2, false, trackPaint);
+      canvas.drawCircle(center, baseRadius, trackPaint);
       return;
     }
 
@@ -230,7 +233,7 @@ class _CircularWavyPainter extends CustomPainter {
       final gapAngle = 2.0 / baseRadius;
       final rect = Rect.fromCircle(center: center, radius: baseRadius);
       const total = math.pi * 2;
-      
+
       if (activeSweep + 2 * gapAngle < total) {
         final trackPaint = Paint()
           ..style = PaintingStyle.stroke

--- a/packages/progress_indicator_m3e_fixed/lib/src/linear_progress_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/linear_progress_m3e.dart
@@ -161,12 +161,16 @@ class _LinearPainter extends CustomPainter {
     // Track occupies the remaining segment to the right of the active,
     // leaving a fixed inter-stroke gap. For indeterminate, fill full width.
     final double activeEndX = value == null ? right : (left + width * p);
-    final double trackStartX =
-        value == null ? left : math.min(right, activeEndX + spec.gap + spec.trackHeight);
+    final double trackStartX = value == null
+        ? left
+        : math.min(right, activeEndX + spec.gap + spec.trackHeight);
 
     if (!waveOnly) {
-      canvas.drawLine(Offset(trackStartX, trackCy), Offset(right, trackCy),
-          base..color = track,);
+      canvas.drawLine(
+        Offset(trackStartX, trackCy),
+        Offset(right, trackCy),
+        base..color = track,
+      );
     }
 
     // --- Active lane ---
@@ -191,30 +195,38 @@ class _LinearPainter extends CustomPainter {
       path.lineTo(end, y);
 
       canvas.drawPath(
-          path,
-          base
-            ..color = active
-            ..strokeWidth = spec.trackHeight,);
+        path,
+        base
+          ..color = active
+          ..strokeWidth = spec.trackHeight,
+      );
 
       // end dot: accent at far right end of the track (shared baseline)
       if (!waveOnly) {
         final dotCenterX = math.max(left, right - spec.dotOffset);
-        canvas.drawCircle(Offset(dotCenterX, trackCy), spec.dotDiameter / 2,
-            Paint()..color = active,);
+        canvas.drawCircle(
+          Offset(dotCenterX, trackCy),
+          spec.dotDiameter / 2,
+          Paint()..color = active,
+        );
       }
     } else {
       // flat active pill + end dot
       final start = left;
       final end = value == null ? right : (left + width * p);
       canvas.drawLine(
-          Offset(start, activeCy),
-          Offset(end, activeCy),
-          base
-            ..color = active
-            ..strokeWidth = spec.trackHeight,);
+        Offset(start, activeCy),
+        Offset(end, activeCy),
+        base
+          ..color = active
+          ..strokeWidth = spec.trackHeight,
+      );
       final dotCenterX = math.max(left, right - spec.dotOffset);
-      canvas.drawCircle(Offset(dotCenterX, trackCy), spec.dotDiameter / 2,
-          Paint()..color = active,);
+      canvas.drawCircle(
+        Offset(dotCenterX, trackCy),
+        spec.dotDiameter / 2,
+        Paint()..color = active,
+      );
     }
   }
 

--- a/packages/progress_indicator_m3e_fixed/lib/src/progress_with_label_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/progress_with_label_m3e.dart
@@ -26,8 +26,10 @@ class ProgressWithLabelM3E extends StatelessWidget {
         alignment: Alignment.center,
         children: [
           CircularProgressIndicatorM3E(value: value, size: size),
-          Text('${(value * 100).round()}%',
-              style: textStyle ?? Theme.of(context).textTheme.labelMedium,),
+          Text(
+            '${(value * 100).round()}%',
+            style: textStyle ?? Theme.of(context).textTheme.labelMedium,
+          ),
         ],
       ),
     );

--- a/services/service_bazarr/lib/src/bazarr_api.dart
+++ b/services/service_bazarr/lib/src/bazarr_api.dart
@@ -42,7 +42,8 @@ class BazarrApi {
         'api/movies/wanted',
         queryParameters: <String, dynamic>{'start': 0, 'length': -1},
       );
-      return BazarrWantedMovies.fromJson(resp.data as Map<String, dynamic>).data;
+      return BazarrWantedMovies.fromJson(resp.data as Map<String, dynamic>)
+          .data;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -377,8 +378,7 @@ class BazarrApi {
           await _dio.get<dynamic>('api/system/health');
       return _listFrom(resp.data)
           .map(
-            (dynamic e) =>
-                BazarrHealthItem.fromJson(e as Map<String, dynamic>),
+            (dynamic e) => BazarrHealthItem.fromJson(e as Map<String, dynamic>),
           )
           .toList();
     } on DioException catch (e) {
@@ -393,8 +393,7 @@ class BazarrApi {
           await _dio.get<dynamic>('api/system/tasks');
       return _listFrom(resp.data)
           .map(
-            (dynamic e) =>
-                BazarrSystemTask.fromJson(e as Map<String, dynamic>),
+            (dynamic e) => BazarrSystemTask.fromJson(e as Map<String, dynamic>),
           )
           .toList();
     } on DioException catch (e) {
@@ -480,7 +479,8 @@ class BazarrApi {
     try {
       final Response<dynamic> resp = await _dio.get<dynamic>('api/system/logs');
       return _listFrom(resp.data)
-          .map((dynamic e) => BazarrLogEntry.fromJson(e as Map<String, dynamic>))
+          .map(
+              (dynamic e) => BazarrLogEntry.fromJson(e as Map<String, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -504,7 +504,8 @@ class BazarrApi {
       final Response<dynamic> resp =
           await _dio.get<dynamic>('api/system/languages');
       return _listFrom(resp.data)
-          .map((dynamic e) => BazarrLanguage.fromJson(e as Map<String, dynamic>))
+          .map(
+              (dynamic e) => BazarrLanguage.fromJson(e as Map<String, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -593,8 +594,10 @@ class BazarrApi {
       final Response<dynamic> resp =
           await _dio.get<dynamic>('api/system/languages/profiles');
       return _listFrom(resp.data)
-          .map((dynamic e) =>
-              BazarrLanguageProfile.fromJson(e as Map<String, dynamic>),)
+          .map(
+            (dynamic e) =>
+                BazarrLanguageProfile.fromJson(e as Map<String, dynamic>),
+          )
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);

--- a/services/service_bazarr/lib/src/bazarr_languages_screen.dart
+++ b/services/service_bazarr/lib/src/bazarr_languages_screen.dart
@@ -102,10 +102,12 @@ class _BazarrLanguagesScreenState extends ConsumerState<BazarrLanguagesScreen> {
           final List<BazarrLanguage> filtered = q.isEmpty
               ? list
               : list
-                  .where((BazarrLanguage l) =>
-                      l.name.toLowerCase().contains(q) ||
-                      l.code2.toLowerCase().contains(q) ||
-                      l.code3.toLowerCase().contains(q),)
+                  .where(
+                    (BazarrLanguage l) =>
+                        l.name.toLowerCase().contains(q) ||
+                        l.code2.toLowerCase().contains(q) ||
+                        l.code3.toLowerCase().contains(q),
+                  )
                   .toList();
           return Column(
             children: <Widget>[

--- a/services/service_bazarr/lib/src/bazarr_movie_detail_screen.dart
+++ b/services/service_bazarr/lib/src/bazarr_movie_detail_screen.dart
@@ -36,8 +36,7 @@ class BazarrMovieDetailScreen extends ConsumerWidget {
           IconButton(
             tooltip: 'Search subtitles',
             icon: const Icon(Icons.subtitles_outlined),
-            onPressed: () =>
-                Navigator.of(context, rootNavigator: true).push(
+            onPressed: () => Navigator.of(context, rootNavigator: true).push(
               MaterialPageRoute<void>(
                 builder: (_) => BazarrSubtitleSearchScreen(
                   instance: instance,
@@ -324,8 +323,8 @@ class _MutedLine extends StatelessWidget {
     final ThemeData theme = Theme.of(context);
     return Text(
       text,
-      style: theme.textTheme.bodySmall
-          ?.copyWith(color: theme.colorScheme.outline),
+      style:
+          theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.outline),
     );
   }
 }

--- a/services/service_bazarr/lib/src/bazarr_profiles_screen.dart
+++ b/services/service_bazarr/lib/src/bazarr_profiles_screen.dart
@@ -116,7 +116,8 @@ class BazarrProfilesScreen extends ConsumerWidget {
     try {
       final BazarrApi api = await ref.read(bazarrApiProvider(instance).future);
       await api.setProfiles(
-        all.where((BazarrLanguageProfile x) => x.profileId != p.profileId)
+        all
+            .where((BazarrLanguageProfile x) => x.profileId != p.profileId)
             .toList(),
       );
       ref.invalidate(bazarrProfilesProvider(instance));
@@ -156,7 +157,8 @@ class _BazarrProfileEditScreenState
   void initState() {
     super.initState();
     _name = TextEditingController(text: widget.existing?.name ?? '');
-    for (final BazarrProfileItem it in widget.existing?.items ?? const <BazarrProfileItem>[]) {
+    for (final BazarrProfileItem it
+        in widget.existing?.items ?? const <BazarrProfileItem>[]) {
       _langs.add(it.language);
     }
   }

--- a/services/service_bazarr/lib/src/bazarr_providers.dart
+++ b/services/service_bazarr/lib/src/bazarr_providers.dart
@@ -6,81 +6,80 @@ import 'bazarr_api.dart';
 import 'models/bazarr_models.dart';
 
 /// A [BazarrApi] for an instance, over the shared `instanceDioProvider`.
-final bazarrApiProvider =
-    FutureProvider.family<BazarrApi, Instance>((Ref ref, Instance instance) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      return BazarrApi(dio);
-    });
+final bazarrApiProvider = FutureProvider.family<BazarrApi, Instance>(
+    (Ref ref, Instance instance) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  return BazarrApi(dio);
+});
 
 /// Summary badge counts for an instance.
-final bazarrBadgesProvider =
-    FutureProvider.family<BazarrBadges, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getBadges();
-    });
+final bazarrBadgesProvider = FutureProvider.family<BazarrBadges, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getBadges();
+});
 
 /// The unified "wanted subtitles" list (episodes + movies) for an instance.
 final bazarrWantedProvider =
     FutureProvider.family<List<BazarrWantedRow>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      final List<BazarrWantedEpisode> eps = await api.getWantedEpisodes();
-      final List<BazarrWantedMovie> movies = await api.getWantedMovies();
-      return <BazarrWantedRow>[
-        for (final BazarrWantedEpisode e in eps)
-          BazarrWantedRow(
-            title: e.seriesTitle,
-            subtitle: <String>[
-              if (e.episodeNumber.isNotEmpty) e.episodeNumber,
-              if (e.episodeTitle.isNotEmpty) e.episodeTitle,
-            ].join(' · '),
-            missing: e.missingSubtitles,
-            isMovie: false,
-          ),
-        for (final BazarrWantedMovie m in movies)
-          BazarrWantedRow(
-            title: m.title,
-            subtitle: 'Movie',
-            missing: m.missingSubtitles,
-            isMovie: true,
-          ),
-      ];
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  final List<BazarrWantedEpisode> eps = await api.getWantedEpisodes();
+  final List<BazarrWantedMovie> movies = await api.getWantedMovies();
+  return <BazarrWantedRow>[
+    for (final BazarrWantedEpisode e in eps)
+      BazarrWantedRow(
+        title: e.seriesTitle,
+        subtitle: <String>[
+          if (e.episodeNumber.isNotEmpty) e.episodeNumber,
+          if (e.episodeTitle.isNotEmpty) e.episodeTitle,
+        ].join(' · '),
+        missing: e.missingSubtitles,
+        isMovie: false,
+      ),
+    for (final BazarrWantedMovie m in movies)
+      BazarrWantedRow(
+        title: m.title,
+        subtitle: 'Movie',
+        missing: m.missingSubtitles,
+        isMovie: true,
+      ),
+  ];
+});
 
 /// All series with subtitle status, sorted by title.
 final bazarrSeriesProvider =
     FutureProvider.family<List<BazarrSeries>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      final List<BazarrSeries> list = await api.getSeries();
-      list.sort(
-        (BazarrSeries a, BazarrSeries b) =>
-            a.title.toLowerCase().compareTo(b.title.toLowerCase()),
-      );
-      return list;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  final List<BazarrSeries> list = await api.getSeries();
+  list.sort(
+    (BazarrSeries a, BazarrSeries b) =>
+        a.title.toLowerCase().compareTo(b.title.toLowerCase()),
+  );
+  return list;
+});
 
 /// All movies with subtitle status, sorted by title.
 final bazarrMoviesProvider =
     FutureProvider.family<List<BazarrMovie>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      final List<BazarrMovie> list = await api.getMovies();
-      list.sort(
-        (BazarrMovie a, BazarrMovie b) =>
-            a.title.toLowerCase().compareTo(b.title.toLowerCase()),
-      );
-      return list;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  final List<BazarrMovie> list = await api.getMovies();
+  list.sort(
+    (BazarrMovie a, BazarrMovie b) =>
+        a.title.toLowerCase().compareTo(b.title.toLowerCase()),
+  );
+  return list;
+});
 
 /// Args for [bazarrEpisodesProvider]: an instance plus the Sonarr series id.
 typedef BazarrEpisodesArgs = ({Instance instance, int seriesId});
@@ -88,18 +87,18 @@ typedef BazarrEpisodesArgs = ({Instance instance, int seriesId});
 /// Episodes for one series, sorted by season then episode number.
 final bazarrEpisodesProvider =
     FutureProvider.family<List<BazarrEpisode>, BazarrEpisodesArgs>((
-      Ref ref,
-      BazarrEpisodesArgs args,
-    ) async {
-      final BazarrApi api =
-          await ref.watch(bazarrApiProvider(args.instance).future);
-      final List<BazarrEpisode> eps = await api.getEpisodes(args.seriesId);
-      eps.sort((BazarrEpisode a, BazarrEpisode b) {
-        final int s = (a.season ?? 0).compareTo(b.season ?? 0);
-        return s != 0 ? s : (a.episode ?? 0).compareTo(b.episode ?? 0);
-      });
-      return eps;
-    });
+  Ref ref,
+  BazarrEpisodesArgs args,
+) async {
+  final BazarrApi api =
+      await ref.watch(bazarrApiProvider(args.instance).future);
+  final List<BazarrEpisode> eps = await api.getEpisodes(args.seriesId);
+  eps.sort((BazarrEpisode a, BazarrEpisode b) {
+    final int s = (a.season ?? 0).compareTo(b.season ?? 0);
+    return s != 0 ? s : (a.episode ?? 0).compareTo(b.episode ?? 0);
+  });
+  return eps;
+});
 
 /// Args for the manual-search providers: an instance plus the item id
 /// (Sonarr episode id, or Radarr movie id).
@@ -109,63 +108,63 @@ typedef BazarrSearchArgs = ({Instance instance, int id});
 /// search screen drops the (slow, provider-hitting) result.
 final bazarrEpisodeSearchProvider = FutureProvider.autoDispose
     .family<List<BazarrSubtitleSearchResult>, BazarrSearchArgs>((
-      Ref ref,
-      BazarrSearchArgs args,
-    ) async {
-      final BazarrApi api =
-          await ref.watch(bazarrApiProvider(args.instance).future);
-      return api.searchEpisodeSubtitles(args.id);
-    });
+  Ref ref,
+  BazarrSearchArgs args,
+) async {
+  final BazarrApi api =
+      await ref.watch(bazarrApiProvider(args.instance).future);
+  return api.searchEpisodeSubtitles(args.id);
+});
 
 /// Manual subtitle search results for a movie.
 final bazarrMovieSearchProvider = FutureProvider.autoDispose
     .family<List<BazarrSubtitleSearchResult>, BazarrSearchArgs>((
-      Ref ref,
-      BazarrSearchArgs args,
-    ) async {
-      final BazarrApi api =
-          await ref.watch(bazarrApiProvider(args.instance).future);
-      return api.searchMovieSubtitles(args.id);
-    });
+  Ref ref,
+  BazarrSearchArgs args,
+) async {
+  final BazarrApi api =
+      await ref.watch(bazarrApiProvider(args.instance).future);
+  return api.searchMovieSubtitles(args.id);
+});
 
 /// Unified subtitle history (episodes + movies), newest first.
 final bazarrHistoryProvider =
     FutureProvider.family<List<BazarrHistoryItem>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      final List<BazarrHistoryItem> eps = await api.getEpisodeHistory();
-      final List<BazarrHistoryItem> movies = await api.getMovieHistory();
-      final List<BazarrHistoryItem> all = <BazarrHistoryItem>[...eps, ...movies];
-      all.sort((BazarrHistoryItem a, BazarrHistoryItem b) {
-        final DateTime? da = _parseHistoryTs(a.parsedTimestamp);
-        final DateTime? db = _parseHistoryTs(b.parsedTimestamp);
-        if (da == null || db == null) {
-          return 0;
-        }
-        return db.compareTo(da);
-      });
-      return all;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  final List<BazarrHistoryItem> eps = await api.getEpisodeHistory();
+  final List<BazarrHistoryItem> movies = await api.getMovieHistory();
+  final List<BazarrHistoryItem> all = <BazarrHistoryItem>[...eps, ...movies];
+  all.sort((BazarrHistoryItem a, BazarrHistoryItem b) {
+    final DateTime? da = _parseHistoryTs(a.parsedTimestamp);
+    final DateTime? db = _parseHistoryTs(b.parsedTimestamp);
+    if (da == null || db == null) {
+      return 0;
+    }
+    return db.compareTo(da);
+  });
+  return all;
+});
 
 /// Unified blacklist (episodes + movies). The movies endpoint errors on some
 /// Bazarr versions, so it is tolerated independently of the episodes one.
 final bazarrBlacklistProvider =
     FutureProvider.family<List<BazarrBlacklistItem>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      final List<BazarrBlacklistItem> eps = await api.getEpisodeBlacklist();
-      List<BazarrBlacklistItem> movies = const <BazarrBlacklistItem>[];
-      try {
-        movies = await api.getMovieBlacklist();
-      } on Object catch (_) {
-        // Tolerate the movies-blacklist quirk; show episodes regardless.
-      }
-      return <BazarrBlacklistItem>[...eps, ...movies];
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  final List<BazarrBlacklistItem> eps = await api.getEpisodeBlacklist();
+  List<BazarrBlacklistItem> movies = const <BazarrBlacklistItem>[];
+  try {
+    movies = await api.getMovieBlacklist();
+  } on Object catch (_) {
+    // Tolerate the movies-blacklist quirk; show episodes regardless.
+  }
+  return <BazarrBlacklistItem>[...eps, ...movies];
+});
 
 /// Parses Bazarr's `parsed_timestamp` ("MM/DD/YY HH:MM:SS") for sorting.
 DateTime? _parseHistoryTs(String s) {
@@ -199,95 +198,95 @@ DateTime? _parseHistoryTs(String s) {
 /// System status (versions, OS, database, uptime).
 final bazarrSystemStatusProvider =
     FutureProvider.family<BazarrSystemStatus, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getSystemStatus();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getSystemStatus();
+});
 
 /// Active health issues (empty when healthy).
 final bazarrSystemHealthProvider =
     FutureProvider.family<List<BazarrHealthItem>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getSystemHealth();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getSystemHealth();
+});
 
 /// Scheduled tasks.
 final bazarrSystemTasksProvider =
     FutureProvider.family<List<BazarrSystemTask>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getSystemTasks();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getSystemTasks();
+});
 
 /// Subtitle provider statuses.
 final bazarrProviderStatusesProvider =
     FutureProvider.family<List<BazarrProviderStatus>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getProviderStatuses();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getProviderStatuses();
+});
 
 /// Existing backups.
 final bazarrBackupsProvider =
     FutureProvider.family<List<BazarrBackup>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getBackups();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getBackups();
+});
 
 /// Recent log lines, newest first.
 final bazarrLogsProvider =
     FutureProvider.family<List<BazarrLogEntry>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getLogs();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getLogs();
+});
 
 /// All subtitle languages with enabled flags (Settings > Languages).
 final bazarrLanguagesProvider =
     FutureProvider.family<List<BazarrLanguage>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      final List<BazarrLanguage> list = await api.getLanguages();
-      list.sort(
-        (BazarrLanguage a, BazarrLanguage b) =>
-            a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      );
-      return list;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  final List<BazarrLanguage> list = await api.getLanguages();
+  list.sort(
+    (BazarrLanguage a, BazarrLanguage b) =>
+        a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+  );
+  return list;
+});
 
 /// Full Bazarr settings object (Settings > Providers: enabled list + per-
 /// provider config sections).
 final bazarrSettingsProvider =
     FutureProvider.family<Map<String, dynamic>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getBazarrSettings();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getBazarrSettings();
+});
 
 /// Language profiles (Settings > Language Profiles).
 final bazarrProfilesProvider =
     FutureProvider.family<List<BazarrLanguageProfile>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
-      return api.getProfiles();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final BazarrApi api = await ref.watch(bazarrApiProvider(instance).future);
+  return api.getProfiles();
+});

--- a/services/service_bazarr/lib/src/bazarr_providers_screen.dart
+++ b/services/service_bazarr/lib/src/bazarr_providers_screen.dart
@@ -154,14 +154,19 @@ class _BazarrProvidersScreenState extends ConsumerState<BazarrProvidersScreen> {
             _seeded = true;
           }
           final String q = _query.text.trim().toLowerCase();
-          final List<MapEntry<String, String>> entries = kBazarrProviders.entries
-              .where((MapEntry<String, String> e) =>
-                  q.isEmpty ||
-                  e.value.toLowerCase().contains(q) ||
-                  e.key.toLowerCase().contains(q),)
-              .toList()
-            ..sort((MapEntry<String, String> a, MapEntry<String, String> b) =>
-                a.value.toLowerCase().compareTo(b.value.toLowerCase()),);
+          final List<MapEntry<String, String>> entries =
+              kBazarrProviders.entries
+                  .where(
+                    (MapEntry<String, String> e) =>
+                        q.isEmpty ||
+                        e.value.toLowerCase().contains(q) ||
+                        e.key.toLowerCase().contains(q),
+                  )
+                  .toList()
+                ..sort(
+                  (MapEntry<String, String> a, MapEntry<String, String> b) =>
+                      a.value.toLowerCase().compareTo(b.value.toLowerCase()),
+                );
           return Column(
             children: <Widget>[
               Padding(
@@ -194,14 +199,16 @@ class _BazarrProvidersScreenState extends ConsumerState<BazarrProvidersScreen> {
                           }
                         }),
                       ),
-                      onTap: () => Navigator.of(context, rootNavigator: true)
-                          .push(MaterialPageRoute<void>(
-                        builder: (_) => BazarrProviderConfigScreen(
-                          instance: widget.instance,
-                          providerKey: p.key,
-                          providerName: p.value,
+                      onTap: () =>
+                          Navigator.of(context, rootNavigator: true).push(
+                        MaterialPageRoute<void>(
+                          builder: (_) => BazarrProviderConfigScreen(
+                            instance: widget.instance,
+                            providerKey: p.key,
+                            providerName: p.value,
+                          ),
                         ),
-                      ),),
+                      ),
                     );
                   },
                 ),
@@ -317,11 +324,15 @@ class _BazarrProviderConfigScreenState
                   <String, dynamic>{};
           // Only scalar fields are editable generically.
           final List<MapEntry<String, dynamic>> fields = section.entries
-              .where((MapEntry<String, dynamic> e) =>
-                  e.value is bool || e.value is String || e.value is num,)
+              .where(
+                (MapEntry<String, dynamic> e) =>
+                    e.value is bool || e.value is String || e.value is num,
+              )
               .toList()
-            ..sort((MapEntry<String, dynamic> a, MapEntry<String, dynamic> b) =>
-                a.key.compareTo(b.key),);
+            ..sort(
+              (MapEntry<String, dynamic> a, MapEntry<String, dynamic> b) =>
+                  a.key.compareTo(b.key),
+            );
           if (!_seeded) {
             _values.clear();
             for (final MapEntry<String, dynamic> e in fields) {
@@ -346,8 +357,7 @@ class _BazarrProviderConfigScreenState
                     ?.copyWith(color: theme.colorScheme.outline),
               ),
               const SizedBox(height: Insets.md),
-              for (final MapEntry<String, dynamic> e in fields)
-                _field(e.key),
+              for (final MapEntry<String, dynamic> e in fields) _field(e.key),
             ],
           );
         },

--- a/services/service_bazarr/lib/src/bazarr_search_screen.dart
+++ b/services/service_bazarr/lib/src/bazarr_search_screen.dart
@@ -190,10 +190,8 @@ class _ResultCardState extends ConsumerState<_ResultCard> {
               crossAxisAlignment: WrapCrossAlignment.center,
               children: <Widget>[
                 Text('Score ${r.score}', style: theme.textTheme.labelSmall),
-                if (hi)
-                  Text('HI', style: theme.textTheme.labelSmall),
-                if (forced)
-                  Text('Forced', style: theme.textTheme.labelSmall),
+                if (hi) Text('HI', style: theme.textTheme.labelSmall),
+                if (forced) Text('Forced', style: theme.textTheme.labelSmall),
                 if (r.uploader != null && r.uploader!.isNotEmpty)
                   Text(
                     r.uploader!,

--- a/services/service_bazarr/lib/src/bazarr_series_detail_screen.dart
+++ b/services/service_bazarr/lib/src/bazarr_series_detail_screen.dart
@@ -29,7 +29,8 @@ class BazarrSeriesDetailScreen extends ConsumerWidget {
     final AsyncValue<List<BazarrEpisode>> episodes =
         ref.watch(bazarrEpisodesProvider(args));
     return Scaffold(
-      appBar: AppBar(title: Text(series.title, overflow: TextOverflow.ellipsis)),
+      appBar:
+          AppBar(title: Text(series.title, overflow: TextOverflow.ellipsis)),
       body: M3RefreshIndicator(
         onRefresh: () async => ref.invalidate(bazarrEpisodesProvider(args)),
         child: AsyncValueView<List<BazarrEpisode>>(
@@ -157,8 +158,7 @@ class _EpisodeCard extends ConsumerWidget {
   final Instance instance;
   final BazarrEpisode episode;
 
-  String get _code =>
-      'S${(episode.season ?? 0).toString().padLeft(2, '0')}'
+  String get _code => 'S${(episode.season ?? 0).toString().padLeft(2, '0')}'
       'E${(episode.episode ?? 0).toString().padLeft(2, '0')}';
 
   @override
@@ -190,8 +190,8 @@ class _EpisodeCard extends ConsumerWidget {
                 tooltip: 'Search subtitles',
                 visualDensity: VisualDensity.compact,
                 icon: const Icon(Icons.subtitles_outlined),
-                onPressed: () => Navigator.of(context, rootNavigator: true)
-                    .push(
+                onPressed: () =>
+                    Navigator.of(context, rootNavigator: true).push(
                   MaterialPageRoute<void>(
                     builder: (_) => BazarrSubtitleSearchScreen(
                       instance: instance,
@@ -261,8 +261,7 @@ class _EpisodeCard extends ConsumerWidget {
       return;
     }
     try {
-      final BazarrApi api =
-          await ref.read(bazarrApiProvider(instance).future);
+      final BazarrApi api = await ref.read(bazarrApiProvider(instance).future);
       await api.deleteEpisodeSubtitle(
         seriesId: episode.sonarrSeriesId,
         episodeId: episode.sonarrEpisodeId,

--- a/services/service_bazarr/lib/src/bazarr_subtitle_chips.dart
+++ b/services/service_bazarr/lib/src/bazarr_subtitle_chips.dart
@@ -33,7 +33,8 @@ class BazarrSubtitleChips extends StatelessWidget {
       spacing: Insets.xs,
       runSpacing: Insets.xs,
       children: <Widget>[
-        for (final BazarrSubtitle s in present) _chip(context, s, present: true),
+        for (final BazarrSubtitle s in present)
+          _chip(context, s, present: true),
         for (final BazarrSubtitle s in missing)
           _chip(context, s, present: false),
       ],
@@ -51,7 +52,8 @@ class BazarrSubtitleChips extends StatelessWidget {
     return tags.isEmpty ? code : '$code ${tags.join('/')}';
   }
 
-  Widget _chip(BuildContext context, BazarrSubtitle s, {required bool present}) {
+  Widget _chip(BuildContext context, BazarrSubtitle s,
+      {required bool present}) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
     // Present subtitles read as a soft tertiary "have it" tone; missing ones as

--- a/services/service_bazarr/pubspec.yaml
+++ b/services/service_bazarr/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   collection: ^1.18.0
   core_models:
   core_networking:

--- a/services/service_emby/lib/src/emby_client.dart
+++ b/services/service_emby/lib/src/emby_client.dart
@@ -37,7 +37,8 @@ class EmbyClient {
   final String password;
   final String deviceId;
   final String? Function(String itemId, String imageType)? getLocalOverride;
-  final void Function(String itemId, String imageType, String tag)? setLocalOverride;
+  final void Function(String itemId, String imageType, String tag)?
+      setLocalOverride;
 
   String? _token;
   String? _userId;
@@ -55,7 +56,8 @@ class EmbyClient {
     required bool allowSelfSigned,
     Map<String, String> customHeaders = const <String, String>{},
     String? Function(String itemId, String imageType)? getLocalOverride,
-    void Function(String itemId, String imageType, String tag)? setLocalOverride,
+    void Function(String itemId, String imageType, String tag)?
+        setLocalOverride,
   }) {
     final String baseUrlStr = baseUrl.toString();
     final String normalizedBaseUrl =
@@ -685,7 +687,9 @@ class EmbyClient {
     String tagParam = '';
     int targetIndex = 0;
 
-    if (item.seriesId != null && item.backdropImageTags.isEmpty && !item.imageTags.containsKey('Backdrop')) {
+    if (item.seriesId != null &&
+        item.backdropImageTags.isEmpty &&
+        !item.imageTags.containsKey('Backdrop')) {
       targetId = item.seriesId!;
     }
 
@@ -720,7 +724,9 @@ class EmbyClient {
   }
 
   Future<List<EmbyRemoteImage>> getRemoteImages(
-          String itemId, String imageType,) =>
+    String itemId,
+    String imageType,
+  ) =>
       _guarded(() async {
         final Response<dynamic> resp = await _dio.get<dynamic>(
           'Items/$itemId/RemoteImages',
@@ -735,7 +741,10 @@ class EmbyClient {
       });
 
   Future<void> setRemoteImage(
-          String itemId, String imageUrl, String imageType,) =>
+    String itemId,
+    String imageUrl,
+    String imageType,
+  ) =>
       _guarded(() async {
         List<String> oldBackdrops = <String>[];
         if (imageType == 'Backdrop') {
@@ -790,7 +799,9 @@ class EmbyClient {
 
   /// Fetches available remote images and commands Emby to download the first one available.
   Future<void> downloadFirstAvailableRemoteImage(
-          String itemId, String imageType,) =>
+    String itemId,
+    String imageType,
+  ) =>
       _guarded(() async {
         // Step 1: Fetch Available Images
         final Response<dynamic> getResp = await _dio.get<dynamic>(
@@ -802,7 +813,8 @@ class EmbyClient {
         );
 
         if (getResp.statusCode != null && getResp.statusCode! >= 400) {
-          throw Exception('Failed to fetch remote images. Status code: ${getResp.statusCode}');
+          throw Exception(
+              'Failed to fetch remote images. Status code: ${getResp.statusCode}');
         }
 
         final EmbyRemoteImagesResult result = EmbyRemoteImagesResult.fromJson(
@@ -814,7 +826,8 @@ class EmbyClient {
           throw Exception('No remote images found for item $itemId.');
         }
 
-        final String? imageUrl = result.images.first.url ?? result.images.first.thumbnailUrl;
+        final String? imageUrl =
+            result.images.first.url ?? result.images.first.thumbnailUrl;
         if (imageUrl == null) {
           throw Exception('First available image has no valid URL.');
         }
@@ -832,7 +845,8 @@ class EmbyClient {
         );
 
         if (postResp.statusCode != null && postResp.statusCode! >= 400) {
-          throw Exception('Failed to download remote image. Status code: ${postResp.statusCode}');
+          throw Exception(
+              'Failed to download remote image. Status code: ${postResp.statusCode}');
         }
       });
 
@@ -844,13 +858,16 @@ class EmbyClient {
       _guarded(() async {
         final Response<dynamic> resp =
             await _dio.get<dynamic>('ScheduledTasks');
-        final List<dynamic> tasks = (resp.data as List<dynamic>?) ?? <dynamic>[];
+        final List<dynamic> tasks =
+            (resp.data as List<dynamic>?) ?? <dynamic>[];
         for (final dynamic t in tasks) {
           final Map<String, dynamic> task = t as Map<String, dynamic>;
           if (task['Key'] == 'RefreshLibrary') {
             return (
               state: (task['State'] as String?) ?? 'Idle',
-              progress: (task['CurrentProgressPercentage'] as num?)?.toDouble() ?? 0.0,
+              progress:
+                  (task['CurrentProgressPercentage'] as num?)?.toDouble() ??
+                      0.0,
             );
           }
         }
@@ -894,7 +911,8 @@ class EmbyClient {
         );
         final List<dynamic> list = res.data as List<dynamic>;
         return list
-            .map((dynamic e) => EmbyRemoteSearchResult.fromJson(e as Map<String, dynamic>))
+            .map((dynamic e) =>
+                EmbyRemoteSearchResult.fromJson(e as Map<String, dynamic>))
             .toList();
       });
 

--- a/services/service_emby/lib/src/emby_deep_link.dart
+++ b/services/service_emby/lib/src/emby_deep_link.dart
@@ -30,9 +30,11 @@ Future<void> launchEmbyDeepLink(
   if (Platform.isAndroid) {
     try {
       const MethodChannel channel = MethodChannel('app.atrium/launcher');
-      final bool launched = await channel.invokeMethod<bool>('launchDeepLink', <String, dynamic>{
-        'url': urlStr,
-      }) ?? false;
+      final bool launched =
+          await channel.invokeMethod<bool>('launchDeepLink', <String, dynamic>{
+                'url': urlStr,
+              }) ??
+              false;
       if (launched) return;
     } catch (_) {}
   }

--- a/services/service_emby/lib/src/emby_home.dart
+++ b/services/service_emby/lib/src/emby_home.dart
@@ -17,6 +17,7 @@ import 'emby_session_detail_screen.dart';
 import 'models/emby_item.dart';
 import 'models/emby_session.dart';
 import 'models/emby_view.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Container types - tapping drills into children. Everything else plays.
 /// (See the note in JellyfinHome: we dispatch on "is it a container?" so an
@@ -47,7 +48,8 @@ class EmbyHome extends ConsumerStatefulWidget {
 class _EmbyHomeState extends ConsumerState<EmbyHome> {
   @override
   Widget build(BuildContext context) {
-    final AsyncValue<List<EmbyView>> viewsAsync = ref.watch(embyViewsProvider(widget.instance));
+    final AsyncValue<List<EmbyView>> viewsAsync =
+        ref.watch(embyViewsProvider(widget.instance));
     final int index = ref.watch(embyActiveTabBarIndexProvider(widget.instance));
 
     return AsyncValueView<List<EmbyView>>(
@@ -61,11 +63,11 @@ class _EmbyHomeState extends ConsumerState<EmbyHome> {
             message: 'This Emby server has no libraries to show.',
           );
         }
-        
+
         final String libsKey = libraries.map((EmbyView l) => l.id).join(',');
         final int targetLength = libraries.length + 3;
         final int initialIndex = (index < targetLength) ? index : 0;
-        
+
         return DefaultTabController(
           key: ValueKey<String>(libsKey),
           length: targetLength,
@@ -717,11 +719,10 @@ class EmbyPosterCard extends ConsumerWidget {
                           ),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(6),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress.clamp(0, 1),
-                              minHeight: 6,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.5),
+                              trackColor: Colors.black.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -1086,10 +1087,10 @@ class EmbyBannerCard extends ConsumerWidget {
                               const SizedBox(height: 8),
                               ClipRRect(
                                 borderRadius: BorderRadius.circular(6),
-                                child: LinearProgressIndicator(
+                                child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
                                   value: progress.clamp(0, 1),
-                                  minHeight: 6,
-                                  backgroundColor:
+                                  trackColor:
                                       Colors.black.withValues(alpha: 0.1),
                                 ),
                               ),
@@ -1454,37 +1455,212 @@ class _SessionCardState extends State<_SessionCard> {
           borderRadius: BorderRadius.circular(24),
         ),
         child: InkWell(
-        onTap: () => pushScreen<void>(
-          context,
-          EmbySessionDetailScreen(
-            initialSession: session,
-            instance: widget.instance,
+          onTap: () => pushScreen<void>(
+            context,
+            EmbySessionDetailScreen(
+              initialSession: session,
+              instance: widget.instance,
+            ),
           ),
-        ),
-        child: Stack(
-          children: <Widget>[
-            // Backdrop
-            if (session.posterUrl != null)
-              Positioned.fill(
-                child: Stack(
-                  fit: StackFit.expand,
+          child: Stack(
+            children: <Widget>[
+              // Backdrop
+              if (session.posterUrl != null)
+                Positioned.fill(
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: <Widget>[
+                      Image.network(
+                        session.posterUrl!,
+                        fit: BoxFit.cover,
+                        alignment: Alignment.topCenter,
+                        errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                      ),
+                      Container(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: <Color>[
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.3),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.85),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.95),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+              // Content
+              Padding(
+                padding: const EdgeInsets.all(Insets.md),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Image.network(
-                      session.posterUrl!,
-                      fit: BoxFit.cover,
-                      alignment: Alignment.topCenter,
-                      errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    // Poster
+                    ConstrainedBox(
+                      constraints:
+                          const BoxConstraints(maxWidth: 120, maxHeight: 126),
+                      child: AspectRatio(
+                        aspectRatio: session.aspectRatio != null &&
+                                session.aspectRatio! > 0.0
+                            ? session.aspectRatio!
+                            : (2 / 3),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(12),
+                            boxShadow: <BoxShadow>[
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.25),
+                                blurRadius: 12,
+                                offset: const Offset(0, 6),
+                              ),
+                            ],
+                            image: session.posterUrl != null
+                                ? DecorationImage(
+                                    image: CachedNetworkImageProvider(
+                                      session.posterUrl!,
+                                    ),
+                                    fit: BoxFit.cover,
+                                    onError: (Object _, StackTrace? __) {},
+                                  )
+                                : null,
+                          ),
+                          child: session.posterUrl == null
+                              ? Icon(
+                                  Icons.movie_outlined,
+                                  color: theme.colorScheme.outline,
+                                  size: 32,
+                                )
+                              : null,
+                        ),
+                      ),
                     ),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: <Color>[
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.3),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.85),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.95),
+                    const SizedBox(width: Insets.lg),
+
+                    // Details
+                    Expanded(
+                      child: SizedBox(
+                        height: 126,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            // Title
+                            Text(
+                              session.showTitle,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18,
+                                shadows: <Shadow>[
+                                  Shadow(
+                                    color: Colors.black.withValues(alpha: 0.8),
+                                    offset: const Offset(0, 2),
+                                    blurRadius: 4,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+
+                            if (session.episodeName != null)
+                              Text(
+                                session.episodeName!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                  shadows: <Shadow>[
+                                    Shadow(
+                                      color:
+                                          Colors.black.withValues(alpha: 0.8),
+                                      offset: const Offset(0, 1),
+                                      blurRadius: 3,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                            const SizedBox(height: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.surfaceContainerHighest
+                                    .withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: theme.colorScheme.outlineVariant
+                                      .withValues(alpha: 0.5),
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: <Widget>[
+                                  Icon(
+                                    Icons.person,
+                                    size: 14,
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Flexible(
+                                    child: Text(
+                                      '${session.user}: ${session.device}',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
+                                        color:
+                                            theme.colorScheme.onSurfaceVariant,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+
+                            const Spacer(),
+
+                            // Progress Header
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: <Widget>[
+                                Text(
+                                  session.timePosition,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                Text(
+                                  session.timeDuration,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+
+                            // Progress Bar
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
+                                  value: pct.clamp(0.0, 1.0),
+                                  trackColor:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  activeColor: playing
+                                      ? theme.colorScheme.primary
+                                      : theme.colorScheme.outline),
+                            ),
                           ],
                         ),
                       ),
@@ -1492,184 +1668,9 @@ class _SessionCardState extends State<_SessionCard> {
                   ],
                 ),
               ),
-
-            // Content
-            Padding(
-              padding: const EdgeInsets.all(Insets.md),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  // Poster
-                  ConstrainedBox(
-                    constraints:
-                        const BoxConstraints(maxWidth: 120, maxHeight: 126),
-                    child: AspectRatio(
-                      aspectRatio: session.aspectRatio != null &&
-                              session.aspectRatio! > 0.0
-                          ? session.aspectRatio!
-                          : (2 / 3),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(12),
-                          boxShadow: <BoxShadow>[
-                            BoxShadow(
-                              color: Colors.black.withValues(alpha: 0.25),
-                              blurRadius: 12,
-                              offset: const Offset(0, 6),
-                            ),
-                          ],
-                          image: session.posterUrl != null
-                              ? DecorationImage(
-                                  image: CachedNetworkImageProvider(
-                                    session.posterUrl!,
-                                  ),
-                                  fit: BoxFit.cover,
-                                  onError: (Object _, StackTrace? __) {},
-                                )
-                              : null,
-                        ),
-                        child: session.posterUrl == null
-                            ? Icon(
-                                Icons.movie_outlined,
-                                color: theme.colorScheme.outline,
-                                size: 32,
-                              )
-                            : null,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: Insets.lg),
-
-                  // Details
-                  Expanded(
-                    child: SizedBox(
-                      height: 126,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          // Title
-                          Text(
-                            session.showTitle,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 18,
-                              shadows: <Shadow>[
-                                Shadow(
-                                  color: Colors.black.withValues(alpha: 0.8),
-                                  offset: const Offset(0, 2),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-
-                          if (session.episodeName != null)
-                            Text(
-                              session.episodeName!,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                                shadows: <Shadow>[
-                                  Shadow(
-                                    color: Colors.black.withValues(alpha: 0.8),
-                                    offset: const Offset(0, 1),
-                                    blurRadius: 3,
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                          const SizedBox(height: 4),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest
-                                  .withValues(alpha: 0.5),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: theme.colorScheme.outlineVariant
-                                    .withValues(alpha: 0.5),
-                              ),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: <Widget>[
-                                Icon(
-                                  Icons.person,
-                                  size: 14,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                                const SizedBox(width: 4),
-                                Flexible(
-                                  child: Text(
-                                    '${session.user}: ${session.device}',
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: theme.textTheme.bodySmall?.copyWith(
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                          const Spacer(),
-
-                          // Progress Header
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: <Widget>[
-                              Text(
-                                session.timePosition,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                              Text(
-                                session.timeDuration,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  color: theme.colorScheme.outline,
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 6),
-
-                          // Progress Bar
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(8),
-                            child: LinearProgressIndicator(
-                              value: pct.clamp(0.0, 1.0),
-                              minHeight: 8,
-                              backgroundColor:
-                                  theme.colorScheme.surfaceContainerHighest,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                playing
-                                    ? theme.colorScheme.primary
-                                    : theme.colorScheme.outline,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
       ),
     );
   }

--- a/services/service_emby/lib/src/emby_identify_screen.dart
+++ b/services/service_emby/lib/src/emby_identify_screen.dart
@@ -66,7 +66,7 @@ class _EmbyIdentifyScreenState extends ConsumerState<EmbyIdentifyScreen> {
     try {
       final yearText = _yearController.text.trim();
       final year = yearText.isNotEmpty ? int.tryParse(yearText) : null;
-      
+
       final providerIds = <String, String>{};
       if (_imdbController.text.trim().isNotEmpty) {
         providerIds['Imdb'] = _imdbController.text.trim();
@@ -139,7 +139,7 @@ class _EmbyIdentifyScreenState extends ConsumerState<EmbyIdentifyScreen> {
         result,
         replaceAllImages: replace,
       );
-      
+
       if (mounted) {
         Navigator.pop(context); // close loading
         Navigator.pop(context, true); // close identify screen
@@ -221,7 +221,8 @@ class _EmbyIdentifyScreenState extends ConsumerState<EmbyIdentifyScreen> {
                     const SizedBox(height: Insets.md),
                     Text(
                       _error!,
-                      style: TextStyle(color: Theme.of(context).colorScheme.error),
+                      style:
+                          TextStyle(color: Theme.of(context).colorScheme.error),
                     ),
                   ],
                 ],
@@ -240,11 +241,13 @@ class _EmbyIdentifyScreenState extends ConsumerState<EmbyIdentifyScreen> {
                             width: 40,
                             height: 60,
                             fit: BoxFit.cover,
-                            errorBuilder: (_, __, ___) => const Icon(Icons.image),
+                            errorBuilder: (_, __, ___) =>
+                                const Icon(Icons.image),
                           )
                         : const Icon(Icons.movie),
                     title: Text(res.name ?? 'Unknown'),
-                    subtitle: Text('${res.productionYear ?? ''} • ${res.searchProviderName ?? ''}'),
+                    subtitle: Text(
+                        '${res.productionYear ?? ''} • ${res.searchProviderName ?? ''}'),
                     onTap: () => _apply(res),
                   );
                 },

--- a/services/service_emby/lib/src/emby_item_detail.dart
+++ b/services/service_emby/lib/src/emby_item_detail.dart
@@ -91,16 +91,21 @@ class EmbyItemDetailScreen extends ConsumerWidget {
                       ),
                     );
                     if (changed == true && context.mounted) {
-                      ref.invalidate(embyItemDetailsProvider((instance, itemId)));
+                      ref.invalidate(
+                          embyItemDetailsProvider((instance, itemId)));
                     }
                   } else if (choice == 'refresh') {
                     try {
-                      await ref.read(embyClientProvider(instance)).value?.refreshMetadata(itemId);
+                      await ref
+                          .read(embyClientProvider(instance))
+                          .value
+                          ?.refreshMetadata(itemId);
                       if (context.mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(content: Text('Refresh queued')),
                         );
-                        ref.invalidate(embyItemDetailsProvider((instance, itemId)));
+                        ref.invalidate(
+                            embyItemDetailsProvider((instance, itemId)));
                       }
                     } catch (e) {
                       if (context.mounted) {
@@ -230,7 +235,9 @@ class EmbyItemDetailScreen extends ConsumerWidget {
                       children: item.genres.map((String g) {
                         return Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 4,),
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
                           decoration: BoxDecoration(
                             color: Theme.of(context)
                                 .colorScheme

--- a/services/service_emby/lib/src/emby_music_screens.dart
+++ b/services/service_emby/lib/src/emby_music_screens.dart
@@ -129,17 +129,19 @@ class EmbyAlbumScreen extends ConsumerWidget {
                           vertical: 4,
                         ),
                         decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.secondaryContainer,
+                          color:
+                              Theme.of(context).colorScheme.secondaryContainer,
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Text(
                           g,
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSecondaryContainer,
-                                fontWeight: FontWeight.w500,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSecondaryContainer,
+                                    fontWeight: FontWeight.w500,
+                                  ),
                         ),
                       );
                     }).toList(),
@@ -249,7 +251,8 @@ class EmbyAlbumScreen extends ConsumerWidget {
                                           color: Theme.of(context)
                                               .colorScheme
                                               .surfaceContainerHighest,
-                                          borderRadius: BorderRadius.circular(4),
+                                          borderRadius:
+                                              BorderRadius.circular(4),
                                         ),
                                         child: const Icon(Icons.music_note),
                                       ),
@@ -372,4 +375,3 @@ class EmbyAlbumScreen extends ConsumerWidget {
     );
   }
 }
-

--- a/services/service_emby/lib/src/emby_providers.dart
+++ b/services/service_emby/lib/src/emby_providers.dart
@@ -39,7 +39,8 @@ final embyClientProvider = FutureProvider.family<EmbyClient, Instance>((
     deviceId: instance.id,
     allowSelfSigned: instance.allowSelfSignedCerts,
     customHeaders: customHeaders,
-    getLocalOverride: (String itemId, String type) => overridesBox.get('${instance.id}_${itemId}_$type'),
+    getLocalOverride: (String itemId, String type) =>
+        overridesBox.get('${instance.id}_${itemId}_$type'),
     setLocalOverride: (String itemId, String type, String tag) {
       if (tag.isEmpty) {
         overridesBox.delete('${instance.id}_${itemId}_$type');
@@ -57,10 +58,10 @@ final embyViewsProvider = FutureProvider.family<List<EmbyView>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
-  final EmbyClient client = await ref.watch(embyClientProvider(instance).future);
+  final EmbyClient client =
+      await ref.watch(embyClientProvider(instance).future);
   return client.getViews();
 });
-
 
 /// Flattened items within a root library, using recursive fetch based on CollectionType.
 final embyLibraryItemsProvider =
@@ -158,8 +159,8 @@ final embyFastSessionsProvider =
   }
 });
 
-final embyLibraryScanProvider =
-    StreamProvider.autoDispose.family<({String state, double progress})?, Instance>((
+final embyLibraryScanProvider = StreamProvider.autoDispose
+    .family<({String state, double progress})?, Instance>((
   Ref ref,
   Instance instance,
 ) async* {
@@ -326,8 +327,8 @@ final embyArtistBioProvider =
   return client.getArtistBio(artistName);
 });
 
-final embyRemoteImagesProvider =
-    FutureProvider.autoDispose.family<List<EmbyRemoteImage>, (Instance, String, String)>((
+final embyRemoteImagesProvider = FutureProvider.autoDispose
+    .family<List<EmbyRemoteImage>, (Instance, String, String)>((
   Ref ref,
   (Instance, String, String) key,
 ) async {

--- a/services/service_emby/lib/src/emby_remote_images_screen.dart
+++ b/services/service_emby/lib/src/emby_remote_images_screen.dart
@@ -90,7 +90,6 @@ class _EmbyRemoteImagesScreenState
         }
       }
 
-
       await client.setRemoteImage(widget.itemId, imageUrl, widget.imageType);
 
       // Evict untagged URL from cache for sessions that don't use tags
@@ -156,7 +155,8 @@ class _EmbyRemoteImagesScreenState
       setState(() => _isSaving = false);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Failed to update ${widget.imageType.toLowerCase()}: $e'),
+          content:
+              Text('Failed to update ${widget.imageType.toLowerCase()}: $e'),
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
@@ -171,7 +171,8 @@ class _EmbyRemoteImagesScreenState
   Widget build(BuildContext context) {
     final AsyncValue<List<EmbyRemoteImage>> imagesAsync = ref.watch(
       embyRemoteImagesProvider(
-          (widget.instance, widget.itemId, widget.imageType),),
+        (widget.instance, widget.itemId, widget.imageType),
+      ),
     );
 
     return Scaffold(
@@ -184,7 +185,8 @@ class _EmbyRemoteImagesScreenState
             value: imagesAsync,
             onRetry: () => ref.invalidate(
               embyRemoteImagesProvider(
-                  (widget.instance, widget.itemId, widget.imageType),),
+                (widget.instance, widget.itemId, widget.imageType),
+              ),
             ),
             data: (List<EmbyRemoteImage> images) {
               if (images.isEmpty) {

--- a/services/service_emby/lib/src/emby_session_detail_screen.dart
+++ b/services/service_emby/lib/src/emby_session_detail_screen.dart
@@ -57,7 +57,8 @@ class _EmbySessionDetailScreenState
     final AsyncValue<List<ActiveSession>> sessionsAsync =
         ref.watch(embyFastSessionsProvider(widget.instance));
     final ActiveSession session = sessionsAsync.value?.firstWhereOrNull(
-            (ActiveSession s) => s.id == widget.initialSession.id,) ??
+          (ActiveSession s) => s.id == widget.initialSession.id,
+        ) ??
         widget.initialSession;
 
     final String? posterUrl = session.posterUrl;
@@ -70,8 +71,8 @@ class _EmbySessionDetailScreenState
       final Color vibrant = _palette!.vibrantColor?.color ??
           _palette!.lightVibrantColor?.color ??
           dominant;
-      final Color muted =
-          _palette!.mutedColor?.color ?? theme.colorScheme.surfaceContainerHighest;
+      final Color muted = _palette!.mutedColor?.color ??
+          theme.colorScheme.surfaceContainerHighest;
       final Color darkMuted = _palette!.darkMutedColor?.color ?? dominant;
       final Color titleText = _palette!.dominantColor?.titleTextColor ??
           theme.colorScheme.onSurface;
@@ -105,616 +106,684 @@ class _EmbySessionDetailScreenState
     return Theme(
       data: theme,
       child: Scaffold(
-      extendBodyBehindAppBar: true,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.keyboard_arrow_down, size: 32),
-          onPressed: () => Navigator.of(context).pop(),
+        extendBodyBehindAppBar: true,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.keyboard_arrow_down, size: 32),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          title: Column(
+            children: <Widget>[
+              Text(
+                'STREAMING ON',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  letterSpacing: 1.2,
+                  fontWeight: FontWeight.w600,
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              Text(
+                session.device,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ),
+          centerTitle: true,
         ),
-        title: Column(
+        body: Stack(
+          fit: StackFit.expand,
           children: <Widget>[
-            Text(
-              'STREAMING ON',
-              style: theme.textTheme.labelSmall?.copyWith(
-                letterSpacing: 1.2,
-                fontWeight: FontWeight.w600,
-                color: theme.colorScheme.onSurfaceVariant,
+            // Background blurred image
+            if (session.posterUrl != null)
+              CachedNetworkImage(
+                imageUrl: session.posterUrl!,
+                fit: BoxFit.cover,
+                errorWidget: (_, __, ___) =>
+                    Container(color: theme.colorScheme.surface),
               ),
-            ),
-            Text(
-              session.device,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: theme.colorScheme.primary,
-              ),
-            ),
-          ],
-        ),
-        centerTitle: true,
-      ),
-      body: Stack(
-        fit: StackFit.expand,
-        children: <Widget>[
-          // Background blurred image
-          if (session.posterUrl != null)
-            CachedNetworkImage(
-              imageUrl: session.posterUrl!,
-              fit: BoxFit.cover,
-              errorWidget: (_, __, ___) =>
-                  Container(color: theme.colorScheme.surface),
-            ),
-          // Blur and gradient overlay
-          BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  stops: const <double>[0.0, 0.5, 1.0],
-                  colors: <Color>[
-                    Colors.black.withValues(alpha: 0.5),
-                    theme.colorScheme.surface.withValues(alpha: 0.8),
-                    Colors.black.withValues(alpha: 0.95),
-                  ],
+            // Blur and gradient overlay
+            BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    stops: const <double>[0.0, 0.5, 1.0],
+                    colors: <Color>[
+                      Colors.black.withValues(alpha: 0.5),
+                      theme.colorScheme.surface.withValues(alpha: 0.8),
+                      Colors.black.withValues(alpha: 0.95),
+                    ],
+                  ),
                 ),
               ),
             ),
-          ),
-          // Content
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: Insets.xl),
-              child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                  // Volume Control
-                  Row(
-                    children: <Widget>[
-                      IconButton(
-                        icon: Icon(
-                          session.isMuted || session.volumeLevel == 0
-                              ? Icons.volume_off
-                              : Icons.volume_up,
-                          color: theme.colorScheme.primary,
-                        ),
-                        onPressed: () async {
-                          final ScaffoldMessengerState messenger =
-                              ScaffoldMessenger.of(context);
-                          try {
-                            final EmbyClient client = await ref.read(
-                                embyClientProvider(widget.instance).future,);
-                            await client.toggleMute(session.id);
-                            if (mounted) {
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
+            // Content
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: Insets.xl),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    // Volume Control
+                    Row(
+                      children: <Widget>[
+                        IconButton(
+                          icon: Icon(
+                            session.isMuted || session.volumeLevel == 0
+                                ? Icons.volume_off
+                                : Icons.volume_up,
+                            color: theme.colorScheme.primary,
+                          ),
+                          onPressed: () async {
+                            final ScaffoldMessengerState messenger =
+                                ScaffoldMessenger.of(context);
+                            try {
+                              final EmbyClient client = await ref.read(
+                                embyClientProvider(widget.instance).future,
+                              );
+                              await client.toggleMute(session.id);
+                              if (mounted) {
+                                ref.invalidate(
+                                  embyFastSessionsProvider(widget.instance),
+                                );
+                              }
+                            } catch (_) {
+                              messenger.showSnackBar(
+                                const SnackBar(content: Text('Action failed')),
+                              );
                             }
-                          } catch (_) {
-                            messenger.showSnackBar(
-                              const SnackBar(content: Text('Action failed')),
-                            );
-                          }
-                        },
+                          },
+                        ),
+                        Expanded(
+                          child: SliderTheme(
+                            data: SliderTheme.of(context).copyWith(
+                              trackHeight: 16,
+                              thumbShape: const ExpressiveSliderThumbShape(),
+                              trackShape: const ExpressiveSliderTrackShape(),
+                              overlayShape: const RoundSliderOverlayShape(),
+                              activeTrackColor: theme.colorScheme.primary,
+                              inactiveTrackColor:
+                                  Colors.white.withValues(alpha: 0.2),
+                              thumbColor: theme.colorScheme.primary,
+                            ),
+                            child: Slider(
+                              value: _isVolumeDragging
+                                  ? _volumeDragPct
+                                  : (session.volumeLevel / 100.0)
+                                      .clamp(0.0, 1.0),
+                              onChangeStart: (double val) {
+                                setState(() {
+                                  _isVolumeDragging = true;
+                                  _volumeDragPct = val;
+                                });
+                              },
+                              onChanged: (double val) {
+                                setState(() {
+                                  _volumeDragPct = val;
+                                });
+                              },
+                              onChangeEnd: (double val) async {
+                                setState(() {
+                                  _isVolumeDragging = false;
+                                });
+                                final int targetVol = (val * 100).round();
+                                final ScaffoldMessengerState messenger =
+                                    ScaffoldMessenger.of(context);
+                                try {
+                                  final EmbyClient client = await ref.read(
+                                    embyClientProvider(widget.instance).future,
+                                  );
+                                  await client.setVolume(session.id, targetVol);
+                                  if (mounted) {
+                                    ref.invalidate(
+                                      embyFastSessionsProvider(
+                                        widget.instance,
+                                      ),
+                                    );
+                                  }
+                                } catch (_) {
+                                  messenger.showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Action failed'),
+                                    ),
+                                  );
+                                }
+                              },
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: Insets.md),
+                      ],
+                    ),
+
+                    const Spacer(),
+
+                    // Artwork with animated music bars
+                    Flexible(
+                      flex: 20,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          // Left animated music bars
+                          AnimatedMusicBars(
+                            color: theme.colorScheme.primary,
+                            isPlaying: playing,
+                          ),
+                          const SizedBox(width: Insets.sm),
+                          // Album art
+                          Flexible(
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                  maxHeight: 420, maxWidth: 420),
+                              child: AspectRatio(
+                                aspectRatio: session.aspectRatio != null &&
+                                        session.aspectRatio! > 0.0
+                                    ? session.aspectRatio!
+                                    : (2 / 3),
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
+                                    borderRadius: Radii.card,
+                                    boxShadow: <BoxShadow>[
+                                      BoxShadow(
+                                        color:
+                                            Colors.black.withValues(alpha: 0.4),
+                                        blurRadius: 20,
+                                        offset: const Offset(0, 10),
+                                      ),
+                                    ],
+                                    image: session.posterUrl != null
+                                        ? DecorationImage(
+                                            image: CachedNetworkImageProvider(
+                                              session.posterUrl!,
+                                            ),
+                                            fit: BoxFit.cover,
+                                          )
+                                        : null,
+                                  ),
+                                  child: session.posterUrl == null
+                                      ? Icon(
+                                          Icons.movie_outlined,
+                                          color: theme.colorScheme.outline,
+                                          size: 80,
+                                        )
+                                      : null,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: Insets.sm),
+                          // Right animated music bars
+                          AnimatedMusicBars(
+                            color: theme.colorScheme.primary,
+                            isPlaying: playing,
+                          ),
+                        ],
                       ),
-                      Expanded(
-                        child: SliderTheme(
-                          data: SliderTheme.of(context).copyWith(
+                    ),
+
+                    const SizedBox(height: Insets.lg),
+
+                    // Track Info
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          SizedBox(
+                            height:
+                                (theme.textTheme.titleLarge?.fontSize ?? 22) *
+                                    1.5,
+                            child: AutoScrollText(
+                              text: session.showTitle,
+                              style: theme.textTheme.titleLarge?.copyWith(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                height: 1.2,
+                              ),
+                            ),
+                          ),
+                          if (session.episodeName != null) ...<Widget>[
+                            const SizedBox(height: Insets.xs),
+                            SizedBox(
+                              height: (theme.textTheme.titleMedium?.fontSize ??
+                                      16) *
+                                  1.5,
+                              child: AutoScrollText(
+                                text: session.episodeName!,
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+
+                    // Progress Bar & Timestamps
+                    Column(
+                      children: <Widget>[
+                        SliderTheme(
+                          data: SliderThemeData(
                             trackHeight: 16,
+                            activeTrackColor: theme.colorScheme.primary,
+                            inactiveTrackColor:
+                                theme.colorScheme.surfaceContainerHighest,
+                            thumbColor: theme.colorScheme.primary,
                             thumbShape: const ExpressiveSliderThumbShape(),
                             trackShape: const ExpressiveSliderTrackShape(),
                             overlayShape: const RoundSliderOverlayShape(),
-                            activeTrackColor: theme.colorScheme.primary,
-                            inactiveTrackColor: Colors.white.withValues(alpha: 0.2),
-                            thumbColor: theme.colorScheme.primary,
                           ),
                           child: Slider(
-                            value: _isVolumeDragging
-                                ? _volumeDragPct
-                                : (session.volumeLevel / 100.0)
-                                    .clamp(0.0, 1.0),
-                            onChangeStart: (double val) {
+                            value: pct.clamp(0.0, 1.0),
+                            onChangeStart: (_) => setState(() {
+                              _isDragging = true;
+                              _dragPct = pct;
+                            }),
+                            onChanged: (double newValue) {
                               setState(() {
-                                _isVolumeDragging = true;
-                                _volumeDragPct = val;
+                                _dragPct = newValue;
                               });
                             },
-                            onChanged: (double val) {
-                              setState(() {
-                                _volumeDragPct = val;
-                              });
+                            onChangeEnd: (double newValue) async {
+                              setState(() => _isDragging = false);
+                              if (session.durationTicks > 0) {
+                                final int targetTicks =
+                                    (session.durationTicks * newValue).round();
+                                final ScaffoldMessengerState messenger =
+                                    ScaffoldMessenger.of(context);
+                                try {
+                                  final EmbyClient client = await ref.read(
+                                    embyClientProvider(widget.instance).future,
+                                  );
+                                  await client.seekSession(
+                                    session.id,
+                                    targetTicks,
+                                  );
+                                  if (!mounted) return;
+                                  ref.invalidate(
+                                    embyFastSessionsProvider(widget.instance),
+                                  );
+                                } catch (_) {
+                                  messenger.showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Action failed'),
+                                    ),
+                                  );
+                                }
+                              }
                             },
-                            onChangeEnd: (double val) async {
-                              setState(() {
-                                _isVolumeDragging = false;
-                              });
-                              final int targetVol = (val * 100).round();
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 24,
+                          ), // Align with slider track
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: <Widget>[
+                              Text(
+                                session.timePosition,
+                                style: theme.textTheme.labelMedium?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              Text(
+                                session.timeDuration,
+                                style: theme.textTheme.labelMedium?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: Insets.md),
+
+                    // Row 1: 10s back, Play/Pause, 10s forward
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            onPressed: () async {
                               final ScaffoldMessengerState messenger =
                                   ScaffoldMessenger.of(context);
                               try {
                                 final EmbyClient client = await ref.read(
-                                    embyClientProvider(widget.instance).future,);
-                                await client.setVolume(session.id, targetVol);
-                                if (mounted) {
-                                  ref.invalidate(embyFastSessionsProvider(
-                                      widget.instance,),);
-                                }
+                                  embyClientProvider(widget.instance).future,
+                                );
+                                final int targetTicks =
+                                    session.positionTicks - 100000000;
+                                await client.seekSession(session.id,
+                                    targetTicks < 0 ? 0 : targetTicks);
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  embyFastSessionsProvider(widget.instance),
+                                );
                               } catch (_) {
                                 messenger.showSnackBar(
                                   const SnackBar(
-                                      content: Text('Action failed'),),
+                                    content: Text('Action failed'),
+                                  ),
                                 );
                               }
                             },
+                            child: const Icon(Icons.replay_10, size: 32),
                           ),
                         ),
-                      ),
-                      const SizedBox(width: Insets.md),
-                    ],
-                  ),
-
-                            const Spacer(),
-
-                            // Artwork with animated music bars
-                            Flexible(
-                              flex: 20,
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: <Widget>[
-                                  // Left animated music bars
-                                  AnimatedMusicBars(
-                                    color: theme.colorScheme.primary,
-                                    isPlaying: playing,
-                                  ),
-                                  const SizedBox(width: Insets.sm),
-                                  // Album art
-                                  Flexible(
-                                    child: ConstrainedBox(
-                                      constraints:
-                                          const BoxConstraints(maxHeight: 420, maxWidth: 420),
-                                      child: AspectRatio(
-                                        aspectRatio: session.aspectRatio != null &&
-                                                session.aspectRatio! > 0.0
-                                            ? session.aspectRatio!
-                                            : (2 / 3),
-                                        child: Container(
-                                          decoration: BoxDecoration(
-                                            color: theme.colorScheme.surfaceContainerHighest,
-                                            borderRadius: Radii.card,
-                                            boxShadow: <BoxShadow>[
-                                              BoxShadow(
-                                                color: Colors.black.withValues(alpha: 0.4),
-                                                blurRadius: 20,
-                                                offset: const Offset(0, 10),
-                                              ),
-                                            ],
-                                            image: session.posterUrl != null
-                                                ? DecorationImage(
-                                                    image: CachedNetworkImageProvider(
-                                                        session.posterUrl!,),
-                                                    fit: BoxFit.cover,
-                                                  )
-                                                : null,
-                                          ),
-                                          child: session.posterUrl == null
-                                              ? Icon(Icons.movie_outlined,
-                                                  color: theme.colorScheme.outline, size: 80,)
-                                              : null,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: Insets.sm),
-                                  // Right animated music bars
-                                  AnimatedMusicBars(
-                                    color: theme.colorScheme.primary,
-                                    isPlaying: playing,
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                  const SizedBox(height: Insets.lg),
-
-                  // Track Info
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
+                        const SizedBox(width: Insets.lg),
                         SizedBox(
-                          height: (theme.textTheme.titleLarge?.fontSize ?? 22) *
-                              1.5,
-                          child: AutoScrollText(
-                            text: session.showTitle,
-                            style: theme.textTheme.titleLarge?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              height: 1.2,
-                            ),
-                          ),
-                        ),
-                        if (session.episodeName != null) ...<Widget>[
-                          const SizedBox(height: Insets.xs),
-                          SizedBox(
-                            height:
-                                (theme.textTheme.titleMedium?.fontSize ?? 16) *
-                                    1.5,
-                            child: AutoScrollText(
-                              text: session.episodeName!,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w500,
+                          width: 120,
+                          height: 80,
+                          child: FilledButton(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.2),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(32),
                               ),
+                              padding: EdgeInsets.zero,
                             ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-
-                  // Progress Bar & Timestamps
-                  Column(
-                    children: <Widget>[
-                      SliderTheme(
-                        data: SliderThemeData(
-                          trackHeight: 16,
-                          activeTrackColor: theme.colorScheme.primary,
-                          inactiveTrackColor:
-                              theme.colorScheme.surfaceContainerHighest,
-                          thumbColor: theme.colorScheme.primary,
-                          thumbShape: const ExpressiveSliderThumbShape(),
-                          trackShape: const ExpressiveSliderTrackShape(),
-                          overlayShape: const RoundSliderOverlayShape(),
-                        ),
-                        child: Slider(
-                          value: pct.clamp(0.0, 1.0),
-                          onChangeStart: (_) => setState(() {
-                            _isDragging = true;
-                            _dragPct = pct;
-                          }),
-                          onChanged: (double newValue) {
-                            setState(() {
-                              _dragPct = newValue;
-                            });
-                          },
-                          onChangeEnd: (double newValue) async {
-                            setState(() => _isDragging = false);
-                            if (session.durationTicks > 0) {
-                              final int targetTicks =
-                                  (session.durationTicks * newValue).round();
-                              final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
                               try {
                                 final EmbyClient client = await ref.read(
-                                    embyClientProvider(widget.instance)
-                                        .future,);
-                                await client.seekSession(
-                                    session.id, targetTicks,);
+                                  embyClientProvider(widget.instance).future,
+                                );
+                                await client.playPauseSession(session.id);
                                 if (!mounted) return;
                                 ref.invalidate(
-                                    embyFastSessionsProvider(widget.instance),);
+                                  embyFastSessionsProvider(widget.instance),
+                                );
                               } catch (_) {
                                 messenger.showSnackBar(
                                   const SnackBar(
-                                      content: Text('Action failed'),),
+                                    content: Text('Action failed'),
+                                  ),
                                 );
                               }
-                            }
-                          },
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 24,), // Align with slider track
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: <Widget>[
-                            Text(
-                              session.timePosition,
-                              style: theme.textTheme.labelMedium?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w600,
-                              ),
+                            },
+                            child: Icon(
+                              playing ? Icons.pause : Icons.play_arrow,
+                              size: 40,
                             ),
-                            Text(
-                              session.timeDuration,
-                              style: theme.textTheme.labelMedium?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(width: Insets.lg),
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
                               ),
+                              padding: EdgeInsets.zero,
                             ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  const SizedBox(height: Insets.md),
-
-                  // Row 1: 10s back, Play/Pause, 10s forward
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
-                          ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final EmbyClient client = await ref.read(
-                                  embyClientProvider(widget.instance).future,);
-                              final int targetTicks = session.positionTicks - 100000000;
-                              await client.seekSession(session.id, targetTicks < 0 ? 0 : targetTicks);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.replay_10, size: 32),
-                        ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 120,
-                        height: 80,
-                        child: FilledButton(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.2),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(32),),
-                            padding: EdgeInsets.zero,
-                          ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final EmbyClient client = await ref.read(
-                                  embyClientProvider(widget.instance).future,);
-                              await client.playPauseSession(session.id);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: Icon(playing ? Icons.pause : Icons.play_arrow,
-                              size: 40,),
-                        ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
-                          ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final EmbyClient client = await ref.read(
-                                  embyClientProvider(widget.instance).future,);
-                              final int targetTicks = session.positionTicks + 100000000;
-                              if (targetTicks < session.durationTicks) {
-                                await client.seekSession(session.id, targetTicks);
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final EmbyClient client = await ref.read(
+                                  embyClientProvider(widget.instance).future,
+                                );
+                                final int targetTicks =
+                                    session.positionTicks + 100000000;
+                                if (targetTicks < session.durationTicks) {
+                                  await client.seekSession(
+                                      session.id, targetTicks);
+                                }
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  embyFastSessionsProvider(widget.instance),
+                                );
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
                               }
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.forward_10, size: 32),
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  const SizedBox(height: Insets.md),
-
-                  // Row 2: Skip Previous, Stop, Skip Next
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
+                            },
+                            child: const Icon(Icons.forward_10, size: 32),
                           ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final EmbyClient client = await ref.read(
-                                  embyClientProvider(widget.instance).future,);
-                              if (session.positionTicks > 50000000) {
-                                await client.seekSession(session.id, 0);
-                              } else {
-                                await client.previousTrack(session.id);
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: Insets.md),
+
+                    // Row 2: Skip Previous, Stop, Skip Next
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final EmbyClient client = await ref.read(
+                                  embyClientProvider(widget.instance).future,
+                                );
+                                if (session.positionTicks > 50000000) {
+                                  await client.seekSession(session.id, 0);
+                                } else {
+                                  await client.previousTrack(session.id);
+                                }
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  embyFastSessionsProvider(widget.instance),
+                                );
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
                               }
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.skip_previous, size: 32),
-                        ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 120,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            foregroundColor: theme.colorScheme.errorContainer,
-                            backgroundColor: Colors.white.withValues(alpha: 0.2),
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(32),),
-                            padding: EdgeInsets.zero,
+                            },
+                            child: const Icon(Icons.skip_previous, size: 32),
                           ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            final NavigatorState navigator = Navigator.of(context);
-                            try {
-                              final EmbyClient client = await ref.read(
-                                  embyClientProvider(widget.instance).future,);
-                              await client.stopSession(session.id);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
-                              navigator.pop();
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.stop, size: 28),
                         ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
+                        const SizedBox(width: Insets.lg),
+                        SizedBox(
+                          width: 120,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              foregroundColor: theme.colorScheme.errorContainer,
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.2),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(32),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              final NavigatorState navigator =
+                                  Navigator.of(context);
+                              try {
+                                final EmbyClient client = await ref.read(
+                                  embyClientProvider(widget.instance).future,
+                                );
+                                await client.stopSession(session.id);
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  embyFastSessionsProvider(widget.instance),
+                                );
+                                navigator.pop();
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
+                              }
+                            },
+                            child: const Icon(Icons.stop, size: 28),
                           ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final EmbyClient client = await ref.read(
-                                  embyClientProvider(widget.instance).future,);
-                              await client.nextTrack(session.id);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  embyFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.skip_next, size: 32),
                         ),
-                      ),
-                    ],
-                  ),
-
-                  const Spacer(),
-                  const SizedBox(height: Insets.lg),
-
-                  // Footer
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      // Device Chip
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 8,),
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest
-                              .withValues(alpha: 0.5),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: <Widget>[
-                            const Icon(
-                              Icons.speaker,
-                              size: 16,
-                              color: Colors.white70,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              session.device,
-                              style: theme.textTheme.labelLarge?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w600,
+                        const SizedBox(width: Insets.lg),
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
                               ),
+                              padding: EdgeInsets.zero,
                             ),
-                          ],
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final EmbyClient client = await ref.read(
+                                  embyClientProvider(widget.instance).future,
+                                );
+                                await client.nextTrack(session.id);
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  embyFastSessionsProvider(widget.instance),
+                                );
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
+                              }
+                            },
+                            child: const Icon(Icons.skip_next, size: 32),
+                          ),
                         ),
-                      ),
-                      // User Chip
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 8,),
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest
-                              .withValues(alpha: 0.5),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: <Widget>[
-                            const Icon(
-                              Icons.person,
-                              size: 16,
-                              color: Colors.white70,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              session.user,
-                              style: theme.textTheme.labelLarge?.copyWith(
+                      ],
+                    ),
+
+                    const Spacer(),
+                    const SizedBox(height: Insets.lg),
+
+                    // Footer
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        // Device Chip
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest
+                                .withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              const Icon(
+                                Icons.speaker,
+                                size: 16,
                                 color: Colors.white70,
-                                fontWeight: FontWeight.w600,
                               ),
-                            ),
-                          ],
+                              const SizedBox(width: 8),
+                              Text(
+                                session.device,
+                                style: theme.textTheme.labelLarge?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: Insets.xl),
-              ],
+                        // User Chip
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest
+                                .withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              const Icon(
+                                Icons.person,
+                                size: 16,
+                                color: Colors.white70,
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                session.user,
+                                style: theme.textTheme.labelLarge?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: Insets.xl),
+                  ],
+                ),
+              ),
             ),
-          ),
+          ],
         ),
-        ],
-      ),
       ),
     );
   }

--- a/services/service_emby/lib/src/emby_settings_screen.dart
+++ b/services/service_emby/lib/src/emby_settings_screen.dart
@@ -13,7 +13,7 @@ class EmbySettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<({double progress, String state})?> scanState = 
+    final AsyncValue<({double progress, String state})?> scanState =
         ref.watch(embyLibraryScanProvider(instance));
 
     return Scaffold(
@@ -30,10 +30,12 @@ class EmbySettingsScreen extends ConsumerWidget {
                 if (data == null || data.state == 'Idle') {
                   return const Text('Ready');
                 }
-                return Text('${data.state} - ${data.progress.toStringAsFixed(1)}%');
+                return Text(
+                    '${data.state} - ${data.progress.toStringAsFixed(1)}%');
               },
               loading: () => const Text('Checking status...'),
-              error: (Object err, StackTrace stack) => const Text('Error checking status'),
+              error: (Object err, StackTrace stack) =>
+                  const Text('Error checking status'),
             ),
             trailing: scanState.maybeWhen(
               data: (({double progress, String state})? data) {
@@ -46,7 +48,8 @@ class EmbySettingsScreen extends ConsumerWidget {
                   icon: const Icon(Icons.play_arrow),
                   onPressed: () async {
                     try {
-                      final EmbyClient client = await ref.read(embyClientProvider(instance).future);
+                      final EmbyClient client =
+                          await ref.read(embyClientProvider(instance).future);
                       await client.startLibraryScan();
                       if (!context.mounted) return;
                       ref.invalidate(embyLibraryScanProvider(instance));

--- a/services/service_emby/lib/src/models/emby_auth.dart
+++ b/services/service_emby/lib/src/models/emby_auth.dart
@@ -35,7 +35,9 @@ abstract class EmbyUserPolicy with _$EmbyUserPolicy {
   const factory EmbyUserPolicy({
     @JsonKey(name: 'IsAdministrator') @Default(false) bool isAdministrator,
     @JsonKey(name: 'EnableAllFolders') @Default(true) bool enableAllFolders,
-    @JsonKey(name: 'EnabledFolders') @Default(<String>[]) List<String> enabledFolders,
+    @JsonKey(name: 'EnabledFolders')
+    @Default(<String>[])
+    List<String> enabledFolders,
   }) = _EmbyUserPolicy;
 
   factory EmbyUserPolicy.fromJson(Map<String, dynamic> json) =>

--- a/services/service_emby/pubspec.yaml
+++ b/services/service_emby/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   cached_network_image: ^3.4.1
   collection: ^1.18.0
   core_models:

--- a/services/service_glances/lib/src/glances_api.dart
+++ b/services/service_glances/lib/src/glances_api.dart
@@ -10,7 +10,8 @@ class GlancesApi {
 
   Future<GlancesStats> getStats() async {
     try {
-      final List<Response<dynamic>> responses = await Future.wait(<Future<Response<dynamic>>>[
+      final List<Response<dynamic>> responses =
+          await Future.wait(<Future<Response<dynamic>>>[
         _dio.get<dynamic>('api/4/cpu'),
         _dio.get<dynamic>('api/4/percpu'),
         _dio.get<dynamic>('api/4/core'),
@@ -22,12 +23,16 @@ class GlancesApi {
         _dio.get<dynamic>('api/4/uptime'),
       ]);
 
-      final Map<String, dynamic> cpuData = responses[0].data as Map<String, dynamic>;
+      final Map<String, dynamic> cpuData =
+          responses[0].data as Map<String, dynamic>;
       final List<dynamic> perCpuData = responses[1].data as List<dynamic>;
-      final Map<String, dynamic> coreData = responses[2].data as Map<String, dynamic>;
+      final Map<String, dynamic> coreData =
+          responses[2].data as Map<String, dynamic>;
       final List<dynamic> sensorsData = responses[3].data as List<dynamic>;
-      final Map<String, dynamic> memData = responses[4].data as Map<String, dynamic>;
-      final Map<String, dynamic> swapData = responses[5].data as Map<String, dynamic>;
+      final Map<String, dynamic> memData =
+          responses[4].data as Map<String, dynamic>;
+      final Map<String, dynamic> swapData =
+          responses[5].data as Map<String, dynamic>;
       final List<dynamic> networkData = responses[6].data as List<dynamic>;
       final List<dynamic> fsData = responses[7].data as List<dynamic>;
       final String uptimeStr = responses[8].data.toString();
@@ -39,13 +44,19 @@ class GlancesApi {
       double packageTemp = 0.0;
       if (sensorsData.isNotEmpty) {
         final Iterable<dynamic> packageSensors = sensorsData.where(
-          (dynamic s) => ((s as Map<String, dynamic>)['label'] as String).toLowerCase().contains('package'),
+          (dynamic s) => ((s as Map<String, dynamic>)['label'] as String)
+              .toLowerCase()
+              .contains('package'),
         );
         if (packageSensors.isNotEmpty) {
-          packageTemp = ((packageSensors.first as Map<String, dynamic>)['value'] as num).toDouble();
+          packageTemp =
+              ((packageSensors.first as Map<String, dynamic>)['value'] as num)
+                  .toDouble();
         } else {
           final Iterable<dynamic> coreSensors = sensorsData.where(
-            (dynamic s) => ((s as Map<String, dynamic>)['label'] as String).toLowerCase().contains('core'),
+            (dynamic s) => ((s as Map<String, dynamic>)['label'] as String)
+                .toLowerCase()
+                .contains('core'),
           );
           if (coreSensors.isNotEmpty) {
             double sum = 0;
@@ -64,10 +75,14 @@ class GlancesApi {
 
         double coreTemp = 0.0;
         final Iterable<dynamic> coreSensor = sensorsData.where(
-          (dynamic s) => ((s as Map<String, dynamic>)['label'] as String).toLowerCase() == 'core $id',
+          (dynamic s) =>
+              ((s as Map<String, dynamic>)['label'] as String).toLowerCase() ==
+              'core $id',
         );
         if (coreSensor.isNotEmpty) {
-          coreTemp = ((coreSensor.first as Map<String, dynamic>)['value'] as num).toDouble();
+          coreTemp =
+              ((coreSensor.first as Map<String, dynamic>)['value'] as num)
+                  .toDouble();
         }
 
         return GlancesCpuCore(id: id, usage: usage, temp: coreTemp);
@@ -104,7 +119,8 @@ class GlancesApi {
         );
       }).toList();
 
-      final RegExp uptimeRegex = RegExp(r'(?:(?<days>[0-9]+) days?, )?(?<hours>[0-9]+):(?<minutes>[0-9]+):(?<seconds>[0-9]+)');
+      final RegExp uptimeRegex = RegExp(
+          r'(?:(?<days>[0-9]+) days?, )?(?<hours>[0-9]+):(?<minutes>[0-9]+):(?<seconds>[0-9]+)');
       final RegExpMatch? match = uptimeRegex.firstMatch(uptimeStr);
       int days = 0;
       int hours = 0;
@@ -116,7 +132,8 @@ class GlancesApi {
         minutes = int.tryParse(match.namedGroup('minutes') ?? '0') ?? 0;
         seconds = int.tryParse(match.namedGroup('seconds') ?? '0') ?? 0;
       }
-      final int totalSeconds = (days * 86400) + (hours * 3600) + (minutes * 60) + seconds;
+      final int totalSeconds =
+          (days * 86400) + (hours * 3600) + (minutes * 60) + seconds;
 
       final GlancesUptime uptime = GlancesUptime(
         days: days,

--- a/services/service_glances/lib/src/glances_home.dart
+++ b/services/service_glances/lib/src/glances_home.dart
@@ -32,14 +32,17 @@ class GlancesHome extends ConsumerWidget {
               shape: RoundedRectangleBorder(
                 borderRadius: Radii.card,
                 side: BorderSide(
-                    color: Theme.of(context).colorScheme.outlineVariant,),
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
               ),
               child: Padding(
                 padding: const EdgeInsets.all(Insets.md),
                 child: Row(
                   children: <Widget>[
-                    const Icon(Icons.schedule_outlined,
-                        color: Color(0xFF3B82F6),),
+                    const Icon(
+                      Icons.schedule_outlined,
+                      color: Color(0xFF3B82F6),
+                    ),
                     const SizedBox(width: Insets.md),
                     Expanded(
                       child: Text(
@@ -63,8 +66,10 @@ class GlancesHome extends ConsumerWidget {
             const SizedBox(height: Insets.md),
             _buildNetworkSectionHeader(context, ref, stats.network),
             ...stats.network
-                .where((GlancesNetwork n) =>
-                    pinnedNets.isEmpty || pinnedNets.contains(n.interface),)
+                .where(
+                  (GlancesNetwork n) =>
+                      pinnedNets.isEmpty || pinnedNets.contains(n.interface),
+                )
                 .map((GlancesNetwork n) => _buildNetworkCard(context, n)),
             const SizedBox(height: Insets.md),
             _buildSectionHeader(context, 'Disks', Icons.storage_outlined),
@@ -112,7 +117,10 @@ class GlancesHome extends ConsumerWidget {
   }
 
   Widget _buildSectionHeader(
-      BuildContext context, String title, IconData icon,) {
+    BuildContext context,
+    String title,
+    IconData icon,
+  ) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: Insets.sm),
       child: Row(
@@ -132,7 +140,10 @@ class GlancesHome extends ConsumerWidget {
   }
 
   Widget _buildNetworkSectionHeader(
-      BuildContext context, WidgetRef ref, List<GlancesNetwork> networks,) {
+    BuildContext context,
+    WidgetRef ref,
+    List<GlancesNetwork> networks,
+  ) {
     final Set<String> pinnedNets =
         ref.watch(glancesPinnedNetworkProvider(instance));
 
@@ -140,8 +151,11 @@ class GlancesHome extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(vertical: Insets.sm),
       child: Row(
         children: <Widget>[
-          Icon(Icons.network_check_outlined,
-              size: 20, color: Theme.of(context).colorScheme.primary,),
+          Icon(
+            Icons.network_check_outlined,
+            size: 20,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           const SizedBox(width: Insets.sm),
           Text(
             'Network',
@@ -180,8 +194,11 @@ class GlancesHome extends ConsumerWidget {
     );
   }
 
-  void _showNetworkFilterDialog(BuildContext context, WidgetRef parentRef,
-      List<GlancesNetwork> networks,) {
+  void _showNetworkFilterDialog(
+    BuildContext context,
+    WidgetRef parentRef,
+    List<GlancesNetwork> networks,
+  ) {
     showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) {
@@ -205,8 +222,9 @@ class GlancesHome extends ConsumerWidget {
                         final Set<String> newSet = Set<String>.from(pinnedNets);
                         if (pinnedNets.isEmpty) {
                           if (checked != true) {
-                            newSet.addAll(networks
-                                .map((GlancesNetwork e) => e.interface),);
+                            newSet.addAll(
+                              networks.map((GlancesNetwork e) => e.interface),
+                            );
                             newSet.remove(net.interface);
                           }
                         } else {
@@ -221,7 +239,8 @@ class GlancesHome extends ConsumerWidget {
                         }
                         ref
                             .read(
-                                glancesPinnedNetworkProvider(instance).notifier,)
+                              glancesPinnedNetworkProvider(instance).notifier,
+                            )
                             .set(newSet);
                       },
                     );
@@ -296,8 +315,10 @@ class GlancesHome extends ConsumerWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Text('Swap',
-                          style: Theme.of(context).textTheme.titleSmall,),
+                      Text(
+                        'Swap',
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
                       const SizedBox(height: 6),
                       LinearProgressIndicatorM3E(
                         shape: ProgressM3EShape.flat,
@@ -349,8 +370,11 @@ class GlancesHome extends ConsumerWidget {
           children: <Widget>[
             Row(
               children: <Widget>[
-                Icon(Icons.developer_board,
-                    size: 20, color: theme.colorScheme.primary,),
+                Icon(
+                  Icons.developer_board,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: Insets.sm),
                 Text(
                   'Cores (${cpu.physicalCores} Phys, ${cpu.logicalCores} Log)',
@@ -368,18 +392,24 @@ class GlancesHome extends ConsumerWidget {
                   children: <Widget>[
                     SizedBox(
                       width: 60,
-                      child: Text('Core ${core.id}',
-                          style: theme.textTheme.labelMedium,),
+                      child: Text(
+                        'Core ${core.id}',
+                        style: theme.textTheme.labelMedium,
+                      ),
                     ),
                     Expanded(
                       child: TweenAnimationBuilder<double>(
                         tween: Tween<double>(
-                            begin: 0.0,
-                            end: (core.usage / 100.0).clamp(0.0, 1.0),),
+                          begin: 0.0,
+                          end: (core.usage / 100.0).clamp(0.0, 1.0),
+                        ),
                         duration: const Duration(milliseconds: 600),
                         curve: Curves.easeOutCubic,
-                        builder: (BuildContext context, double value,
-                            Widget? child,) {
+                        builder: (
+                          BuildContext context,
+                          double value,
+                          Widget? child,
+                        ) {
                           return LinearProgressIndicatorM3E(
                             shape: ProgressM3EShape.flat,
                             value: value,
@@ -443,8 +473,7 @@ class GlancesHome extends ConsumerWidget {
             LinearProgressIndicatorM3E(
               shape: ProgressM3EShape.flat,
               value: pct.clamp(0.0, 1.0),
-              trackColor:
-                  Theme.of(context).colorScheme.surfaceContainerHighest,
+              trackColor: Theme.of(context).colorScheme.surfaceContainerHighest,
               activeColor: pct > 0.9
                   ? Theme.of(context).colorScheme.error
                   : Theme.of(context).colorScheme.primary,
@@ -502,16 +531,22 @@ class GlancesHome extends ConsumerWidget {
                   const SizedBox(height: 6),
                   Row(
                     children: <Widget>[
-                      Icon(Icons.arrow_upward,
-                          size: 14, color: theme.colorScheme.tertiary,),
+                      Icon(
+                        Icons.arrow_upward,
+                        size: 14,
+                        color: theme.colorScheme.tertiary,
+                      ),
                       const SizedBox(width: 4),
                       Text(
                         '${_formatBytes(net.txSpeed)}/s',
                         style: theme.textTheme.labelMedium,
                       ),
                       const SizedBox(width: Insets.lg),
-                      Icon(Icons.arrow_downward,
-                          size: 14, color: theme.colorScheme.primary,),
+                      Icon(
+                        Icons.arrow_downward,
+                        size: 14,
+                        color: theme.colorScheme.primary,
+                      ),
                       const SizedBox(width: 4),
                       Text(
                         '${_formatBytes(net.rxSpeed)}/s',
@@ -565,7 +600,9 @@ class _GaugeCard extends StatelessWidget {
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(
-            vertical: Insets.lg, horizontal: Insets.md,),
+          vertical: Insets.lg,
+          horizontal: Insets.md,
+        ),
         child: Column(
           children: <Widget>[
             Row(

--- a/services/service_glances/lib/src/glances_providers.dart
+++ b/services/service_glances/lib/src/glances_providers.dart
@@ -8,16 +8,14 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'glances_api.dart';
 import 'models/glances_stats.dart';
 
-final glancesApiProvider =
-    Provider.family<Future<GlancesApi>, Instance>(
-        (Ref ref, Instance instance) async {
+final glancesApiProvider = Provider.family<Future<GlancesApi>, Instance>(
+    (Ref ref, Instance instance) async {
   final DioFactory factory = ref.watch(dioFactoryProvider);
   return GlancesApi(await factory.create(instance));
 });
 
-final glancesStatsProvider =
-    FutureProvider.autoDispose.family<GlancesStats, Instance>(
-        (Ref ref, Instance instance) async {
+final glancesStatsProvider = FutureProvider.autoDispose
+    .family<GlancesStats, Instance>((Ref ref, Instance instance) async {
   ref.pollEvery(Duration(seconds: instance.pollingIntervalSeconds));
   final GlancesApi api = await ref.watch(glancesApiProvider(instance));
   return api.getStats();

--- a/services/service_jellyfin/lib/src/jellyfin_client.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_client.dart
@@ -40,7 +40,8 @@ class JellyfinClient {
   final String deviceId;
 
   final String? Function(String itemId, String imageType)? getLocalOverride;
-  final void Function(String itemId, String imageType, String tag)? setLocalOverride;
+  final void Function(String itemId, String imageType, String tag)?
+      setLocalOverride;
 
   String? _token;
   String? _userId;
@@ -58,7 +59,8 @@ class JellyfinClient {
     required bool allowSelfSigned,
     Map<String, String> customHeaders = const <String, String>{},
     String? Function(String itemId, String imageType)? getLocalOverride,
-    void Function(String itemId, String imageType, String tag)? setLocalOverride,
+    void Function(String itemId, String imageType, String tag)?
+        setLocalOverride,
   }) {
     final String baseUrlStr = baseUrl.toString();
     final String normalizedBaseUrl =
@@ -137,10 +139,13 @@ class JellyfinClient {
       });
 
   Future<List<JellyfinVirtualFolder>> getVirtualFolders() => _guarded(() async {
-        final Response<dynamic> resp = await _dio.get<dynamic>('Library/VirtualFolders');
-        final List<dynamic> items = (resp.data as List<dynamic>?) ?? <dynamic>[];
+        final Response<dynamic> resp =
+            await _dio.get<dynamic>('Library/VirtualFolders');
+        final List<dynamic> items =
+            (resp.data as List<dynamic>?) ?? <dynamic>[];
         return items
-            .map((dynamic e) => JellyfinVirtualFolder.fromJson(e as Map<String, dynamic>))
+            .map((dynamic e) =>
+                JellyfinVirtualFolder.fromJson(e as Map<String, dynamic>))
             .toList();
       });
 
@@ -716,7 +721,9 @@ class JellyfinClient {
     String tagParam = '';
     int targetIndex = 0;
 
-    if (item.seriesId != null && item.backdropImageTags.isEmpty && !item.imageTags.containsKey('Backdrop')) {
+    if (item.seriesId != null &&
+        item.backdropImageTags.isEmpty &&
+        !item.imageTags.containsKey('Backdrop')) {
       targetId = item.seriesId!;
     }
 
@@ -751,7 +758,9 @@ class JellyfinClient {
   }
 
   Future<List<JellyfinRemoteImage>> getRemoteImages(
-          String itemId, String imageType,) =>
+    String itemId,
+    String imageType,
+  ) =>
       _guarded(() async {
         final Response<dynamic> resp = await _dio.get<dynamic>(
           'Items/$itemId/RemoteImages',
@@ -766,7 +775,10 @@ class JellyfinClient {
       });
 
   Future<void> setRemoteImage(
-          String itemId, String imageUrl, String imageType,) =>
+    String itemId,
+    String imageUrl,
+    String imageType,
+  ) =>
       _guarded(() async {
         List<String> oldBackdrops = <String>[];
         if (imageType == 'Backdrop') {
@@ -827,13 +839,16 @@ class JellyfinClient {
       _guarded(() async {
         final Response<dynamic> resp =
             await _dio.get<dynamic>('ScheduledTasks');
-        final List<dynamic> tasks = (resp.data as List<dynamic>?) ?? <dynamic>[];
+        final List<dynamic> tasks =
+            (resp.data as List<dynamic>?) ?? <dynamic>[];
         for (final dynamic t in tasks) {
           final Map<String, dynamic> task = t as Map<String, dynamic>;
           if (task['Key'] == 'RefreshLibrary') {
             return (
               state: (task['State'] as String?) ?? 'Idle',
-              progress: (task['CurrentProgressPercentage'] as num?)?.toDouble() ?? 0.0,
+              progress:
+                  (task['CurrentProgressPercentage'] as num?)?.toDouble() ??
+                      0.0,
             );
           }
         }
@@ -851,26 +866,31 @@ class JellyfinClient {
             users = map['Items'] as List<dynamic>;
           }
         }
-        return users.map((dynamic u) => JellyfinUser.fromJson(u as Map<String, dynamic>)).toList();
+        return users
+            .map(
+                (dynamic u) => JellyfinUser.fromJson(u as Map<String, dynamic>))
+            .toList();
       });
 
   Future<List<JellyfinUser>> getPublicUsers() async {
-        try {
-          final Response<dynamic> resp = await _dio.get<dynamic>('Users/Public');
-          List<dynamic> users = <dynamic>[];
-          if (resp.data is List) {
-            users = resp.data as List<dynamic>;
-          } else if (resp.data is Map<String, dynamic>) {
-            final Map<String, dynamic> map = resp.data as Map<String, dynamic>;
-            if (map['Items'] != null) {
-              users = map['Items'] as List<dynamic>;
-            }
-          }
-          return users.map((dynamic u) => JellyfinUser.fromJson(u as Map<String, dynamic>)).toList();
-        } catch (e) {
-          return <JellyfinUser>[];
+    try {
+      final Response<dynamic> resp = await _dio.get<dynamic>('Users/Public');
+      List<dynamic> users = <dynamic>[];
+      if (resp.data is List) {
+        users = resp.data as List<dynamic>;
+      } else if (resp.data is Map<String, dynamic>) {
+        final Map<String, dynamic> map = resp.data as Map<String, dynamic>;
+        if (map['Items'] != null) {
+          users = map['Items'] as List<dynamic>;
         }
       }
+      return users
+          .map((dynamic u) => JellyfinUser.fromJson(u as Map<String, dynamic>))
+          .toList();
+    } catch (e) {
+      return <JellyfinUser>[];
+    }
+  }
 
   Future<JellyfinUser> getCurrentUser() => _guarded(() async {
         final Response<dynamic> resp = await _dio.get<dynamic>('Users/Me');
@@ -919,7 +939,8 @@ class JellyfinClient {
         );
         final List<dynamic> list = res.data as List<dynamic>;
         return list
-            .map((dynamic e) => JellyfinRemoteSearchResult.fromJson(e as Map<String, dynamic>))
+            .map((dynamic e) =>
+                JellyfinRemoteSearchResult.fromJson(e as Map<String, dynamic>))
             .toList();
       });
 

--- a/services/service_jellyfin/lib/src/jellyfin_home.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_home.dart
@@ -16,6 +16,7 @@ import 'jellyfin_session_detail_screen.dart';
 import 'models/jellyfin_item.dart';
 import 'models/jellyfin_session.dart';
 import 'models/jellyfin_view.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Container types - tapping drills into children. Everything else plays.
 /// (See the note in JellyfinHome: we dispatch on "is it a container?" so an
@@ -46,8 +47,10 @@ class JellyfinHome extends ConsumerStatefulWidget {
 class _JellyfinHomeState extends ConsumerState<JellyfinHome> {
   @override
   Widget build(BuildContext context) {
-    final AsyncValue<List<JellyfinView>> viewsAsync = ref.watch(jellyfinViewsProvider(widget.instance));
-    final int index = ref.watch(jellyfinActiveTabBarIndexProvider(widget.instance));
+    final AsyncValue<List<JellyfinView>> viewsAsync =
+        ref.watch(jellyfinViewsProvider(widget.instance));
+    final int index =
+        ref.watch(jellyfinActiveTabBarIndexProvider(widget.instance));
 
     return AsyncValueView<List<JellyfinView>>(
       value: viewsAsync,
@@ -60,11 +63,12 @@ class _JellyfinHomeState extends ConsumerState<JellyfinHome> {
             message: 'This Jellyfin server has no libraries to show.',
           );
         }
-        
-        final String libsKey = libraries.map((JellyfinView l) => l.id).join(',');
+
+        final String libsKey =
+            libraries.map((JellyfinView l) => l.id).join(',');
         final int targetLength = libraries.length + 3;
         final int initialIndex = (index < targetLength) ? index : 0;
-        
+
         return DefaultTabController(
           key: ValueKey<String>(libsKey),
           length: targetLength,
@@ -684,11 +688,10 @@ class JellyfinPosterCard extends ConsumerWidget {
                           ),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(6),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress.clamp(0, 1),
-                              minHeight: 6,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.5),
+                              trackColor: Colors.black.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -859,7 +862,8 @@ class JellyfinBannerCard extends ConsumerWidget {
                             ref.read(jellyfinClientProvider(instance)).value;
                         if (client != null) {
                           try {
-                            final bool isFav = item.userData?.isFavorite == true;
+                            final bool isFav =
+                                item.userData?.isFavorite == true;
                             await client.markFavorite(item.id, !isFav);
                             if (!context.mounted) return;
                             ref.invalidate(
@@ -868,7 +872,8 @@ class JellyfinBannerCard extends ConsumerWidget {
                             ref.invalidate(jellyfinFavoritesProvider(instance));
                             ref.invalidate(jellyfinItemsProvider);
                             ref.invalidate(jellyfinNextUpProvider(instance));
-                            ref.invalidate(jellyfinResumeItemsProvider(instance));
+                            ref.invalidate(
+                                jellyfinResumeItemsProvider(instance));
                           } catch (_) {
                             // Action failed; no revert needed.
                           }
@@ -896,7 +901,8 @@ class JellyfinBannerCard extends ConsumerWidget {
                             );
                             ref.invalidate(jellyfinItemsProvider);
                             ref.invalidate(jellyfinNextUpProvider(instance));
-                            ref.invalidate(jellyfinResumeItemsProvider(instance));
+                            ref.invalidate(
+                                jellyfinResumeItemsProvider(instance));
                           }
                         },
                       ),
@@ -1045,10 +1051,10 @@ class JellyfinBannerCard extends ConsumerWidget {
                               const SizedBox(height: 8),
                               ClipRRect(
                                 borderRadius: BorderRadius.circular(6),
-                                child: LinearProgressIndicator(
+                                child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
                                   value: progress.clamp(0, 1),
-                                  minHeight: 6,
-                                  backgroundColor:
+                                  trackColor:
                                       Colors.black.withValues(alpha: 0.1),
                                 ),
                               ),
@@ -1415,37 +1421,209 @@ class _SessionCardState extends State<_SessionCard> {
           borderRadius: BorderRadius.circular(24),
         ),
         child: InkWell(
-        onTap: () => pushScreen<void>(
-          context,
-          JellyfinSessionDetailScreen(
-            initialSession: session,
-            instance: widget.instance,
+          onTap: () => pushScreen<void>(
+            context,
+            JellyfinSessionDetailScreen(
+              initialSession: session,
+              instance: widget.instance,
+            ),
           ),
-        ),
-        child: Stack(
-          children: <Widget>[
-            // Backdrop
-            if (session.posterUrl != null)
-              Positioned.fill(
-                child: Stack(
-                  fit: StackFit.expand,
+          child: Stack(
+            children: <Widget>[
+              // Backdrop
+              if (session.posterUrl != null)
+                Positioned.fill(
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: <Widget>[
+                      Image.network(
+                        session.posterUrl!,
+                        fit: BoxFit.cover,
+                        alignment: Alignment.topCenter,
+                        errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                      ),
+                      Container(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: <Color>[
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.3),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.85),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.95),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+              // Content
+              Padding(
+                padding: const EdgeInsets.all(Insets.md),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Image.network(
-                      session.posterUrl!,
-                      fit: BoxFit.cover,
-                      alignment: Alignment.topCenter,
-                      errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    // Poster
+                    ConstrainedBox(
+                      constraints:
+                          const BoxConstraints(maxWidth: 120, maxHeight: 126),
+                      child: AspectRatio(
+                        aspectRatio: session.aspectRatio != null &&
+                                session.aspectRatio! > 0.0
+                            ? session.aspectRatio!
+                            : (2 / 3),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(12),
+                            boxShadow: <BoxShadow>[
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.25),
+                                blurRadius: 12,
+                                offset: const Offset(0, 6),
+                              ),
+                            ],
+                            image: session.posterUrl != null
+                                ? DecorationImage(
+                                    image: NetworkImage(session.posterUrl!),
+                                    fit: BoxFit.cover,
+                                  )
+                                : null,
+                          ),
+                          child: session.posterUrl == null
+                              ? Icon(
+                                  Icons.movie_outlined,
+                                  color: theme.colorScheme.outline,
+                                  size: 32,
+                                )
+                              : null,
+                        ),
+                      ),
                     ),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: <Color>[
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.3),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.85),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.95),
+                    const SizedBox(width: Insets.lg),
+
+                    // Details
+                    Expanded(
+                      child: SizedBox(
+                        height: 126,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            // Title
+                            Text(
+                              session.showTitle,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18,
+                                shadows: <Shadow>[
+                                  Shadow(
+                                    color: Colors.black.withValues(alpha: 0.8),
+                                    offset: const Offset(0, 2),
+                                    blurRadius: 4,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+
+                            if (session.episodeName != null)
+                              Text(
+                                session.episodeName!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                  shadows: <Shadow>[
+                                    Shadow(
+                                      color:
+                                          Colors.black.withValues(alpha: 0.8),
+                                      offset: const Offset(0, 1),
+                                      blurRadius: 3,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                            const SizedBox(height: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.surfaceContainerHighest
+                                    .withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: theme.colorScheme.outlineVariant
+                                      .withValues(alpha: 0.5),
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: <Widget>[
+                                  Icon(
+                                    Icons.person,
+                                    size: 14,
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Flexible(
+                                    child: Text(
+                                      '${session.user}: ${session.device}',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
+                                        color:
+                                            theme.colorScheme.onSurfaceVariant,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+
+                            const Spacer(),
+
+                            // Progress Header
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: <Widget>[
+                                Text(
+                                  session.timePosition,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                Text(
+                                  session.timeDuration,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+
+                            // Progress Bar
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
+                                  value: pct.clamp(0.0, 1.0),
+                                  trackColor:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  activeColor: playing
+                                      ? theme.colorScheme.primary
+                                      : theme.colorScheme.outline),
+                            ),
                           ],
                         ),
                       ),
@@ -1453,181 +1631,9 @@ class _SessionCardState extends State<_SessionCard> {
                   ],
                 ),
               ),
-
-            // Content
-            Padding(
-              padding: const EdgeInsets.all(Insets.md),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  // Poster
-                  ConstrainedBox(
-                    constraints:
-                        const BoxConstraints(maxWidth: 120, maxHeight: 126),
-                    child: AspectRatio(
-                      aspectRatio: session.aspectRatio != null &&
-                              session.aspectRatio! > 0.0
-                          ? session.aspectRatio!
-                          : (2 / 3),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(12),
-                          boxShadow: <BoxShadow>[
-                            BoxShadow(
-                              color: Colors.black.withValues(alpha: 0.25),
-                              blurRadius: 12,
-                              offset: const Offset(0, 6),
-                            ),
-                          ],
-                          image: session.posterUrl != null
-                              ? DecorationImage(
-                                  image: NetworkImage(session.posterUrl!),
-                                  fit: BoxFit.cover,
-                                )
-                              : null,
-                        ),
-                        child: session.posterUrl == null
-                            ? Icon(
-                                Icons.movie_outlined,
-                                color: theme.colorScheme.outline,
-                                size: 32,
-                              )
-                            : null,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: Insets.lg),
-
-                  // Details
-                  Expanded(
-                    child: SizedBox(
-                      height: 126,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          // Title
-                          Text(
-                            session.showTitle,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 18,
-                              shadows: <Shadow>[
-                                Shadow(
-                                  color: Colors.black.withValues(alpha: 0.8),
-                                  offset: const Offset(0, 2),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-
-                          if (session.episodeName != null)
-                            Text(
-                              session.episodeName!,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                                shadows: <Shadow>[
-                                  Shadow(
-                                    color: Colors.black.withValues(alpha: 0.8),
-                                    offset: const Offset(0, 1),
-                                    blurRadius: 3,
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                          const SizedBox(height: 4),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest
-                                  .withValues(alpha: 0.5),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: theme.colorScheme.outlineVariant
-                                    .withValues(alpha: 0.5),
-                              ),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: <Widget>[
-                                Icon(
-                                  Icons.person,
-                                  size: 14,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                                const SizedBox(width: 4),
-                                Flexible(
-                                  child: Text(
-                                    '${session.user}: ${session.device}',
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: theme.textTheme.bodySmall?.copyWith(
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                          const Spacer(),
-
-                          // Progress Header
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: <Widget>[
-                              Text(
-                                session.timePosition,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                              Text(
-                                session.timeDuration,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  color: theme.colorScheme.outline,
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 6),
-
-                          // Progress Bar
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(8),
-                            child: LinearProgressIndicator(
-                              value: pct.clamp(0.0, 1.0),
-                              minHeight: 8,
-                              backgroundColor:
-                                  theme.colorScheme.surfaceContainerHighest,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                playing
-                                    ? theme.colorScheme.primary
-                                    : theme.colorScheme.outline,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
       ),
     );
   }

--- a/services/service_jellyfin/lib/src/jellyfin_identify_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_identify_screen.dart
@@ -20,10 +20,12 @@ class JellyfinIdentifyScreen extends ConsumerStatefulWidget {
   final JellyfinItem item;
 
   @override
-  ConsumerState<JellyfinIdentifyScreen> createState() => _JellyfinIdentifyScreenState();
+  ConsumerState<JellyfinIdentifyScreen> createState() =>
+      _JellyfinIdentifyScreenState();
 }
 
-class _JellyfinIdentifyScreenState extends ConsumerState<JellyfinIdentifyScreen> {
+class _JellyfinIdentifyScreenState
+    extends ConsumerState<JellyfinIdentifyScreen> {
   late final TextEditingController _nameController;
   late final TextEditingController _yearController;
   late final TextEditingController _imdbController;
@@ -66,7 +68,7 @@ class _JellyfinIdentifyScreenState extends ConsumerState<JellyfinIdentifyScreen>
     try {
       final yearText = _yearController.text.trim();
       final year = yearText.isNotEmpty ? int.tryParse(yearText) : null;
-      
+
       final providerIds = <String, String>{};
       if (_imdbController.text.trim().isNotEmpty) {
         providerIds['Imdb'] = _imdbController.text.trim();
@@ -139,7 +141,7 @@ class _JellyfinIdentifyScreenState extends ConsumerState<JellyfinIdentifyScreen>
         result,
         replaceAllImages: replace,
       );
-      
+
       if (mounted) {
         Navigator.pop(context); // close loading
         Navigator.pop(context, true); // close identify screen
@@ -221,7 +223,8 @@ class _JellyfinIdentifyScreenState extends ConsumerState<JellyfinIdentifyScreen>
                     const SizedBox(height: Insets.md),
                     Text(
                       _error!,
-                      style: TextStyle(color: Theme.of(context).colorScheme.error),
+                      style:
+                          TextStyle(color: Theme.of(context).colorScheme.error),
                     ),
                   ],
                 ],
@@ -240,11 +243,13 @@ class _JellyfinIdentifyScreenState extends ConsumerState<JellyfinIdentifyScreen>
                             width: 40,
                             height: 60,
                             fit: BoxFit.cover,
-                            errorBuilder: (_, __, ___) => const Icon(Icons.image),
+                            errorBuilder: (_, __, ___) =>
+                                const Icon(Icons.image),
                           )
                         : const Icon(Icons.movie),
                     title: Text(res.name ?? 'Unknown'),
-                    subtitle: Text('${res.productionYear ?? ''} • ${res.searchProviderName ?? ''}'),
+                    subtitle: Text(
+                        '${res.productionYear ?? ''} • ${res.searchProviderName ?? ''}'),
                     onTap: () => _apply(res),
                   );
                 },

--- a/services/service_jellyfin/lib/src/jellyfin_item_detail.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_item_detail.dart
@@ -84,16 +84,21 @@ class JellyfinItemDetailScreen extends ConsumerWidget {
                       ),
                     );
                     if (changed == true && context.mounted) {
-                      ref.invalidate(jellyfinItemDetailsProvider((instance, itemId)));
+                      ref.invalidate(
+                          jellyfinItemDetailsProvider((instance, itemId)));
                     }
                   } else if (choice == 'refresh') {
                     try {
-                      await ref.read(jellyfinClientProvider(instance)).value?.refreshMetadata(itemId);
+                      await ref
+                          .read(jellyfinClientProvider(instance))
+                          .value
+                          ?.refreshMetadata(itemId);
                       if (context.mounted) {
                         ScaffoldMessenger.of(context).showSnackBar(
                           const SnackBar(content: Text('Refresh queued')),
                         );
-                        ref.invalidate(jellyfinItemDetailsProvider((instance, itemId)));
+                        ref.invalidate(
+                            jellyfinItemDetailsProvider((instance, itemId)));
                       }
                     } catch (e) {
                       if (context.mounted) {
@@ -223,7 +228,9 @@ class JellyfinItemDetailScreen extends ConsumerWidget {
                       children: item.genres.map((String g) {
                         return Container(
                           padding: const EdgeInsets.symmetric(
-                              horizontal: 10, vertical: 4,),
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
                           decoration: BoxDecoration(
                             color: Theme.of(context)
                                 .colorScheme

--- a/services/service_jellyfin/lib/src/jellyfin_music_screens.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_music_screens.dart
@@ -130,17 +130,19 @@ class JellyfinAlbumScreen extends ConsumerWidget {
                           vertical: 4,
                         ),
                         decoration: BoxDecoration(
-                          color: Theme.of(context).colorScheme.secondaryContainer,
+                          color:
+                              Theme.of(context).colorScheme.secondaryContainer,
                           borderRadius: BorderRadius.circular(12),
                         ),
                         child: Text(
                           g,
-                          style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                color: Theme.of(context)
-                                    .colorScheme
-                                    .onSecondaryContainer,
-                                fontWeight: FontWeight.w500,
-                              ),
+                          style:
+                              Theme.of(context).textTheme.bodySmall?.copyWith(
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSecondaryContainer,
+                                    fontWeight: FontWeight.w500,
+                                  ),
                         ),
                       );
                     }).toList(),
@@ -211,7 +213,8 @@ class JellyfinAlbumScreen extends ConsumerWidget {
                             ),
                             onTap: () {
                               if (client != null) {
-                                launchJellyfinDeepLink(context, client, song.id);
+                                launchJellyfinDeepLink(
+                                    context, client, song.id);
                               }
                             },
                             leading: Row(
@@ -250,7 +253,8 @@ class JellyfinAlbumScreen extends ConsumerWidget {
                                           color: Theme.of(context)
                                               .colorScheme
                                               .surfaceContainerHighest,
-                                          borderRadius: BorderRadius.circular(4),
+                                          borderRadius:
+                                              BorderRadius.circular(4),
                                         ),
                                         child: const Icon(Icons.music_note),
                                       ),
@@ -372,4 +376,3 @@ class JellyfinAlbumScreen extends ConsumerWidget {
     );
   }
 }
-

--- a/services/service_jellyfin/lib/src/jellyfin_providers.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_providers.dart
@@ -40,7 +40,8 @@ final jellyfinClientProvider = FutureProvider.family<JellyfinClient, Instance>((
     deviceId: instance.id,
     allowSelfSigned: instance.allowSelfSignedCerts,
     customHeaders: customHeaders,
-    getLocalOverride: (String itemId, String type) => overridesBox.get('${instance.id}_${itemId}_$type'),
+    getLocalOverride: (String itemId, String type) =>
+        overridesBox.get('${instance.id}_${itemId}_$type'),
     setLocalOverride: (String itemId, String type, String tag) {
       if (tag.isEmpty) {
         overridesBox.delete('${instance.id}_${itemId}_$type');
@@ -54,11 +55,13 @@ final jellyfinClientProvider = FutureProvider.family<JellyfinClient, Instance>((
 });
 
 /// Libraries for an instance.
-final jellyfinViewsProvider = FutureProvider.family<List<JellyfinView>, Instance>((
+final jellyfinViewsProvider =
+    FutureProvider.family<List<JellyfinView>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
-  final JellyfinClient client = await ref.watch(jellyfinClientProvider(instance).future);
+  final JellyfinClient client =
+      await ref.watch(jellyfinClientProvider(instance).future);
   return client.getViews();
 });
 
@@ -169,8 +172,8 @@ final jellyfinEpisodesProvider =
   return client.getEpisodes(seriesId, seasonId);
 });
 
-final jellyfinLibraryScanProvider =
-    StreamProvider.autoDispose.family<({String state, double progress})?, Instance>((
+final jellyfinLibraryScanProvider = StreamProvider.autoDispose
+    .family<({String state, double progress})?, Instance>((
   Ref ref,
   Instance instance,
 ) async* {
@@ -322,8 +325,8 @@ final jellyfinFastSessionsProvider =
   }
 });
 
-final jellyfinRemoteImagesProvider = FutureProvider.autoDispose.family<
-    List<JellyfinRemoteImage>, (Instance, String, String)>((
+final jellyfinRemoteImagesProvider = FutureProvider.autoDispose
+    .family<List<JellyfinRemoteImage>, (Instance, String, String)>((
   Ref ref,
   (Instance, String, String) key,
 ) async {

--- a/services/service_jellyfin/lib/src/jellyfin_remote_images_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_remote_images_screen.dart
@@ -50,7 +50,6 @@ class _JellyfinRemoteImagesScreenState
         }
       }
 
-
       await client.setRemoteImage(widget.itemId, imageUrl, widget.imageType);
 
       // Evict untagged URL from cache for sessions that don't use tags
@@ -95,7 +94,8 @@ class _JellyfinRemoteImagesScreenState
 
       // Invalidate relevant providers to force refresh of the image
       ref.invalidate(
-          jellyfinItemDetailsProvider((widget.instance, widget.itemId)),);
+        jellyfinItemDetailsProvider((widget.instance, widget.itemId)),
+      );
       ref.invalidate(jellyfinItemsProvider);
       ref.invalidate(jellyfinLibraryItemsProvider);
       ref.invalidate(jellyfinFastSessionsProvider(widget.instance));
@@ -117,7 +117,8 @@ class _JellyfinRemoteImagesScreenState
       setState(() => _isSaving = false);
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: Text('Failed to update ${widget.imageType.toLowerCase()}: $e'),
+          content:
+              Text('Failed to update ${widget.imageType.toLowerCase()}: $e'),
           behavior: SnackBarBehavior.floating,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(16),
@@ -155,7 +156,8 @@ class _JellyfinRemoteImagesScreenState
   Widget build(BuildContext context) {
     final AsyncValue<List<JellyfinRemoteImage>> imagesAsync = ref.watch(
       jellyfinRemoteImagesProvider(
-          (widget.instance, widget.itemId, widget.imageType),),
+        (widget.instance, widget.itemId, widget.imageType),
+      ),
     );
 
     return Scaffold(
@@ -168,7 +170,8 @@ class _JellyfinRemoteImagesScreenState
             value: imagesAsync,
             onRetry: () => ref.invalidate(
               jellyfinRemoteImagesProvider(
-                  (widget.instance, widget.itemId, widget.imageType),),
+                (widget.instance, widget.itemId, widget.imageType),
+              ),
             ),
             data: (List<JellyfinRemoteImage> images) {
               if (images.isEmpty) {

--- a/services/service_jellyfin/lib/src/jellyfin_search.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_search.dart
@@ -157,7 +157,10 @@ class _SearchResults extends ConsumerWidget {
   }
 
   void _openItem(
-      BuildContext context, JellyfinClient client, JellyfinItem item,) {
+    BuildContext context,
+    JellyfinClient client,
+    JellyfinItem item,
+  ) {
     if (item.type == 'MusicAlbum') {
       pushScreen<void>(
         context,

--- a/services/service_jellyfin/lib/src/jellyfin_session_detail_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_session_detail_screen.dart
@@ -57,7 +57,8 @@ class _JellyfinSessionDetailScreenState
     final AsyncValue<List<ActiveSession>> sessionsAsync =
         ref.watch(jellyfinFastSessionsProvider(widget.instance));
     final ActiveSession session = sessionsAsync.value?.firstWhereOrNull(
-            (ActiveSession s) => s.id == widget.initialSession.id,) ??
+          (ActiveSession s) => s.id == widget.initialSession.id,
+        ) ??
         widget.initialSession;
 
     final String? posterUrl = session.posterUrl;
@@ -70,8 +71,8 @@ class _JellyfinSessionDetailScreenState
       final Color vibrant = _palette!.vibrantColor?.color ??
           _palette!.lightVibrantColor?.color ??
           dominant;
-      final Color muted =
-          _palette!.mutedColor?.color ?? theme.colorScheme.surfaceContainerHighest;
+      final Color muted = _palette!.mutedColor?.color ??
+          theme.colorScheme.surfaceContainerHighest;
       final Color darkMuted = _palette!.darkMutedColor?.color ?? dominant;
       final Color titleText = _palette!.dominantColor?.titleTextColor ??
           theme.colorScheme.onSurface;
@@ -105,615 +106,692 @@ class _JellyfinSessionDetailScreenState
     return Theme(
       data: theme,
       child: Scaffold(
-      extendBodyBehindAppBar: true,
-      appBar: AppBar(
-        backgroundColor: Colors.transparent,
-        elevation: 0,
-        leading: IconButton(
-          icon: const Icon(Icons.keyboard_arrow_down, size: 32),
-          onPressed: () => Navigator.of(context).pop(),
+        extendBodyBehindAppBar: true,
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          leading: IconButton(
+            icon: const Icon(Icons.keyboard_arrow_down, size: 32),
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          title: Column(
+            children: <Widget>[
+              Text(
+                'STREAMING ON',
+                style: theme.textTheme.labelSmall?.copyWith(
+                  letterSpacing: 1.2,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white70,
+                ),
+              ),
+              Text(
+                session.device,
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  color: theme.colorScheme.primary,
+                ),
+              ),
+            ],
+          ),
+          centerTitle: true,
         ),
-        title: Column(
+        body: Stack(
+          fit: StackFit.expand,
           children: <Widget>[
-            Text(
-              'STREAMING ON',
-              style: theme.textTheme.labelSmall?.copyWith(
-                letterSpacing: 1.2,
-                fontWeight: FontWeight.w600,
-                color: Colors.white70,
+            // Background blurred image
+            if (session.posterUrl != null)
+              Image(
+                image: CachedNetworkImageProvider(session.posterUrl!),
+                fit: BoxFit.cover,
+                errorBuilder: (_, __, ___) =>
+                    Container(color: theme.colorScheme.surface),
               ),
-            ),
-            Text(
-              session.device,
-              style: theme.textTheme.titleSmall?.copyWith(
-                fontWeight: FontWeight.bold,
-                color: theme.colorScheme.primary,
-              ),
-            ),
-          ],
-        ),
-        centerTitle: true,
-      ),
-      body: Stack(
-        fit: StackFit.expand,
-        children: <Widget>[
-          // Background blurred image
-          if (session.posterUrl != null)
-            Image(
-              image: CachedNetworkImageProvider(session.posterUrl!),
-              fit: BoxFit.cover,
-              errorBuilder: (_, __, ___) =>
-                  Container(color: theme.colorScheme.surface),
-            ),
-          // Blur and gradient overlay
-          BackdropFilter(
-            filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
-            child: Container(
-              decoration: BoxDecoration(
-                gradient: LinearGradient(
-                  begin: Alignment.topCenter,
-                  end: Alignment.bottomCenter,
-                  colors: <Color>[
-                    Colors.black.withValues(alpha: 0.5),
-                    theme.colorScheme.surface.withValues(alpha: 0.8),
-                    Colors.black.withValues(alpha: 0.95),
-                  ],
+            // Blur and gradient overlay
+            BackdropFilter(
+              filter: ImageFilter.blur(sigmaX: 20, sigmaY: 20),
+              child: Container(
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    colors: <Color>[
+                      Colors.black.withValues(alpha: 0.5),
+                      theme.colorScheme.surface.withValues(alpha: 0.8),
+                      Colors.black.withValues(alpha: 0.95),
+                    ],
+                  ),
                 ),
               ),
             ),
-          ),
-          // Content
-          SafeArea(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: Insets.xl),
-              child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: <Widget>[
-                  // Volume Control
-                  Row(
-                    children: <Widget>[
-                      IconButton(
-                        icon: Icon(
-                          session.isMuted || session.volumeLevel == 0
-                              ? Icons.volume_off
-                              : Icons.volume_up,
-                          color: theme.colorScheme.primary,
-                        ),
-                        onPressed: () async {
-                          final ScaffoldMessengerState messenger =
-                              ScaffoldMessenger.of(context);
-                          try {
-                            final JellyfinClient client = await ref.read(
-                                jellyfinClientProvider(widget.instance).future,);
-                            await client.toggleMute(session.id);
-                            if (mounted) {
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
+            // Content
+            SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: Insets.xl),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    // Volume Control
+                    Row(
+                      children: <Widget>[
+                        IconButton(
+                          icon: Icon(
+                            session.isMuted || session.volumeLevel == 0
+                                ? Icons.volume_off
+                                : Icons.volume_up,
+                            color: theme.colorScheme.primary,
+                          ),
+                          onPressed: () async {
+                            final ScaffoldMessengerState messenger =
+                                ScaffoldMessenger.of(context);
+                            try {
+                              final JellyfinClient client = await ref.read(
+                                jellyfinClientProvider(widget.instance).future,
+                              );
+                              await client.toggleMute(session.id);
+                              if (mounted) {
+                                ref.invalidate(
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
+                              }
+                            } catch (_) {
+                              messenger.showSnackBar(
+                                const SnackBar(content: Text('Action failed')),
+                              );
                             }
-                          } catch (_) {
-                            messenger.showSnackBar(
-                              const SnackBar(content: Text('Action failed')),
-                            );
-                          }
-                        },
+                          },
+                        ),
+                        Expanded(
+                          child: SliderTheme(
+                            data: SliderTheme.of(context).copyWith(
+                              trackHeight: 16,
+                              thumbShape: const ExpressiveSliderThumbShape(),
+                              trackShape: const ExpressiveSliderTrackShape(),
+                              overlayShape: const RoundSliderOverlayShape(),
+                              activeTrackColor: theme.colorScheme.primary,
+                              inactiveTrackColor:
+                                  Colors.white.withValues(alpha: 0.2),
+                              thumbColor: theme.colorScheme.primary,
+                            ),
+                            child: Slider(
+                              value: _isVolumeDragging
+                                  ? _volumeDragPct
+                                  : (session.volumeLevel / 100.0)
+                                      .clamp(0.0, 1.0),
+                              onChangeStart: (double val) {
+                                setState(() {
+                                  _isVolumeDragging = true;
+                                  _volumeDragPct = val;
+                                });
+                              },
+                              onChanged: (double val) {
+                                setState(() {
+                                  _volumeDragPct = val;
+                                });
+                              },
+                              onChangeEnd: (double val) async {
+                                setState(() {
+                                  _isVolumeDragging = false;
+                                });
+                                final int targetVol = (val * 100).round();
+                                final ScaffoldMessengerState messenger =
+                                    ScaffoldMessenger.of(context);
+                                try {
+                                  final JellyfinClient client = await ref.read(
+                                    jellyfinClientProvider(widget.instance)
+                                        .future,
+                                  );
+                                  await client.setVolume(session.id, targetVol);
+                                  if (mounted) {
+                                    ref.invalidate(
+                                      jellyfinFastSessionsProvider(
+                                        widget.instance,
+                                      ),
+                                    );
+                                  }
+                                } catch (_) {
+                                  messenger.showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Action failed'),
+                                    ),
+                                  );
+                                }
+                              },
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: Insets.md),
+                      ],
+                    ),
+
+                    const Spacer(),
+
+                    // Artwork with animated music bars
+                    Flexible(
+                      flex: 10,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          // Left animated music bars
+                          AnimatedMusicBars(
+                            color: theme.colorScheme.primary,
+                            isPlaying: playing,
+                          ),
+                          const SizedBox(width: Insets.sm),
+                          // Album art
+                          Flexible(
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                  maxHeight: 420, maxWidth: 420),
+                              child: AspectRatio(
+                                aspectRatio: session.aspectRatio != null &&
+                                        session.aspectRatio! > 0.0
+                                    ? session.aspectRatio!
+                                    : (2 / 3),
+                                child: Container(
+                                  decoration: BoxDecoration(
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
+                                    borderRadius: Radii.card,
+                                    boxShadow: <BoxShadow>[
+                                      BoxShadow(
+                                        color:
+                                            Colors.black.withValues(alpha: 0.4),
+                                        blurRadius: 20,
+                                        offset: const Offset(0, 10),
+                                      ),
+                                    ],
+                                    image: session.posterUrl != null
+                                        ? DecorationImage(
+                                            image: CachedNetworkImageProvider(
+                                              session.posterUrl!,
+                                            ),
+                                            fit: BoxFit.cover,
+                                          )
+                                        : null,
+                                  ),
+                                  child: session.posterUrl == null
+                                      ? Icon(
+                                          Icons.movie_outlined,
+                                          color: theme.colorScheme.outline,
+                                          size: 80,
+                                        )
+                                      : null,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: Insets.sm),
+                          // Right animated music bars
+                          AnimatedMusicBars(
+                            color: theme.colorScheme.primary,
+                            isPlaying: playing,
+                          ),
+                        ],
                       ),
-                      Expanded(
-                        child: SliderTheme(
-                          data: SliderTheme.of(context).copyWith(
+                    ),
+
+                    const SizedBox(height: Insets.lg),
+
+                    // Track Info
+                    Align(
+                      alignment: Alignment.centerLeft,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          SizedBox(
+                            height:
+                                (theme.textTheme.titleLarge?.fontSize ?? 22) *
+                                    1.5,
+                            child: AutoScrollText(
+                              text: session.showTitle,
+                              style: theme.textTheme.titleLarge?.copyWith(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                height: 1.2,
+                              ),
+                            ),
+                          ),
+                          if (session.episodeName != null) ...<Widget>[
+                            const SizedBox(height: Insets.xs),
+                            SizedBox(
+                              height: (theme.textTheme.titleMedium?.fontSize ??
+                                      16) *
+                                  1.5,
+                              child: AutoScrollText(
+                                text: session.episodeName!,
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ],
+                      ),
+                    ),
+
+                    // Progress Bar & Timestamps
+                    Column(
+                      children: <Widget>[
+                        SliderTheme(
+                          data: SliderThemeData(
                             trackHeight: 16,
+                            activeTrackColor: theme.colorScheme.primary,
+                            inactiveTrackColor:
+                                theme.colorScheme.surfaceContainerHighest,
+                            thumbColor: theme.colorScheme.primary,
                             thumbShape: const ExpressiveSliderThumbShape(),
                             trackShape: const ExpressiveSliderTrackShape(),
                             overlayShape: const RoundSliderOverlayShape(),
-                            activeTrackColor: theme.colorScheme.primary,
-                            inactiveTrackColor: Colors.white.withValues(alpha: 0.2),
-                            thumbColor: theme.colorScheme.primary,
                           ),
                           child: Slider(
-                            value: _isVolumeDragging
-                                ? _volumeDragPct
-                                : (session.volumeLevel / 100.0)
-                                    .clamp(0.0, 1.0),
-                            onChangeStart: (double val) {
+                            value: pct.clamp(0.0, 1.0),
+                            onChangeStart: (_) => setState(() {
+                              _isDragging = true;
+                              _dragPct = pct;
+                            }),
+                            onChanged: (double newValue) {
                               setState(() {
-                                _isVolumeDragging = true;
-                                _volumeDragPct = val;
+                                _dragPct = newValue;
                               });
                             },
-                            onChanged: (double val) {
-                              setState(() {
-                                _volumeDragPct = val;
-                              });
+                            onChangeEnd: (double newValue) async {
+                              setState(() => _isDragging = false);
+                              if (session.durationTicks > 0) {
+                                final int targetTicks =
+                                    (session.durationTicks * newValue).round();
+                                final ScaffoldMessengerState messenger =
+                                    ScaffoldMessenger.of(context);
+                                try {
+                                  final JellyfinClient client = await ref.read(
+                                    jellyfinClientProvider(widget.instance)
+                                        .future,
+                                  );
+                                  await client.seekSession(
+                                    session.id,
+                                    targetTicks,
+                                  );
+                                  if (!mounted) return;
+                                  ref.invalidate(
+                                    jellyfinFastSessionsProvider(
+                                        widget.instance),
+                                  );
+                                } catch (_) {
+                                  messenger.showSnackBar(
+                                    const SnackBar(
+                                      content: Text('Action failed'),
+                                    ),
+                                  );
+                                }
+                              }
                             },
-                            onChangeEnd: (double val) async {
-                              setState(() {
-                                _isVolumeDragging = false;
-                              });
-                              final int targetVol = (val * 100).round();
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 24,
+                          ), // Align with slider track
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                            children: <Widget>[
+                              Text(
+                                session.timePosition,
+                                style: theme.textTheme.labelMedium?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              Text(
+                                session.timeDuration,
+                                style: theme.textTheme.labelMedium?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: Insets.md),
+
+                    // Row 1: 10s back, Play/Pause, 10s forward
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            onPressed: () async {
                               final ScaffoldMessengerState messenger =
                                   ScaffoldMessenger.of(context);
                               try {
                                 final JellyfinClient client = await ref.read(
-                                    jellyfinClientProvider(widget.instance).future,);
-                                await client.setVolume(session.id, targetVol);
-                                if (mounted) {
-                                  ref.invalidate(jellyfinFastSessionsProvider(
-                                      widget.instance,),);
-                                }
+                                  jellyfinClientProvider(widget.instance)
+                                      .future,
+                                );
+                                final int targetTicks =
+                                    session.positionTicks - 10000000;
+                                await client.seekSession(session.id,
+                                    targetTicks < 0 ? 0 : targetTicks);
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
                               } catch (_) {
                                 messenger.showSnackBar(
                                   const SnackBar(
-                                      content: Text('Action failed'),),
+                                    content: Text('Action failed'),
+                                  ),
                                 );
                               }
                             },
+                            child: const Icon(Icons.replay_10, size: 32),
                           ),
                         ),
-                      ),
-                      const SizedBox(width: Insets.md),
-                    ],
-                  ),
-
-                            const Spacer(),
-
-                            // Artwork with animated music bars
-                            Flexible(
-                              flex: 10,
-                              child: Row(
-                                mainAxisAlignment: MainAxisAlignment.center,
-                                children: <Widget>[
-                                  // Left animated music bars
-                                  AnimatedMusicBars(
-                                    color: theme.colorScheme.primary,
-                                    isPlaying: playing,
-                                  ),
-                                  const SizedBox(width: Insets.sm),
-                                  // Album art
-                                  Flexible(
-                                    child: ConstrainedBox(
-                                      constraints:
-                                          const BoxConstraints(maxHeight: 420, maxWidth: 420),
-                                      child: AspectRatio(
-                                        aspectRatio: session.aspectRatio != null &&
-                                                session.aspectRatio! > 0.0
-                                            ? session.aspectRatio!
-                                            : (2 / 3),
-                                        child: Container(
-                                          decoration: BoxDecoration(
-                                            color: theme.colorScheme.surfaceContainerHighest,
-                                            borderRadius: Radii.card,
-                                            boxShadow: <BoxShadow>[
-                                              BoxShadow(
-                                                color: Colors.black.withValues(alpha: 0.4),
-                                                blurRadius: 20,
-                                                offset: const Offset(0, 10),
-                                              ),
-                                            ],
-                                            image: session.posterUrl != null
-                                                ? DecorationImage(
-                                                    image: CachedNetworkImageProvider(
-                                                        session.posterUrl!,),
-                                                    fit: BoxFit.cover,
-                                                  )
-                                                : null,
-                                          ),
-                                          child: session.posterUrl == null
-                                              ? Icon(Icons.movie_outlined,
-                                                  color: theme.colorScheme.outline, size: 80,)
-                                              : null,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                  const SizedBox(width: Insets.sm),
-                                  // Right animated music bars
-                                  AnimatedMusicBars(
-                                    color: theme.colorScheme.primary,
-                                    isPlaying: playing,
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                  const SizedBox(height: Insets.lg),
-
-                  // Track Info
-                  Align(
-                    alignment: Alignment.centerLeft,
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
+                        const SizedBox(width: Insets.lg),
                         SizedBox(
-                          height: (theme.textTheme.titleLarge?.fontSize ?? 22) *
-                              1.5,
-                          child: AutoScrollText(
-                            text: session.showTitle,
-                            style: theme.textTheme.titleLarge?.copyWith(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                              height: 1.2,
-                            ),
-                          ),
-                        ),
-                        if (session.episodeName != null) ...<Widget>[
-                          const SizedBox(height: Insets.xs),
-                          SizedBox(
-                            height:
-                                (theme.textTheme.titleMedium?.fontSize ?? 16) *
-                                    1.5,
-                            child: AutoScrollText(
-                              text: session.episodeName!,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w500,
+                          width: 120,
+                          height: 80,
+                          child: FilledButton(
+                            style: FilledButton.styleFrom(
+                              backgroundColor: theme.colorScheme.primary
+                                  .withValues(alpha: 0.85),
+                              foregroundColor: theme.colorScheme.onPrimary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(32),
                               ),
+                              padding: EdgeInsets.zero,
                             ),
-                          ),
-                        ],
-                      ],
-                    ),
-                  ),
-
-                  // Progress Bar & Timestamps
-                  Column(
-                    children: <Widget>[
-                      SliderTheme(
-                        data: SliderThemeData(
-                          trackHeight: 16,
-                          activeTrackColor: theme.colorScheme.primary,
-                          inactiveTrackColor:
-                              theme.colorScheme.surfaceContainerHighest,
-                          thumbColor: theme.colorScheme.primary,
-                          thumbShape: const ExpressiveSliderThumbShape(),
-                          trackShape: const ExpressiveSliderTrackShape(),
-                          overlayShape: const RoundSliderOverlayShape(),
-                        ),
-                        child: Slider(
-                          value: pct.clamp(0.0, 1.0),
-                          onChangeStart: (_) => setState(() {
-                            _isDragging = true;
-                            _dragPct = pct;
-                          }),
-                          onChanged: (double newValue) {
-                            setState(() {
-                              _dragPct = newValue;
-                            });
-                          },
-                          onChangeEnd: (double newValue) async {
-                            setState(() => _isDragging = false);
-                            if (session.durationTicks > 0) {
-                              final int targetTicks =
-                                  (session.durationTicks * newValue).round();
-                              final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
                               try {
                                 final JellyfinClient client = await ref.read(
-                                    jellyfinClientProvider(widget.instance)
-                                        .future,);
-                                await client.seekSession(
-                                    session.id, targetTicks,);
+                                  jellyfinClientProvider(widget.instance)
+                                      .future,
+                                );
+                                await client.playPauseSession(session.id);
                                 if (!mounted) return;
                                 ref.invalidate(
-                                    jellyfinFastSessionsProvider(widget.instance),);
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
                               } catch (_) {
                                 messenger.showSnackBar(
                                   const SnackBar(
-                                      content: Text('Action failed'),),
+                                    content: Text('Action failed'),
+                                  ),
                                 );
                               }
-                            }
-                          },
-                        ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 24,), // Align with slider track
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                          children: <Widget>[
-                            Text(
-                              session.timePosition,
-                              style: theme.textTheme.labelMedium?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w600,
-                              ),
+                            },
+                            child: Icon(
+                              playing ? Icons.pause : Icons.play_arrow,
+                              size: 40,
                             ),
-                            Text(
-                              session.timeDuration,
-                              style: theme.textTheme.labelMedium?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(width: Insets.lg),
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
                               ),
+                              padding: EdgeInsets.zero,
                             ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  const SizedBox(height: Insets.md),
-
-                  // Row 1: 10s back, Play/Pause, 10s forward
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
-                          ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final JellyfinClient client = await ref.read(
-                                  jellyfinClientProvider(widget.instance).future,);
-                              final int targetTicks = session.positionTicks - 10000000;
-                              await client.seekSession(session.id, targetTicks < 0 ? 0 : targetTicks);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.replay_10, size: 32),
-                        ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 120,
-                        height: 80,
-                        child: FilledButton(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: theme.colorScheme.primary.withValues(alpha: 0.85),
-                            foregroundColor: theme.colorScheme.onPrimary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(32),),
-                            padding: EdgeInsets.zero,
-                          ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final JellyfinClient client = await ref.read(
-                                  jellyfinClientProvider(widget.instance).future,);
-                              await client.playPauseSession(session.id);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: Icon(playing ? Icons.pause : Icons.play_arrow,
-                              size: 40,),
-                        ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
-                          ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final JellyfinClient client = await ref.read(
-                                  jellyfinClientProvider(widget.instance).future,);
-                              final int targetTicks = session.positionTicks + 10000000;
-                              if (targetTicks < session.durationTicks) {
-                                await client.seekSession(session.id, targetTicks);
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final JellyfinClient client = await ref.read(
+                                  jellyfinClientProvider(widget.instance)
+                                      .future,
+                                );
+                                final int targetTicks =
+                                    session.positionTicks + 10000000;
+                                if (targetTicks < session.durationTicks) {
+                                  await client.seekSession(
+                                      session.id, targetTicks);
+                                }
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
                               }
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.forward_10, size: 32),
-                        ),
-                      ),
-                    ],
-                  ),
-
-                  const SizedBox(height: Insets.md),
-
-                  // Row 2: Skip Previous, Stop, Skip Next
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: <Widget>[
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
+                            },
+                            child: const Icon(Icons.forward_10, size: 32),
                           ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final JellyfinClient client = await ref.read(
-                                  jellyfinClientProvider(widget.instance).future,);
-                              if (session.positionTicks > 50000000) {
-                                await client.seekSession(session.id, 0);
-                              } else {
-                                await client.previousTrack(session.id);
+                        ),
+                      ],
+                    ),
+
+                    const SizedBox(height: Insets.md),
+
+                    // Row 2: Skip Previous, Stop, Skip Next
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: <Widget>[
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final JellyfinClient client = await ref.read(
+                                  jellyfinClientProvider(widget.instance)
+                                      .future,
+                                );
+                                if (session.positionTicks > 50000000) {
+                                  await client.seekSession(session.id, 0);
+                                } else {
+                                  await client.previousTrack(session.id);
+                                }
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
                               }
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.skip_previous, size: 32),
-                        ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 120,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            foregroundColor: theme.colorScheme.errorContainer,
-                            backgroundColor: Colors.white.withValues(alpha: 0.2),
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(32),),
-                            padding: EdgeInsets.zero,
+                            },
+                            child: const Icon(Icons.skip_previous, size: 32),
                           ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            final NavigatorState navigator = Navigator.of(context);
-                            try {
-                              final JellyfinClient client = await ref.read(
-                                  jellyfinClientProvider(widget.instance).future,);
-                              await client.stopSession(session.id);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
-                              navigator.pop();
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.stop, size: 28),
                         ),
-                      ),
-                      const SizedBox(width: Insets.lg),
-                      SizedBox(
-                        width: 80,
-                        height: 80,
-                        child: FilledButton.tonal(
-                          style: FilledButton.styleFrom(
-                            backgroundColor: Colors.white.withValues(alpha: 0.15),
-                            foregroundColor: theme.colorScheme.primary,
-                            shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(24),),
-                            padding: EdgeInsets.zero,
+                        const SizedBox(width: Insets.lg),
+                        SizedBox(
+                          width: 120,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              foregroundColor: theme.colorScheme.errorContainer,
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.2),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(32),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              final NavigatorState navigator =
+                                  Navigator.of(context);
+                              try {
+                                final JellyfinClient client = await ref.read(
+                                  jellyfinClientProvider(widget.instance)
+                                      .future,
+                                );
+                                await client.stopSession(session.id);
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
+                                navigator.pop();
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
+                              }
+                            },
+                            child: const Icon(Icons.stop, size: 28),
                           ),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
-                            try {
-                              final JellyfinClient client = await ref.read(
-                                  jellyfinClientProvider(widget.instance).future,);
-                              await client.nextTrack(session.id);
-                              if (!mounted) return;
-                              ref.invalidate(
-                                  jellyfinFastSessionsProvider(widget.instance),);
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(
-                                    content: Text('Action failed'),),
-                              );
-                            }
-                          },
-                          child: const Icon(Icons.skip_next, size: 32),
                         ),
-                      ),
-                    ],
-                  ),
-
-                  const Spacer(),
-                  const SizedBox(height: Insets.lg),
-
-                  // Footer
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      // Device Chip
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 8,),
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest
-                              .withValues(alpha: 0.5),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: <Widget>[
-                            const Icon(
-                              Icons.speaker,
-                              size: 16,
-                              color: Colors.white70,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              session.device,
-                              style: theme.textTheme.labelLarge?.copyWith(
-                                color: Colors.white70,
-                                fontWeight: FontWeight.w600,
+                        const SizedBox(width: Insets.lg),
+                        SizedBox(
+                          width: 80,
+                          height: 80,
+                          child: FilledButton.tonal(
+                            style: FilledButton.styleFrom(
+                              backgroundColor:
+                                  Colors.white.withValues(alpha: 0.15),
+                              foregroundColor: theme.colorScheme.primary,
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(24),
                               ),
+                              padding: EdgeInsets.zero,
                             ),
-                          ],
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final JellyfinClient client = await ref.read(
+                                  jellyfinClientProvider(widget.instance)
+                                      .future,
+                                );
+                                await client.nextTrack(session.id);
+                                if (!mounted) return;
+                                ref.invalidate(
+                                  jellyfinFastSessionsProvider(widget.instance),
+                                );
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                    content: Text('Action failed'),
+                                  ),
+                                );
+                              }
+                            },
+                            child: const Icon(Icons.skip_next, size: 32),
+                          ),
                         ),
-                      ),
-                      // User Chip
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 16, vertical: 8,),
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest
-                              .withValues(alpha: 0.5),
-                          borderRadius: BorderRadius.circular(20),
-                        ),
-                        child: Row(
-                          mainAxisSize: MainAxisSize.min,
-                          children: <Widget>[
-                            const Icon(
-                              Icons.person,
-                              size: 16,
-                              color: Colors.white70,
-                            ),
-                            const SizedBox(width: 8),
-                            Text(
-                              session.user,
-                              style: theme.textTheme.labelLarge?.copyWith(
+                      ],
+                    ),
+
+                    const Spacer(),
+                    const SizedBox(height: Insets.lg),
+
+                    // Footer
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: <Widget>[
+                        // Device Chip
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest
+                                .withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              const Icon(
+                                Icons.speaker,
+                                size: 16,
                                 color: Colors.white70,
-                                fontWeight: FontWeight.w600,
                               ),
-                            ),
-                          ],
+                              const SizedBox(width: 8),
+                              Text(
+                                session.device,
+                                style: theme.textTheme.labelLarge?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
-                      ),
-                    ],
-                  ),
-                  const SizedBox(height: Insets.xl),
-              ],
+                        // User Chip
+                        Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 8,
+                          ),
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest
+                                .withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: <Widget>[
+                              const Icon(
+                                Icons.person,
+                                size: 16,
+                                color: Colors.white70,
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                session.user,
+                                style: theme.textTheme.labelLarge?.copyWith(
+                                  color: Colors.white70,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: Insets.xl),
+                  ],
+                ),
+              ),
             ),
-          ),
+          ],
         ),
-        ],
-      ),
       ),
     );
   }

--- a/services/service_jellyfin/lib/src/jellyfin_settings_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_settings_screen.dart
@@ -13,7 +13,7 @@ class JellyfinSettingsScreen extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<({double progress, String state})?> scanState = 
+    final AsyncValue<({double progress, String state})?> scanState =
         ref.watch(jellyfinLibraryScanProvider(instance));
 
     return Scaffold(
@@ -30,10 +30,12 @@ class JellyfinSettingsScreen extends ConsumerWidget {
                 if (data == null || data.state == 'Idle') {
                   return const Text('Ready');
                 }
-                return Text('${data.state} - ${data.progress.toStringAsFixed(1)}%');
+                return Text(
+                    '${data.state} - ${data.progress.toStringAsFixed(1)}%');
               },
               loading: () => const Text('Checking status...'),
-              error: (Object err, StackTrace stack) => const Text('Error checking status'),
+              error: (Object err, StackTrace stack) =>
+                  const Text('Error checking status'),
             ),
             trailing: scanState.maybeWhen(
               data: (({double progress, String state})? data) {
@@ -46,7 +48,8 @@ class JellyfinSettingsScreen extends ConsumerWidget {
                   icon: const Icon(Icons.play_arrow),
                   onPressed: () async {
                     try {
-                      final JellyfinClient client = await ref.read(jellyfinClientProvider(instance).future);
+                      final JellyfinClient client = await ref
+                          .read(jellyfinClientProvider(instance).future);
                       await client.startLibraryScan();
                       if (!context.mounted) return;
                       ref.invalidate(jellyfinLibraryScanProvider(instance));

--- a/services/service_jellyfin/lib/src/models/jellyfin_auth.dart
+++ b/services/service_jellyfin/lib/src/models/jellyfin_auth.dart
@@ -23,7 +23,9 @@ abstract class JellyfinUser with _$JellyfinUser {
     @JsonKey(name: 'Id') required String id,
     @JsonKey(name: 'Name') @Default('') String name,
     @JsonKey(name: 'HasPassword') @Default(false) bool hasPassword,
-    @JsonKey(name: 'Policy') @Default(JellyfinUserPolicy()) JellyfinUserPolicy policy,
+    @JsonKey(name: 'Policy')
+    @Default(JellyfinUserPolicy())
+    JellyfinUserPolicy policy,
   }) = _JellyfinUser;
 
   factory JellyfinUser.fromJson(Map<String, dynamic> json) =>
@@ -35,7 +37,9 @@ abstract class JellyfinUserPolicy with _$JellyfinUserPolicy {
   const factory JellyfinUserPolicy({
     @JsonKey(name: 'IsAdministrator') @Default(false) bool isAdministrator,
     @JsonKey(name: 'EnableAllFolders') @Default(true) bool enableAllFolders,
-    @JsonKey(name: 'EnabledFolders') @Default(<String>[]) List<String> enabledFolders,
+    @JsonKey(name: 'EnabledFolders')
+    @Default(<String>[])
+    List<String> enabledFolders,
   }) = _JellyfinUserPolicy;
 
   factory JellyfinUserPolicy.fromJson(Map<String, dynamic> json) =>

--- a/services/service_jellyfin/pubspec.yaml
+++ b/services/service_jellyfin/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   android_intent_plus: ^6.0.0
   cached_network_image: ^3.4.1
   collection: ^1.18.0

--- a/services/service_plex/lib/src/models/plex_models.dart
+++ b/services/service_plex/lib/src/models/plex_models.dart
@@ -34,6 +34,7 @@ abstract class PlexLibrary with _$PlexLibrary {
   const factory PlexLibrary({
     required String key,
     @Default('') String title,
+
     /// "movie", "show", "artist", "photo".
     @Default('') String type,
   }) = _PlexLibrary;
@@ -72,34 +73,45 @@ abstract class PlexMetadata with _$PlexMetadata {
     @JsonKey(name: 'ratingKey') @Default('') String ratingKey,
     @Default('') String title,
     int? year,
+
     /// Relative thumbnail path, e.g. `/library/metadata/123/thumb/456`.
     String? thumb,
     @Default('') String type,
+
     /// Present and > 0 when the user has watched it.
     @JsonKey(name: 'viewCount') @Default(0) int viewCount,
+
     /// Resume point in milliseconds, when partially watched.
     @JsonKey(name: 'viewOffset') int? viewOffset,
+
     /// Total runtime in milliseconds.
     @JsonKey(name: 'duration') int? duration,
+
     /// Playable media (present on movies/episodes; absent on shows/seasons).
     @JsonKey(name: 'Media') @Default(<PlexMedia>[]) List<PlexMedia> media,
+
     /// Detail fields (populated by `GET /library/metadata/{ratingKey}`).
     String? summary,
     String? tagline,
     String? studio,
+
     /// Age/content rating, e.g. "PG-13".
     String? contentRating,
+
     /// Critic rating (0-10); `audienceRating` is the audience score.
     double? rating,
     @JsonKey(name: 'audienceRating') double? audienceRating,
+
     /// Backdrop art, relative path.
     String? art,
+
     /// For an episode: the show + season titles and the season/episode numbers.
     String? grandparentTitle,
     String? parentTitle,
     @JsonKey(name: 'grandparentRatingKey') String? grandparentRatingKey,
     int? index,
     int? parentIndex,
+
     /// For a show: total vs watched leaf (episode) counts.
     int? leafCount,
     int? viewedLeafCount,
@@ -142,8 +154,10 @@ abstract class PlexRole with _$PlexRole {
   const factory PlexRole({
     /// Actor name.
     String? tag,
+
     /// Character played.
     String? role,
+
     /// Headshot - sometimes an absolute URL, sometimes a relative path.
     String? thumb,
   }) = _PlexRole;

--- a/services/service_plex/lib/src/plex_api.dart
+++ b/services/service_plex/lib/src/plex_api.dart
@@ -159,8 +159,7 @@ class PlexApi {
     if (thumb == null || thumb.isEmpty) {
       return null;
     }
-    final String base =
-        _dio.options.baseUrl.replaceAll(RegExp(r'/+$'), '');
+    final String base = _dio.options.baseUrl.replaceAll(RegExp(r'/+$'), '');
     return '$base$thumb?X-Plex-Token=$token';
   }
 
@@ -172,8 +171,7 @@ class PlexApi {
   /// Active playback sessions (`GET /status/sessions`). No Plex Pass needed.
   Future<List<PlexSession>> getSessions() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('status/sessions');
+      final Response<dynamic> resp = await _dio.get<dynamic>('status/sessions');
       return PlexSessionsResponse.fromJson(resp.data as Map<String, dynamic>)
               .mediaContainer
               ?.metadata ??

--- a/services/service_plex/lib/src/plex_deep_link.dart
+++ b/services/service_plex/lib/src/plex_deep_link.dart
@@ -21,7 +21,9 @@ Future<void> launchPlexDeepLink(BuildContext context, {String? webUrl}) async {
       if (Platform.isAndroid) {
         try {
           const MethodChannel channel = MethodChannel('app.atrium/launcher');
-          if (await channel.invokeMethod<bool>('launchDeepLink', <String, dynamic>{'url': webUrl}) ?? false) {
+          if (await channel.invokeMethod<bool>(
+                  'launchDeepLink', <String, dynamic>{'url': webUrl}) ??
+              false) {
             return;
           }
         } catch (_) {}

--- a/services/service_plex/lib/src/plex_home.dart
+++ b/services/service_plex/lib/src/plex_home.dart
@@ -13,6 +13,7 @@ import 'plex_item_detail.dart';
 import 'plex_music_screens.dart';
 import 'plex_providers.dart';
 import 'plex_session_detail_screen.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Plex item types that open the detail screen; everything else is a container
 /// we drill into. Plex types are reliable and lowercase, so an allowlist is
@@ -214,10 +215,9 @@ class _ItemsGridState extends ConsumerState<_ItemsGrid> {
   /// blocked. Once loaded, `.value` keeps the last-known genres through a
   /// later refresh error rather than dropping the strip.
   Widget _genreStrip() {
-    final List<PlexGenreDir> genres = ref
-            .watch(plexGenresProvider((widget.instance, widget.id)))
-            .value ??
-        const <PlexGenreDir>[];
+    final List<PlexGenreDir> genres =
+        ref.watch(plexGenresProvider((widget.instance, widget.id))).value ??
+            const <PlexGenreDir>[];
     if (genres.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -500,7 +500,8 @@ class _NowStreamingSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final List<PlexSession> sessions =
-        ref.watch(plexSessionsProvider(instance)).value ?? const <PlexSession>[];
+        ref.watch(plexSessionsProvider(instance)).value ??
+            const <PlexSession>[];
     if (sessions.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -576,7 +577,8 @@ class _SessionCard extends ConsumerWidget {
         child: InkWell(
           onTap: () => pushScreen<void>(
             context,
-            PlexSessionDetailScreen(instance: instance, initialSession: session),
+            PlexSessionDetailScreen(
+                instance: instance, initialSession: session),
           ),
           child: Stack(
             fit: StackFit.expand,
@@ -660,10 +662,10 @@ class _SessionCard extends ConsumerWidget {
               ),
               Align(
                 alignment: Alignment.bottomCenter,
-                child: LinearProgressIndicator(
+                child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
                   value: session.progress,
-                  minHeight: 4,
-                  backgroundColor: Colors.white.withValues(alpha: 0.25),
+                  trackColor: Colors.white.withValues(alpha: 0.25),
                 ),
               ),
             ],
@@ -821,11 +823,10 @@ class PlexPosterCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    final double progress = (item.viewOffset != null &&
-            item.duration != null &&
-            item.duration! > 0)
-        ? item.viewOffset! / item.duration!
-        : 0;
+    final double progress =
+        (item.viewOffset != null && item.duration != null && item.duration! > 0)
+            ? item.viewOffset! / item.duration!
+            : 0;
     final bool isEpisode = item.grandparentTitle != null;
 
     return InkWell(
@@ -888,11 +889,10 @@ class PlexPosterCard extends ConsumerWidget {
                           padding: const EdgeInsets.all(Insets.sm),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(6),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress.clamp(0, 1),
-                              minHeight: 6,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.5),
+                              trackColor: Colors.black.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -938,9 +938,8 @@ class PlexPosterCard extends ConsumerWidget {
   }
 
   Widget _poster(ThemeData theme) {
-    final bool isMusic = item.type == 'album' ||
-        item.type == 'artist' ||
-        item.type == 'track';
+    final bool isMusic =
+        item.type == 'album' || item.type == 'artist' || item.type == 'track';
     final Widget fallback = Container(
       color: theme.colorScheme.surfaceContainerHighest,
       child: Icon(

--- a/services/service_plex/lib/src/plex_item_detail.dart
+++ b/services/service_plex/lib/src/plex_item_detail.dart
@@ -133,9 +133,8 @@ class _PlexItemDetailScreenState extends ConsumerState<PlexItemDetailScreen> {
           actions: <Widget>[
             if (current != null && api != null)
               IconButton(
-                tooltip: _watched(current)
-                    ? 'Mark as unwatched'
-                    : 'Mark as watched',
+                tooltip:
+                    _watched(current) ? 'Mark as unwatched' : 'Mark as watched',
                 icon: Icon(
                   _watched(current)
                       ? Icons.check_circle

--- a/services/service_plex/lib/src/plex_music_screens.dart
+++ b/services/service_plex/lib/src/plex_music_screens.dart
@@ -250,8 +250,8 @@ class PlexAlbumScreen extends ConsumerWidget {
             SliverToBoxAdapter(
               child: AsyncValueView<List<PlexMetadata>>(
                 value: tracks,
-                onRetry: () => ref
-                    .invalidate(plexChildrenProvider((instance, album.ratingKey))),
+                onRetry: () => ref.invalidate(
+                    plexChildrenProvider((instance, album.ratingKey))),
                 data: (List<PlexMetadata> list) {
                   if (list.isEmpty) {
                     return const EmptyView(

--- a/services/service_plex/lib/src/plex_providers.dart
+++ b/services/service_plex/lib/src/plex_providers.dart
@@ -7,79 +7,78 @@ import 'models/plex_session.dart';
 import 'plex_api.dart';
 
 /// A [PlexApi] for an instance, over the shared `instanceDioProvider`.
-final plexApiProvider =
-    FutureProvider.family<PlexApi, Instance>((Ref ref, Instance instance) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      final String token = switch (instance.auth) {
-        InstanceAuthPlex(:final String token) => token,
-        _ => '',
-      };
-      return PlexApi(dio, token: token);
-    });
+final plexApiProvider = FutureProvider.family<PlexApi, Instance>(
+    (Ref ref, Instance instance) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  final String token = switch (instance.auth) {
+    InstanceAuthPlex(:final String token) => token,
+    _ => '',
+  };
+  return PlexApi(dio, token: token);
+});
 
 /// Libraries for an instance.
 final plexLibrariesProvider =
     FutureProvider.family<List<PlexLibrary>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getLibraries();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getLibraries();
+});
 
 /// Items within a library, keyed by (instance, sectionKey).
 final plexItemsProvider =
     FutureProvider.family<List<PlexMetadata>, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      final (Instance instance, String sectionKey) = key;
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getItems(sectionKey);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  final (Instance instance, String sectionKey) = key;
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getItems(sectionKey);
+});
 
 /// Children of a show (seasons) or season (episodes), keyed by
 /// (instance, ratingKey).
 final plexChildrenProvider =
     FutureProvider.family<List<PlexMetadata>, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      final (Instance instance, String ratingKey) = key;
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getChildren(ratingKey);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  final (Instance instance, String ratingKey) = key;
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getChildren(ratingKey);
+});
 
 /// Full metadata for one item (detail screen), keyed by (instance, ratingKey).
 final plexItemDetailProvider =
     FutureProvider.family<PlexMetadata?, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      final (Instance instance, String ratingKey) = key;
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getMetadata(ratingKey);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  final (Instance instance, String ratingKey) = key;
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getMetadata(ratingKey);
+});
 
 /// "Continue Watching" (on deck) for an instance.
-final plexOnDeckProvider =
-    FutureProvider.family<List<PlexMetadata>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getOnDeck();
-    });
+final plexOnDeckProvider = FutureProvider.family<List<PlexMetadata>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getOnDeck();
+});
 
 /// Recently added items for an instance.
 final plexRecentlyAddedProvider =
     FutureProvider.family<List<PlexMetadata>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getRecentlyAdded();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getRecentlyAdded();
+});
 
 /// How often the now-playing sessions refresh while a Plex session screen or
 /// the home now-streaming row is visible.
@@ -88,32 +87,32 @@ const Duration plexSessionsPollInterval = Duration(seconds: 3);
 /// Active playback sessions. Polls while watched; stops on dispose.
 final plexSessionsProvider =
     FutureProvider.autoDispose.family<List<PlexSession>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(plexSessionsPollInterval);
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getSessions();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(plexSessionsPollInterval);
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getSessions();
+});
 
 /// Genre directories for a library section.
 final plexGenresProvider =
     FutureProvider.autoDispose.family<List<PlexGenreDir>, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      final (Instance instance, String sectionKey) = key;
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getGenres(sectionKey);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  final (Instance instance, String sectionKey) = key;
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getGenres(sectionKey);
+});
 
 /// Items in a section filtered by genre, keyed by (instance, section, genre).
 final plexGenreItemsProvider = FutureProvider.autoDispose
     .family<List<PlexMetadata>, (Instance, String, String)>((
-      Ref ref,
-      (Instance, String, String) key,
-    ) async {
-      final (Instance instance, String sectionKey, String genreKey) = key;
-      final PlexApi api = await ref.watch(plexApiProvider(instance).future);
-      return api.getItemsByGenre(sectionKey, genreKey);
-    });
+  Ref ref,
+  (Instance, String, String) key,
+) async {
+  final (Instance instance, String sectionKey, String genreKey) = key;
+  final PlexApi api = await ref.watch(plexApiProvider(instance).future);
+  return api.getItemsByGenre(sectionKey, genreKey);
+});

--- a/services/service_plex/lib/src/plex_season_screen.dart
+++ b/services/service_plex/lib/src/plex_season_screen.dart
@@ -8,6 +8,7 @@ import 'models/plex_models.dart';
 import 'plex_api.dart';
 import 'plex_item_detail.dart';
 import 'plex_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Season and episode browsing for a Plex show. Browse/manage only: episodes
 /// carry a watched toggle; playback stays with the official Plex app. Seasons
@@ -81,9 +82,9 @@ class PlexSeasonCard extends StatelessWidget {
                       const SizedBox(height: Insets.sm),
                       ClipRRect(
                         borderRadius: BorderRadius.circular(6),
-                        child: LinearProgressIndicator(
+                        child: LinearProgressIndicatorM3E(
+                          shape: ProgressM3EShape.flat,
                           value: progress,
-                          minHeight: 6,
                         ),
                       ),
                     ],
@@ -123,7 +124,8 @@ class PlexSeasonCard extends StatelessWidget {
 /// a trailing toggle that scrobbles/unscrobbles the episode on the server.
 /// Tapping a row opens the episode detail screen.
 class PlexEpisodeList extends ConsumerWidget {
-  const PlexEpisodeList({required this.instance, required this.season, super.key});
+  const PlexEpisodeList(
+      {required this.instance, required this.season, super.key});
 
   final Instance instance;
   final PlexMetadata season;
@@ -137,8 +139,8 @@ class PlexEpisodeList extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: Text(season.title)),
       body: M3RefreshIndicator(
-        onRefresh: () async => ref
-            .invalidate(plexChildrenProvider((instance, season.ratingKey))),
+        onRefresh: () async =>
+            ref.invalidate(plexChildrenProvider((instance, season.ratingKey))),
         child: AsyncValueView<List<PlexMetadata>>(
           value: episodes,
           onRetry: () => ref
@@ -185,10 +187,9 @@ class _EpisodeTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final bool watched = episode.viewCount > 0;
-    final String label =
-        (episode.parentIndex != null && episode.index != null)
-            ? 'S${episode.parentIndex}E${episode.index} - ${episode.title}'
-            : episode.title;
+    final String label = (episode.parentIndex != null && episode.index != null)
+        ? 'S${episode.parentIndex}E${episode.index} - ${episode.title}'
+        : episode.title;
     final int minutes =
         episode.duration != null ? episode.duration! ~/ 60000 : 0;
 

--- a/services/service_plex/lib/src/plex_session_detail_screen.dart
+++ b/services/service_plex/lib/src/plex_session_detail_screen.dart
@@ -13,6 +13,7 @@ import 'models/plex_session.dart';
 import 'plex_api.dart';
 import 'plex_deep_link.dart';
 import 'plex_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Full-screen now-playing controller for one Plex stream.
 ///
@@ -313,7 +314,8 @@ class _PlexSessionDetailScreenState
                             child: Container(
                               clipBehavior: Clip.antiAlias,
                               decoration: BoxDecoration(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                                 borderRadius: Radii.card,
                                 boxShadow: <BoxShadow>[
                                   BoxShadow(
@@ -415,8 +417,7 @@ class _PlexSessionDetailScreenState
                             _isDragging = true;
                             _dragPct = v;
                           }),
-                          onChanged: (double v) =>
-                              setState(() => _dragPct = v),
+                          onChanged: (double v) => setState(() => _dragPct = v),
                           onChangeEnd: (double v) {
                             setState(() => _isDragging = false);
                             final int? duration = session.duration;
@@ -436,12 +437,11 @@ class _PlexSessionDetailScreenState
                             const EdgeInsets.symmetric(horizontal: Insets.md),
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(4),
-                          child: LinearProgressIndicator(
+                          child: LinearProgressIndicatorM3E(
+                            shape: ProgressM3EShape.flat,
                             value: session.progress,
-                            minHeight: 6,
-                            color: theme.colorScheme.primary,
-                            backgroundColor:
-                                Colors.white.withValues(alpha: 0.2),
+                            activeColor: theme.colorScheme.primary,
+                            trackColor: Colors.white.withValues(alpha: 0.2),
                           ),
                         ),
                       ),

--- a/services/service_plex/pubspec.yaml
+++ b/services/service_plex/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   cached_network_image: ^3.4.1
   collection: ^1.18.0
   core_models:

--- a/services/service_plex/test/plex_session_test.dart
+++ b/services/service_plex/test/plex_session_test.dart
@@ -4,7 +4,8 @@ import 'package:service_plex/service_plex.dart';
 void main() {
   group('PlexSession parsing', () {
     test('direct play, controllable player', () {
-      final PlexSessionsResponse r = PlexSessionsResponse.fromJson(<String, dynamic>{
+      final PlexSessionsResponse r =
+          PlexSessionsResponse.fromJson(<String, dynamic>{
         'MediaContainer': <String, dynamic>{
           'Metadata': <dynamic>[
             <String, dynamic>{
@@ -13,7 +14,10 @@ void main() {
               'thumb': '/library/metadata/10/thumb/1',
               'viewOffset': 600000,
               'duration': 6000000,
-              'User': <String, dynamic>{'title': 'alice', 'thumb': 'http://x/y.png'},
+              'User': <String, dynamic>{
+                'title': 'alice',
+                'thumb': 'http://x/y.png'
+              },
               'Player': <String, dynamic>{
                 'title': 'Living Room',
                 'product': 'Plex for Apple TV',
@@ -22,7 +26,11 @@ void main() {
                 'local': true,
                 'protocolCapabilities': 'timeline,playback,navigation',
               },
-              'Session': <String, dynamic>{'id': 'sess-1', 'bandwidth': 4200, 'location': 'lan'},
+              'Session': <String, dynamic>{
+                'id': 'sess-1',
+                'bandwidth': 4200,
+                'location': 'lan'
+              },
             },
           ],
         },
@@ -40,7 +48,8 @@ void main() {
     });
 
     test('transcode, non-controllable player, missing nested nodes', () {
-      final PlexSessionsResponse r = PlexSessionsResponse.fromJson(<String, dynamic>{
+      final PlexSessionsResponse r =
+          PlexSessionsResponse.fromJson(<String, dynamic>{
         'MediaContainer': <String, dynamic>{
           'Metadata': <dynamic>[
             <String, dynamic>{
@@ -71,8 +80,8 @@ void main() {
     });
 
     test('empty container -> empty list', () {
-      final PlexSessionsResponse r =
-          PlexSessionsResponse.fromJson(<String, dynamic>{'MediaContainer': <String, dynamic>{}});
+      final PlexSessionsResponse r = PlexSessionsResponse.fromJson(
+          <String, dynamic>{'MediaContainer': <String, dynamic>{}});
       expect(r.mediaContainer!.metadata, isEmpty);
     });
   });

--- a/services/service_prowlarr/lib/src/models/prowlarr_release.dart
+++ b/services/service_prowlarr/lib/src/models/prowlarr_release.dart
@@ -25,8 +25,8 @@ abstract class ProwlarrRelease with _$ProwlarrRelease {
     double? ageHours,
     DateTime? publishDate,
     String? protocol,
-    @Default(<ProwlarrReleaseCategory>[]) List<ProwlarrReleaseCategory>
-        categories,
+    @Default(<ProwlarrReleaseCategory>[])
+    List<ProwlarrReleaseCategory> categories,
     String? downloadUrl,
     String? infoUrl,
     int? grabs,

--- a/services/service_prowlarr/lib/src/prowlarr_api.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_api.dart
@@ -76,7 +76,8 @@ class ProwlarrApi {
       final Response<dynamic> resp =
           await _dio.get<dynamic>('$_base/indexer/schema');
       return (resp.data as List<dynamic>)
-          .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
+          .map((dynamic e) =>
+              Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -113,7 +114,8 @@ class ProwlarrApi {
       final Response<dynamic> resp =
           await _dio.get<dynamic>('$_base/appprofile');
       return (resp.data as List<dynamic>)
-          .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
+          .map((dynamic e) =>
+              Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -233,7 +235,8 @@ class ProwlarrApi {
       final Response<dynamic> resp =
           await _dio.get<dynamic>('$_base/applications/schema');
       return (resp.data as List<dynamic>)
-          .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
+          .map((dynamic e) =>
+              Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -312,9 +315,11 @@ class ProwlarrApi {
   /// Configured instances of a provider resource (`GET /{endpoint}`).
   Future<List<Map<String, dynamic>>> getProviders(String endpoint) async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/$endpoint');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/$endpoint');
       return (resp.data as List<dynamic>)
-          .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
+          .map((dynamic e) =>
+              Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -327,7 +332,8 @@ class ProwlarrApi {
       final Response<dynamic> resp =
           await _dio.get<dynamic>('$_base/$endpoint/schema');
       return (resp.data as List<dynamic>)
-          .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
+          .map((dynamic e) =>
+              Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
           .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -346,7 +352,8 @@ class ProwlarrApi {
   }
 
   /// Creates a provider (`POST /{endpoint}`, `forceSave=true`).
-  Future<void> createProvider(String endpoint, Map<String, dynamic> body) async {
+  Future<void> createProvider(
+      String endpoint, Map<String, dynamic> body) async {
     try {
       await _dio.post<dynamic>(
         '$_base/$endpoint',
@@ -359,7 +366,8 @@ class ProwlarrApi {
   }
 
   /// Updates a provider (`PUT /{endpoint}/{id}`, `forceSave=true`).
-  Future<void> updateProvider(String endpoint, Map<String, dynamic> body) async {
+  Future<void> updateProvider(
+      String endpoint, Map<String, dynamic> body) async {
     try {
       await _dio.put<dynamic>(
         '$_base/$endpoint/${body['id']}',

--- a/services/service_prowlarr/lib/src/prowlarr_app_form_screen.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_app_form_screen.dart
@@ -87,7 +87,8 @@ class _ProwlarrAppFormScreenState extends ConsumerState<ProwlarrAppFormScreen> {
         (source['implementationName'] as String?) ??
         '';
     _fields = ((source['fields'] as List<dynamic>?) ?? <dynamic>[])
-        .map((dynamic f) => Map<String, dynamic>.from(f as Map<dynamic, dynamic>))
+        .map((dynamic f) =>
+            Map<String, dynamic>.from(f as Map<dynamic, dynamic>))
         .toList();
     final String? lvl = source['syncLevel'] as String?;
     _syncLevel = (lvl == null || lvl.isEmpty) ? 'addOnly' : lvl;

--- a/services/service_prowlarr/lib/src/prowlarr_form_fields.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_form_fields.dart
@@ -145,7 +145,8 @@ class _ProwlarrDynamicFieldState extends State<ProwlarrDynamicField> {
         List<dynamic>.from((_f['value'] as List<dynamic>?) ?? <dynamic>[]);
     final List<String> names = options
         .where((Map<String, dynamic> o) => selected.contains(o['value']))
-        .map((Map<String, dynamic> o) => (o['name'] ?? o['value'] ?? '').toString())
+        .map((Map<String, dynamic> o) =>
+            (o['name'] ?? o['value'] ?? '').toString())
         .toList();
     return Container(
       margin: const EdgeInsets.only(bottom: Insets.md),
@@ -220,10 +221,11 @@ class _ProwlarrDynamicFieldState extends State<ProwlarrDynamicField> {
     }
   }
 
-  List<Map<String, dynamic>> _options() =>
-      ((_f['selectOptions'] as List<dynamic>?) ?? <dynamic>[])
-          .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
-          .toList();
+  List<Map<String, dynamic>> _options() => ((_f['selectOptions']
+              as List<dynamic>?) ??
+          <dynamic>[])
+      .map((dynamic e) => Map<String, dynamic>.from(e as Map<dynamic, dynamic>))
+      .toList();
 }
 
 /// A bordered switch tile for a resource's top-level boolean (a download

--- a/services/service_prowlarr/lib/src/prowlarr_history_tab.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_history_tab.dart
@@ -84,7 +84,8 @@ class _ProwlarrHistoryTabState extends ConsumerState<ProwlarrHistoryTab> {
                 return ListView.separated(
                   padding: Insets.page,
                   itemCount: page.records.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: Insets.sm),
+                  separatorBuilder: (_, __) =>
+                      const SizedBox(height: Insets.sm),
                   itemBuilder: (BuildContext context, int index) {
                     final ProwlarrHistoryRecord r = page.records[index];
                     return _HistoryTile(

--- a/services/service_prowlarr/lib/src/prowlarr_home.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_home.dart
@@ -77,8 +77,7 @@ class _ProwlarrHomeState extends State<ProwlarrHome>
           ),
         ],
       ),
-      floatingActionButton:
-          _tab.index == 0 ? _indexerFabs(context) : null,
+      floatingActionButton: _tab.index == 0 ? _indexerFabs(context) : null,
     );
   }
 

--- a/services/service_prowlarr/lib/src/prowlarr_indexer_form_screen.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_indexer_form_screen.dart
@@ -74,7 +74,8 @@ class _ProwlarrIndexerFormScreenState
     try {
       final ProwlarrApi api =
           await ref.read(prowlarrApiProvider(widget.instance).future);
-      final Map<String, dynamic> raw = await api.getIndexerRaw(widget.indexerId!);
+      final Map<String, dynamic> raw =
+          await api.getIndexerRaw(widget.indexerId!);
       if (!mounted) {
         return;
       }
@@ -93,7 +94,8 @@ class _ProwlarrIndexerFormScreenState
         (source['implementationName'] as String?) ??
         '';
     _fields = ((source['fields'] as List<dynamic>?) ?? <dynamic>[])
-        .map((dynamic f) => Map<String, dynamic>.from(f as Map<dynamic, dynamic>))
+        .map((dynamic f) =>
+            Map<String, dynamic>.from(f as Map<dynamic, dynamic>))
         .toList();
     _enabled = (source['enable'] as bool?) ?? true;
     _priority = (source['priority'] as num?)?.toInt() ?? 25;
@@ -551,9 +553,8 @@ class _IndexerStatsSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    final ProwlarrIndexerStat? stat = ref
-        .watch(prowlarrStatsByIdProvider(instance))
-        .value?[indexerId];
+    final ProwlarrIndexerStat? stat =
+        ref.watch(prowlarrStatsByIdProvider(instance)).value?[indexerId];
     if (stat == null) {
       return const SizedBox.shrink();
     }

--- a/services/service_prowlarr/lib/src/prowlarr_provider_settings.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_provider_settings.dart
@@ -87,16 +87,13 @@ class ProwlarrProviderScreen extends ConsumerWidget {
               itemBuilder: (BuildContext context, int i) {
                 final Map<String, dynamic> m = items[i];
                 final String name = (m['name'] as String?) ?? 'Unknown';
-                final String impl =
-                    (m['implementationName'] as String?) ?? '';
+                final String impl = (m['implementationName'] as String?) ?? '';
                 final bool hasEnable = m.containsKey('enable');
                 final bool enabled = m['enable'] == true;
                 return ListTile(
                   leading: hasEnable
                       ? Icon(
-                          enabled
-                              ? Icons.check_circle
-                              : Icons.cancel_outlined,
+                          enabled ? Icons.check_circle : Icons.cancel_outlined,
                           color: enabled
                               ? Colors.green
                               : Theme.of(context).colorScheme.outline,
@@ -207,7 +204,8 @@ class _ProviderFormScreenState extends ConsumerState<_ProviderFormScreen> {
         (source['implementationName'] as String?) ??
         '';
     _fields = ((source['fields'] as List<dynamic>?) ?? <dynamic>[])
-        .map((dynamic f) => Map<String, dynamic>.from(f as Map<dynamic, dynamic>))
+        .map((dynamic f) =>
+            Map<String, dynamic>.from(f as Map<dynamic, dynamic>))
         .toList();
   }
 
@@ -351,8 +349,7 @@ class _ProviderFormScreenState extends ConsumerState<_ProviderFormScreen> {
 
   Widget _buildForm(BuildContext context) {
     final String impl = (_selected!['implementationName'] as String?) ?? '';
-    final String title =
-        _isEdit ? 'Edit ${_nameController.text}' : 'Add $impl';
+    final String title = _isEdit ? 'Edit ${_nameController.text}' : 'Add $impl';
 
     final List<Map<String, dynamic>> visibleFields =
         _fields.where((Map<String, dynamic> f) {
@@ -365,9 +362,9 @@ class _ProviderFormScreenState extends ConsumerState<_ProviderFormScreen> {
       return true;
     }).toList();
 
-    final List<Widget> topLevel = _cfg.topLevel
-            ?.call(context, _selected!, () => setState(() {})) ??
-        const <Widget>[];
+    final List<Widget> topLevel =
+        _cfg.topLevel?.call(context, _selected!, () => setState(() {})) ??
+            const <Widget>[];
 
     return Scaffold(
       appBar: AppBar(

--- a/services/service_prowlarr/lib/src/prowlarr_providers.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_providers.dart
@@ -18,120 +18,115 @@ const Duration prowlarrPollInterval = Duration(seconds: 60);
 ///
 /// Deliberately NOT autoDispose: the underlying Dio is shared and cheap to
 /// keep; disposing it per-screen would re-run the LAN/WAN probe needlessly.
-final prowlarrApiProvider =
-    FutureProvider.family<ProwlarrApi, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      return ProwlarrApi(dio);
-    });
+final prowlarrApiProvider = FutureProvider.family<ProwlarrApi, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  return ProwlarrApi(dio);
+});
 
 /// All indexers for an instance, sorted by name. Polls slowly while watched.
 final prowlarrIndexersProvider =
     FutureProvider.autoDispose.family<List<ProwlarrIndexer>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(prowlarrPollInterval);
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      final List<ProwlarrIndexer> indexers = await api.getIndexers();
-      indexers.sort(
-        (ProwlarrIndexer a, ProwlarrIndexer b) =>
-            a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      );
-      return indexers;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(prowlarrPollInterval);
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  final List<ProwlarrIndexer> indexers = await api.getIndexers();
+  indexers.sort(
+    (ProwlarrIndexer a, ProwlarrIndexer b) =>
+        a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+  );
+  return indexers;
+});
 
 /// Indexer stats keyed by indexerId, for badge counts in the list. Polls
 /// slowly while watched.
 final prowlarrStatsByIdProvider =
-    FutureProvider.autoDispose
-        .family<Map<int, ProwlarrIndexerStat>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(prowlarrPollInterval);
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      final ProwlarrIndexerStats stats = await api.getIndexerStats();
-      return <int, ProwlarrIndexerStat>{
-        for (final ProwlarrIndexerStat s in stats.indexers) s.indexerId: s,
-      };
-    });
+    FutureProvider.autoDispose.family<Map<int, ProwlarrIndexerStat>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(prowlarrPollInterval);
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  final ProwlarrIndexerStats stats = await api.getIndexerStats();
+  return <int, ProwlarrIndexerStat>{
+    for (final ProwlarrIndexerStat s in stats.indexers) s.indexerId: s,
+  };
+});
 
 /// Addable indexer definitions for the "Add indexer" picker. Effectively
 /// static for a session, so no polling.
 final prowlarrIndexerSchemasProvider =
-    FutureProvider.autoDispose
-        .family<List<Map<String, dynamic>>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      final List<Map<String, dynamic>> schemas = await api.getIndexerSchemas();
-      schemas.sort(
-        (Map<String, dynamic> a, Map<String, dynamic> b) =>
-            ((a['name'] ?? a['implementationName'] ?? '') as String)
-                .toLowerCase()
-                .compareTo(
-                  ((b['name'] ?? b['implementationName'] ?? '') as String)
-                      .toLowerCase(),
-                ),
-      );
-      return schemas;
-    });
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  final List<Map<String, dynamic>> schemas = await api.getIndexerSchemas();
+  schemas.sort(
+    (Map<String, dynamic> a, Map<String, dynamic> b) =>
+        ((a['name'] ?? a['implementationName'] ?? '') as String)
+            .toLowerCase()
+            .compareTo(
+              ((b['name'] ?? b['implementationName'] ?? '') as String)
+                  .toLowerCase(),
+            ),
+  );
+  return schemas;
+});
 
 /// App (sync) profiles, for the indexer form's sync-profile dropdown.
 final prowlarrAppProfilesProvider =
-    FutureProvider.autoDispose
-        .family<List<Map<String, dynamic>>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      return api.getAppProfiles();
-    });
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  return api.getAppProfiles();
+});
 
 /// All configured application sync targets, sorted by name. Polls slowly while
 /// watched to pick up sync-level changes made elsewhere.
 final prowlarrApplicationsProvider =
     FutureProvider.autoDispose.family<List<ProwlarrApplication>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(prowlarrPollInterval);
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      final List<ProwlarrApplication> apps = await api.getApplications();
-      apps.sort(
-        (ProwlarrApplication a, ProwlarrApplication b) =>
-            a.name.toLowerCase().compareTo(b.name.toLowerCase()),
-      );
-      return apps;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(prowlarrPollInterval);
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  final List<ProwlarrApplication> apps = await api.getApplications();
+  apps.sort(
+    (ProwlarrApplication a, ProwlarrApplication b) =>
+        a.name.toLowerCase().compareTo(b.name.toLowerCase()),
+  );
+  return apps;
+});
 
 /// Addable application definitions for the "Add application" picker. Effectively
 /// static for a session, so no polling.
 final prowlarrApplicationSchemasProvider =
-    FutureProvider.autoDispose
-        .family<List<Map<String, dynamic>>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      return api.getApplicationSchemas();
-    });
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  return api.getApplicationSchemas();
+});
 
 /// Args for the generic provider list/schema providers: an instance plus the
 /// resource endpoint ('downloadclient', 'notification', 'indexerproxy').
@@ -139,39 +134,36 @@ typedef ProwlarrProviderArgs = ({Instance instance, String endpoint});
 
 /// Configured instances of a provider resource (download clients, etc.) as raw
 /// maps, sorted by name. Polls slowly while watched.
-final prowlarrProvidersProvider =
-    FutureProvider.autoDispose
-        .family<List<Map<String, dynamic>>, ProwlarrProviderArgs>((
-      Ref ref,
-      ProwlarrProviderArgs args,
-    ) async {
-      ref.pollEvery(prowlarrPollInterval);
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(args.instance).future,
-      );
-      final List<Map<String, dynamic>> list =
-          await api.getProviders(args.endpoint);
-      list.sort(
-        (Map<String, dynamic> a, Map<String, dynamic> b) =>
-            ((a['name'] ?? '') as String)
-                .toLowerCase()
-                .compareTo(((b['name'] ?? '') as String).toLowerCase()),
-      );
-      return list;
-    });
+final prowlarrProvidersProvider = FutureProvider.autoDispose
+    .family<List<Map<String, dynamic>>, ProwlarrProviderArgs>((
+  Ref ref,
+  ProwlarrProviderArgs args,
+) async {
+  ref.pollEvery(prowlarrPollInterval);
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(args.instance).future,
+  );
+  final List<Map<String, dynamic>> list = await api.getProviders(args.endpoint);
+  list.sort(
+    (Map<String, dynamic> a, Map<String, dynamic> b) =>
+        ((a['name'] ?? '') as String)
+            .toLowerCase()
+            .compareTo(((b['name'] ?? '') as String).toLowerCase()),
+  );
+  return list;
+});
 
 /// Addable definitions for a provider resource. Static for a session.
-final prowlarrProviderSchemasProvider =
-    FutureProvider.autoDispose
-        .family<List<Map<String, dynamic>>, ProwlarrProviderArgs>((
-      Ref ref,
-      ProwlarrProviderArgs args,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(args.instance).future,
-      );
-      return api.getProviderSchemas(args.endpoint);
-    });
+final prowlarrProviderSchemasProvider = FutureProvider.autoDispose
+    .family<List<Map<String, dynamic>>, ProwlarrProviderArgs>((
+  Ref ref,
+  ProwlarrProviderArgs args,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(args.instance).future,
+  );
+  return api.getProviderSchemas(args.endpoint);
+});
 
 /// Args for [prowlarrHistoryProvider]: an instance plus an optional
 /// HistoryEventType filter (1 grabbed, 2 query, 3 RSS, 4 auth; null = all).
@@ -179,62 +171,62 @@ typedef ProwlarrHistoryArgs = ({Instance instance, int? eventType});
 
 /// Recent history, newest first, optionally filtered by event type. Polls
 /// slowly while watched.
-final prowlarrHistoryProvider =
-    FutureProvider.autoDispose.family<ProwlarrHistoryPage, ProwlarrHistoryArgs>((
-      Ref ref,
-      ProwlarrHistoryArgs args,
-    ) async {
-      ref.pollEvery(prowlarrPollInterval);
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(args.instance).future,
-      );
-      return api.getHistory(eventType: args.eventType);
-    });
+final prowlarrHistoryProvider = FutureProvider.autoDispose
+    .family<ProwlarrHistoryPage, ProwlarrHistoryArgs>((
+  Ref ref,
+  ProwlarrHistoryArgs args,
+) async {
+  ref.pollEvery(prowlarrPollInterval);
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(args.instance).future,
+  );
+  return api.getHistory(eventType: args.eventType);
+});
 
 /// System status (version, OS, runtime). Effectively static for a session.
 final prowlarrSystemStatusProvider =
     FutureProvider.autoDispose.family<ProwlarrSystemStatus, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      return api.getSystemStatus();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  return api.getSystemStatus();
+});
 
 /// Active health warnings/errors.
 final prowlarrHealthProvider =
     FutureProvider.autoDispose.family<List<ProwlarrHealth>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      return api.getHealth();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  return api.getHealth();
+});
 
 /// Scheduled tasks.
 final prowlarrTasksProvider =
     FutureProvider.autoDispose.family<List<ProwlarrSystemTask>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      return api.getTasks();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  return api.getTasks();
+});
 
 /// Existing backups.
 final prowlarrBackupsProvider =
     FutureProvider.autoDispose.family<List<ProwlarrBackup>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ProwlarrApi api = await ref.watch(
-        prowlarrApiProvider(instance).future,
-      );
-      return api.getBackups();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final ProwlarrApi api = await ref.watch(
+    prowlarrApiProvider(instance).future,
+  );
+  return api.getBackups();
+});

--- a/services/service_prowlarr/lib/src/prowlarr_settings_tab.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_settings_tab.dart
@@ -155,7 +155,9 @@ final ProwlarrProviderConfig _downloadClientConfig = ProwlarrProviderConfig(
   title: 'Download Clients',
   resourceLabel: 'download client',
   icon: Icons.download_outlined,
-  topLevel: (BuildContext context, Map<String, dynamic> raw, VoidCallback onChanged) => <Widget>[
+  topLevel: (BuildContext context, Map<String, dynamic> raw,
+          VoidCallback onChanged) =>
+      <Widget>[
     ProwlarrSwitchTile(
       label: 'Enabled',
       value: raw['enable'] != false,
@@ -178,7 +180,8 @@ final ProwlarrProviderConfig _notificationConfig = ProwlarrProviderConfig(
   title: 'Notifications',
   resourceLabel: 'notification',
   icon: Icons.notifications_outlined,
-  topLevel: (BuildContext context, Map<String, dynamic> raw, VoidCallback onChanged) {
+  topLevel:
+      (BuildContext context, Map<String, dynamic> raw, VoidCallback onChanged) {
     Widget? event(String supportKey, String valueKey, String label) {
       if (raw[supportKey] != true) {
         return null;
@@ -223,7 +226,9 @@ final ProwlarrProviderConfig _indexerProxyConfig = ProwlarrProviderConfig(
   title: 'Indexer Proxies',
   resourceLabel: 'indexer proxy',
   icon: Icons.vpn_lock_outlined,
-  topLevel: (BuildContext context, Map<String, dynamic> raw, VoidCallback onChanged) => <Widget>[
+  topLevel: (BuildContext context, Map<String, dynamic> raw,
+          VoidCallback onChanged) =>
+      <Widget>[
     if (raw['supportsOnHealthIssue'] == true)
       ProwlarrSwitchTile(
         label: 'On Health Issue',

--- a/services/service_prowlarr/lib/src/prowlarr_tags_screen.dart
+++ b/services/service_prowlarr/lib/src/prowlarr_tags_screen.dart
@@ -42,13 +42,13 @@ class ProwlarrTagsScreen extends ConsumerWidget {
                 message: 'Tap Add to create a tag.',
               );
             }
-            final List<Map<String, dynamic>> sorted =
-                <Map<String, dynamic>>[...items]..sort(
-                    (Map<String, dynamic> a, Map<String, dynamic> b) =>
-                        ((a['label'] ?? '') as String)
-                            .toLowerCase()
-                            .compareTo(((b['label'] ?? '') as String).toLowerCase()),
-                  );
+            final List<Map<String, dynamic>> sorted = <Map<String, dynamic>>[
+              ...items
+            ]..sort(
+                (Map<String, dynamic> a, Map<String, dynamic> b) =>
+                    ((a['label'] ?? '') as String).toLowerCase().compareTo(
+                        ((b['label'] ?? '') as String).toLowerCase()),
+              );
             return ListView.builder(
               padding: Insets.pageH,
               itemCount: sorted.length,

--- a/services/service_prowlarr/pubspec.yaml
+++ b/services/service_prowlarr/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   collection: ^1.18.0
   core_models:
   core_networking:

--- a/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
+++ b/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import 'qbittorrent_client.dart';
 import 'qbittorrent_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Bottom sheet to add a torrent to a qBittorrent instance.
 ///
@@ -150,7 +151,6 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-
             if (_mode == AddTorrentMode.link)
               TextField(
                 controller: _links,
@@ -191,7 +191,9 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
                 ],
                 onChanged: (String? v) => setState(() => _category = v),
               ),
-              loading: () => const LinearProgressIndicator(),
+              loading: () => const LinearProgressIndicatorM3E(
+                shape: ProgressM3EShape.flat,
+              ),
               error: (_, __) => const SizedBox.shrink(),
             ),
             const SizedBox(height: Insets.sm),
@@ -225,8 +227,7 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
       ),
       actions: <Widget>[
         TextButton(
-          onPressed:
-              _busy ? null : () => Navigator.of(context).pop(false),
+          onPressed: _busy ? null : () => Navigator.of(context).pop(false),
           child: const Text('Cancel'),
         ),
         FilledButton.icon(

--- a/services/service_qbittorrent/lib/src/models/qbit_detail.dart
+++ b/services/service_qbittorrent/lib/src/models/qbit_detail.dart
@@ -44,8 +44,10 @@ abstract class QbitFile with _$QbitFile {
     @Default(0) int index,
     @Default('') String name,
     @Default(0) int size,
+
     /// 0.0 - 1.0.
     @Default(0) double progress,
+
     /// 0 = skip, 1 = normal, 6 = high, 7 = maximal.
     @Default(1) int priority,
   }) = _QbitFile;
@@ -62,6 +64,7 @@ abstract class QbitFile with _$QbitFile {
 abstract class QbitTracker with _$QbitTracker {
   const factory QbitTracker({
     @Default('') String url,
+
     /// 0 disabled, 1 not-contacted, 2 working, 3 updating, 4 not-working.
     @Default(0) int status,
     @JsonKey(name: 'num_seeds') @Default(-1) int numSeeds,

--- a/services/service_qbittorrent/lib/src/models/qbit_torrent.dart
+++ b/services/service_qbittorrent/lib/src/models/qbit_torrent.dart
@@ -12,19 +12,25 @@ abstract class QbitTorrent with _$QbitTorrent {
   const factory QbitTorrent({
     required String hash,
     required String name,
+
     /// Raw qBittorrent state string (downloading, stalledUP, pausedDL,
     /// stoppedUP, queuedDL, checkingUP, error, …).
     required String state,
+
     /// 0.0 - 1.0.
     @Default(0) double progress,
+
     /// Download speed, bytes/s.
     @Default(0) int dlspeed,
+
     /// Upload speed, bytes/s.
     @Default(0) int upspeed,
+
     /// Total size of selected files, bytes.
     @Default(0) int size,
     @Default(0) int downloaded,
     @Default(0) int uploaded,
+
     /// ETA in seconds; 8640000 means infinity / unknown.
     @Default(8640000) int eta,
     @JsonKey(name: 'magnet_uri') @Default('') String magnetUri,

--- a/services/service_qbittorrent/lib/src/models/qbit_transfer_info.dart
+++ b/services/service_qbittorrent/lib/src/models/qbit_transfer_info.dart
@@ -9,14 +9,19 @@ abstract class QbitTransferInfo with _$QbitTransferInfo {
   const factory QbitTransferInfo({
     /// Global download speed, bytes/s.
     @JsonKey(name: 'dl_info_speed') @Default(0) int dlSpeed,
+
     /// Global upload speed, bytes/s.
     @JsonKey(name: 'up_info_speed') @Default(0) int upSpeed,
+
     /// Bytes downloaded this session.
     @JsonKey(name: 'dl_info_data') @Default(0) int dlData,
+
     /// Bytes uploaded this session.
     @JsonKey(name: 'up_info_data') @Default(0) int upData,
+
     /// connected / firewalled / disconnected.
-    @JsonKey(name: 'connection_status') @Default('disconnected')
+    @JsonKey(name: 'connection_status')
+    @Default('disconnected')
     String connectionStatus,
   }) = _QbitTransferInfo;
 

--- a/services/service_qbittorrent/lib/src/qbittorrent_client.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_client.dart
@@ -55,11 +55,13 @@ class QbittorrentClient {
     Map<String, String> customHeaders = const <String, String>{},
   }) {
     final String baseUrlStr = baseUrl.toString();
-    final String normalizedBaseUrl = baseUrlStr.endsWith('/') ? baseUrlStr : '$baseUrlStr/';
+    final String normalizedBaseUrl =
+        baseUrlStr.endsWith('/') ? baseUrlStr : '$baseUrlStr/';
     final CookieJar cookies = CookieJar();
     final Map<String, dynamic> headers = <String, dynamic>{
       'Referer': normalizedBaseUrl,
-      if (apiKey != null && apiKey.isNotEmpty) 'Authorization': 'Bearer $apiKey',
+      if (apiKey != null && apiKey.isNotEmpty)
+        'Authorization': 'Bearer $apiKey',
     };
     final Dio dio = Dio(
       BaseOptions(
@@ -159,15 +161,20 @@ class QbittorrentClient {
         return QbitTransferInfo.fromJson(resp.data as Map<String, dynamic>);
       });
 
-  Future<void> pause(List<String> hashes) => _torrentCommand(hashes.join('|'), stop: true);
+  Future<void> pause(List<String> hashes) =>
+      _torrentCommand(hashes.join('|'), stop: true);
 
-  Future<void> resume(List<String> hashes) => _torrentCommand(hashes.join('|'), stop: false);
+  Future<void> resume(List<String> hashes) =>
+      _torrentCommand(hashes.join('|'), stop: false);
 
   Future<void> delete(List<String> hashes, {required bool deleteFiles}) =>
       _guarded(() async {
         await _dio.post<dynamic>(
           'api/v2/torrents/delete',
-          data: <String, dynamic>{'hashes': hashes.join('|'), 'deleteFiles': deleteFiles},
+          data: <String, dynamic>{
+            'hashes': hashes.join('|'),
+            'deleteFiles': deleteFiles
+          },
           options: Options(contentType: Headers.formUrlEncodedContentType),
         );
       });
@@ -275,7 +282,7 @@ class QbittorrentClient {
           final String ipPort = entry.key;
           final Map<String, dynamic> peerData =
               entry.value as Map<String, dynamic>;
-          
+
           String ip = ipPort;
           int port = 0;
           if (ipPort.contains(':')) {
@@ -323,10 +330,14 @@ class QbittorrentClient {
       });
 
   /// Moves a torrent into [category] (empty string clears it).
-  Future<void> setCategory(List<String> hashes, String category) => _guarded(() async {
+  Future<void> setCategory(List<String> hashes, String category) =>
+      _guarded(() async {
         await _dio.post<dynamic>(
           'api/v2/torrents/setCategory',
-          data: <String, dynamic>{'hashes': hashes.join('|'), 'category': category},
+          data: <String, dynamic>{
+            'hashes': hashes.join('|'),
+            'category': category
+          },
           options: Options(contentType: Headers.formUrlEncodedContentType),
         );
       });
@@ -361,7 +372,8 @@ class QbittorrentClient {
         );
       });
 
-  Future<void> setForceStart(List<String> hashes, {required bool value}) => _guarded(() async {
+  Future<void> setForceStart(List<String> hashes, {required bool value}) =>
+      _guarded(() async {
         await _dio.post<dynamic>(
           'api/v2/torrents/setForceStart',
           data: <String, dynamic>{'hashes': hashes.join('|'), 'value': value},
@@ -377,10 +389,14 @@ class QbittorrentClient {
         );
       });
 
-  Future<void> setLocation(List<String> hashes, String location) => _guarded(() async {
+  Future<void> setLocation(List<String> hashes, String location) =>
+      _guarded(() async {
         await _dio.post<dynamic>(
           'api/v2/torrents/setLocation',
-          data: <String, dynamic>{'hashes': hashes.join('|'), 'location': location},
+          data: <String, dynamic>{
+            'hashes': hashes.join('|'),
+            'location': location
+          },
           options: Options(contentType: Headers.formUrlEncodedContentType),
         );
       });
@@ -406,12 +422,10 @@ class QbittorrentClient {
   /// (pause→stop, resume→start) just like the per-torrent ones, so we try the
   /// new path first and fall back on 404.
   Future<void> setAllPaused({required bool paused}) => _guarded(() async {
-        final String primary = paused
-            ? 'api/v2/torrents/stop'
-            : 'api/v2/torrents/start';
-        final String fallback = paused
-            ? 'api/v2/torrents/pause'
-            : 'api/v2/torrents/resume';
+        final String primary =
+            paused ? 'api/v2/torrents/stop' : 'api/v2/torrents/start';
+        final String fallback =
+            paused ? 'api/v2/torrents/pause' : 'api/v2/torrents/resume';
         try {
           await _dio.post<dynamic>(
             primary,

--- a/services/service_qbittorrent/lib/src/qbittorrent_filter_drawer.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_filter_drawer.dart
@@ -13,9 +13,11 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final statusFilter = ref.watch(qbitFilterStatusProvider(instance));
     final categoryFilter = ref.watch(qbitFilterCategoryProvider(instance));
-    
-    final AsyncValue<List<String>> categoriesAsync = ref.watch(qbitCategoriesProvider(instance));
-    final AsyncValue<List<QbitTorrent>> rawTorrentsAsync = ref.watch(qbitRawTorrentsProvider(instance));
+
+    final AsyncValue<List<String>> categoriesAsync =
+        ref.watch(qbitCategoriesProvider(instance));
+    final AsyncValue<List<QbitTorrent>> rawTorrentsAsync =
+        ref.watch(qbitRawTorrentsProvider(instance));
 
     int getStatusCount(String status, List<QbitTorrent> torrents) {
       return torrents
@@ -57,7 +59,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.filter_alt,
                     isSelected: statusFilter == null || statusFilter == 'all',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'all';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'all';
                     },
                   ),
                   _FilterTile(
@@ -66,7 +70,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.sync,
                     isSelected: statusFilter == 'active',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'active';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'active';
                     },
                   ),
                   _FilterTile(
@@ -75,7 +81,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.download,
                     isSelected: statusFilter == 'downloading',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'downloading';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'downloading';
                     },
                   ),
                   _FilterTile(
@@ -84,7 +92,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.upload,
                     isSelected: statusFilter == 'seeding',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'seeding';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'seeding';
                     },
                   ),
                   _FilterTile(
@@ -93,7 +103,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.stop,
                     isSelected: statusFilter == 'stopped',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'stopped';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'stopped';
                     },
                   ),
                   _FilterTile(
@@ -102,7 +114,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.check,
                     isSelected: statusFilter == 'completed',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'completed';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'completed';
                     },
                   ),
                   _FilterTile(
@@ -111,7 +125,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.error_outline,
                     isSelected: statusFilter == 'errored',
                     onTap: () {
-                      ref.read(qbitFilterStatusProvider(instance).notifier).state = 'errored';
+                      ref
+                          .read(qbitFilterStatusProvider(instance).notifier)
+                          .state = 'errored';
                     },
                   ),
                 ],
@@ -131,7 +147,9 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.folder_copy,
                     isSelected: categoryFilter == null,
                     onTap: () {
-                      ref.read(qbitFilterCategoryProvider(instance).notifier).state = null;
+                      ref
+                          .read(qbitFilterCategoryProvider(instance).notifier)
+                          .state = null;
                     },
                   ),
                   _FilterTile(
@@ -140,19 +158,26 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                     icon: Icons.folder_open,
                     isSelected: categoryFilter == 'uncategorized',
                     onTap: () {
-                      ref.read(qbitFilterCategoryProvider(instance).notifier).state = 'uncategorized';
+                      ref
+                          .read(qbitFilterCategoryProvider(instance).notifier)
+                          .state = 'uncategorized';
                     },
                   ),
                   ...categoriesAsync.maybeWhen(
-                    data: (categories) => categories.map((cat) => _FilterTile(
-                      title: cat,
-                      count: getCategoryCount(cat, torrents),
-                      icon: Icons.folder,
-                      isSelected: categoryFilter == cat,
-                      onTap: () {
-                        ref.read(qbitFilterCategoryProvider(instance).notifier).state = cat;
-                      },
-                    ),),
+                    data: (categories) => categories.map(
+                      (cat) => _FilterTile(
+                        title: cat,
+                        count: getCategoryCount(cat, torrents),
+                        icon: Icons.folder,
+                        isSelected: categoryFilter == cat,
+                        onTap: () {
+                          ref
+                              .read(
+                                  qbitFilterCategoryProvider(instance).notifier)
+                              .state = cat;
+                        },
+                      ),
+                    ),
                     orElse: () => [],
                   ),
                 ],
@@ -189,7 +214,8 @@ class _FilterTile extends StatelessWidget {
       child: ListTile(
         shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(100)),
         leading: Icon(icon),
-        title: Text('$title ($count)', style: TextStyle(fontWeight: isSelected ? FontWeight.bold : null)),
+        title: Text('$title ($count)',
+            style: TextStyle(fontWeight: isSelected ? FontWeight.bold : null)),
         onTap: onTap,
         selected: isSelected,
         selectedColor: Theme.of(context).colorScheme.onSecondaryContainer,

--- a/services/service_qbittorrent/lib/src/qbittorrent_home.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_home.dart
@@ -10,6 +10,7 @@ import 'models/qbit_transfer_info.dart';
 import 'qbittorrent_client.dart';
 import 'qbittorrent_providers.dart';
 import 'torrent_detail_screen.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// qBittorrent's per-instance UI: a global up/down header (with pause-all /
 /// resume-all), a torrent list with progress / speeds / per-item actions, and
@@ -38,7 +39,8 @@ class QbittorrentHome extends ConsumerWidget {
               onRefresh: () async => _refresh(ref),
               child: AsyncValueView<List<QbitTorrent>>(
                 value: torrents,
-                onRetry: () => ref.invalidate(qbitRawTorrentsProvider(instance)),
+                onRetry: () =>
+                    ref.invalidate(qbitRawTorrentsProvider(instance)),
                 data: (List<QbitTorrent> list) {
                   if (list.isEmpty) {
                     return const EmptyView(
@@ -145,7 +147,9 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
                     setState(() {
                       _isSearching = false;
                       _searchController.clear();
-                      ref.read(qbitSearchProvider(widget.instance).notifier).state = '';
+                      ref
+                          .read(qbitSearchProvider(widget.instance).notifier)
+                          .state = '';
                     });
                   },
                 ),
@@ -158,7 +162,9 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
                       border: InputBorder.none,
                     ),
                     onChanged: (String val) {
-                      ref.read(qbitSearchProvider(widget.instance).notifier).state = val;
+                      ref
+                          .read(qbitSearchProvider(widget.instance).notifier)
+                          .state = val;
                       // setState to show/hide the clear button
                       setState(() {});
                     },
@@ -169,7 +175,9 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
                     icon: const Icon(Icons.clear),
                     onPressed: () {
                       _searchController.clear();
-                      ref.read(qbitSearchProvider(widget.instance).notifier).state = '';
+                      ref
+                          .read(qbitSearchProvider(widget.instance).notifier)
+                          .state = '';
                       setState(() {});
                     },
                   ),
@@ -213,20 +221,22 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
   }
 }
 
-
 class QbittorrentAppBarActions extends ConsumerWidget {
   const QbittorrentAppBarActions({required this.instance, super.key});
 
   final Instance instance;
 
-  Future<void> _run(WidgetRef ref, Future<void> Function(QbittorrentClient) action) async {
-    final QbittorrentClient client = await ref.read(qbittorrentClientProvider(instance).future);
+  Future<void> _run(
+      WidgetRef ref, Future<void> Function(QbittorrentClient) action) async {
+    final QbittorrentClient client =
+        await ref.read(qbittorrentClientProvider(instance).future);
     await action(client);
     ref.invalidate(qbitRawTorrentsProvider(instance));
     ref.invalidate(qbitSelectionProvider(instance));
   }
 
-  Future<void> _confirmDelete(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _confirmDelete(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
     bool deleteFiles = false;
     final bool? ok = await showDialog<bool>(
       context: context,
@@ -236,13 +246,15 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Text('Are you sure to delete the selected ${selectedHashes.length} torrents?'),
+              Text(
+                  'Are you sure to delete the selected ${selectedHashes.length} torrents?'),
               const SizedBox(height: Insets.md),
               CheckboxListTile(
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Delete files'),
                 value: deleteFiles,
-                onChanged: (bool? v) => setState(() => deleteFiles = v ?? false),
+                onChanged: (bool? v) =>
+                    setState(() => deleteFiles = v ?? false),
               ),
             ],
           ),
@@ -268,8 +280,10 @@ class QbittorrentAppBarActions extends ConsumerWidget {
     }
   }
 
-  Future<void> _editCategory(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
-    final List<String> cats = await ref.read(qbitCategoriesProvider(instance).future);
+  Future<void> _editCategory(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+    final List<String> cats =
+        await ref.read(qbitCategoriesProvider(instance).future);
     if (!context.mounted) return;
     final String? chosen = await showDialog<String>(
       context: context,
@@ -289,11 +303,15 @@ class QbittorrentAppBarActions extends ConsumerWidget {
       ),
     );
     if (chosen != null) {
-      await _run(ref, (QbittorrentClient c) => c.setCategory(selectedHashes.toList(), chosen));
+      await _run(
+          ref,
+          (QbittorrentClient c) =>
+              c.setCategory(selectedHashes.toList(), chosen));
     }
   }
 
-  Future<void> _editTags(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _editTags(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
     final TextEditingController ctrl = TextEditingController();
     final String? chosen = await showDialog<String>(
       context: context,
@@ -304,17 +322,23 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           decoration: const InputDecoration(hintText: 'tag1, tag2'),
         ),
         actions: <Widget>[
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.of(context).pop(ctrl.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(ctrl.text),
+              child: const Text('Save')),
         ],
       ),
     );
     if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref, (QbittorrentClient c) => c.addTags(selectedHashes.toList(), chosen));
+      await _run(ref,
+          (QbittorrentClient c) => c.addTags(selectedHashes.toList(), chosen));
     }
   }
 
-  Future<void> _editSavePath(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _editSavePath(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
     final TextEditingController ctrl = TextEditingController();
     final String? chosen = await showDialog<String>(
       context: context,
@@ -325,17 +349,25 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           decoration: const InputDecoration(hintText: '/downloads/new_path'),
         ),
         actions: <Widget>[
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.of(context).pop(ctrl.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(ctrl.text),
+              child: const Text('Save')),
         ],
       ),
     );
     if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref, (QbittorrentClient c) => c.setLocation(selectedHashes.toList(), chosen));
+      await _run(
+          ref,
+          (QbittorrentClient c) =>
+              c.setLocation(selectedHashes.toList(), chosen));
     }
   }
 
-  Future<void> _rename(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _rename(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
     final TextEditingController ctrl = TextEditingController();
     final String? chosen = await showDialog<String>(
       context: context,
@@ -346,13 +378,18 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           decoration: const InputDecoration(hintText: 'New name'),
         ),
         actions: <Widget>[
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.of(context).pop(ctrl.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel')),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(ctrl.text),
+              child: const Text('Save')),
         ],
       ),
     );
     if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref, (QbittorrentClient c) => c.rename(selectedHashes.first, chosen));
+      await _run(
+          ref, (QbittorrentClient c) => c.rename(selectedHashes.first, chosen));
     }
   }
 
@@ -368,19 +405,24 @@ class QbittorrentAppBarActions extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: Insets.md),
               children: <Widget>[
                 ListTile(
-                  leading: Icon(config.ascending ? Icons.arrow_upward : Icons.arrow_downward),
+                  leading: Icon(config.ascending
+                      ? Icons.arrow_upward
+                      : Icons.arrow_downward),
                   title: Text(config.ascending ? 'Ascending' : 'Descending'),
                   onTap: () {
-                    ref.read(qbitSortProvider(instance).notifier).state = config.copyWith(ascending: !config.ascending);
+                    ref.read(qbitSortProvider(instance).notifier).state =
+                        config.copyWith(ascending: !config.ascending);
                   },
                 ),
                 const Divider(),
                 for (final QbitSortField field in QbitSortField.values)
                   ListTile(
                     title: Text(field.displayName),
-                    trailing: config.field == field ? const Icon(Icons.check) : null,
+                    trailing:
+                        config.field == field ? const Icon(Icons.check) : null,
                     onTap: () {
-                      ref.read(qbitSortProvider(instance).notifier).state = config.copyWith(field: field);
+                      ref.read(qbitSortProvider(instance).notifier).state =
+                          config.copyWith(field: field);
                       Navigator.of(context).pop();
                     },
                   ),
@@ -394,7 +436,8 @@ class QbittorrentAppBarActions extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final Set<String> selectedHashes = ref.watch(qbitSelectionProvider(instance));
+    final Set<String> selectedHashes =
+        ref.watch(qbitSelectionProvider(instance));
 
     if (selectedHashes.isEmpty) {
       return Row(
@@ -429,7 +472,8 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           tooltip: 'Select All',
           icon: const Icon(Icons.select_all),
           onPressed: () {
-            final List<QbitTorrent>? torrents = ref.read(qbitTorrentsProvider(instance)).value;
+            final List<QbitTorrent>? torrents =
+                ref.read(qbitTorrentsProvider(instance)).value;
             if (torrents != null) {
               ref.read(qbitSelectionProvider(instance).notifier).state =
                   torrents.map((QbitTorrent t) => t.hash).toSet();
@@ -458,14 +502,18 @@ class QbittorrentAppBarActions extends ConsumerWidget {
               case 'copy':
                 await Clipboard.setData(ClipboardData(text: hashes.join('\n')));
                 if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Hashes copied')));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Hashes copied')));
                 }
               case 'recheck':
                 await _run(ref, (QbittorrentClient c) => c.recheck(hashes));
               case 'reannounce':
                 await _run(ref, (QbittorrentClient c) => c.reannounce(hashes));
               case 'forcestart':
-                await _run(ref, (QbittorrentClient c) => c.setForceStart(hashes, value: true));
+                await _run(
+                    ref,
+                    (QbittorrentClient c) =>
+                        c.setForceStart(hashes, value: true));
               case 'rename':
                 await _rename(context, ref, selectedHashes);
               case 'savepath':
@@ -476,14 +524,17 @@ class QbittorrentAppBarActions extends ConsumerWidget {
                 await _editTags(context, ref, selectedHashes);
               case 'export':
                 try {
-                  final QbittorrentClient client = await ref.read(qbittorrentClientProvider(instance).future);
+                  final QbittorrentClient client = await ref
+                      .read(qbittorrentClientProvider(instance).future);
                   await client.exportTorrent(hashes.first);
                   if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Torrent exported successfully')));
+                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                        content: Text('Torrent exported successfully')));
                   }
                 } catch (e) {
                   if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Export failed: $e')));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Export failed: $e')));
                   }
                 }
             }
@@ -492,16 +543,21 @@ class QbittorrentAppBarActions extends ConsumerWidget {
             const PopupMenuItem<String>(value: 'pause', child: Text('Pause')),
             const PopupMenuItem<String>(value: 'resume', child: Text('Resume')),
             const PopupMenuItem<String>(value: 'copy', child: Text('Copy')),
-            const PopupMenuItem<String>(value: 'recheck', child: Text('Force Recheck')),
-            const PopupMenuItem<String>(value: 'reannounce', child: Text('Force Reannounce')),
-            const PopupMenuItem<String>(value: 'forcestart', child: Text('Force Start')),
+            const PopupMenuItem<String>(
+                value: 'recheck', child: Text('Force Recheck')),
+            const PopupMenuItem<String>(
+                value: 'reannounce', child: Text('Force Reannounce')),
+            const PopupMenuItem<String>(
+                value: 'forcestart', child: Text('Force Start')),
             PopupMenuItem<String>(
               value: 'rename',
               enabled: selectedHashes.length == 1,
               child: const Text('Rename'),
             ),
-            const PopupMenuItem<String>(value: 'savepath', child: Text('Set SavePath')),
-            const PopupMenuItem<String>(value: 'category', child: Text('Set Category')),
+            const PopupMenuItem<String>(
+                value: 'savepath', child: Text('Set SavePath')),
+            const PopupMenuItem<String>(
+                value: 'category', child: Text('Set Category')),
             const PopupMenuItem<String>(value: 'tags', child: Text('Set Tags')),
             PopupMenuItem<String>(
               value: 'export',
@@ -544,9 +600,10 @@ class _TorrentTile extends ConsumerWidget {
     final bool complete = progress >= 1.0;
     final bool dlActive = torrent.dlspeed > 0;
     final bool upActive = torrent.upspeed > 0;
-    
+
     return Padding(
-      padding: const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
+      padding:
+          const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
       child: Material(
         color: isSelected ? cs.primaryContainer : cs.surfaceContainerHigh,
         borderRadius: BorderRadius.circular(20),
@@ -561,7 +618,8 @@ class _TorrentTile extends ConsumerWidget {
           },
           onTap: () {
             if (selectionMode) {
-              ref.read(qbitSelectionProvider(instance).notifier)
+              ref
+                  .read(qbitSelectionProvider(instance).notifier)
                   .update((Set<String> s) {
                 final Set<String> next = Set<String>.of(s);
                 if (next.contains(torrent.hash)) {
@@ -655,11 +713,11 @@ class _TorrentTile extends ConsumerWidget {
                     Expanded(
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(8),
-                        child: LinearProgressIndicator(
+                        child: LinearProgressIndicatorM3E(
+                          shape: ProgressM3EShape.flat,
                           value: progress,
-                          minHeight: 8,
-                          color: complete ? cs.tertiary : v.color,
-                          backgroundColor: isSelected
+                          activeColor: complete ? cs.tertiary : v.color,
+                          trackColor: isSelected
                               ? cs.onPrimaryContainer.withValues(alpha: 0.15)
                               : cs.surfaceContainerHighest,
                         ),
@@ -701,7 +759,8 @@ class _TorrentTile extends ConsumerWidget {
                     ),
                     if (!complete) ...<Widget>[
                       const SizedBox(width: Insets.sm),
-                      Icon(Icons.schedule, size: 14, color: cs.onSurfaceVariant),
+                      Icon(Icons.schedule,
+                          size: 14, color: cs.onSurfaceVariant),
                       const SizedBox(width: 2),
                       Text(
                         _formatEta(torrent.eta),

--- a/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
@@ -28,38 +28,37 @@ const Duration qbitDetailPollInterval = Duration(seconds: 10);
 /// failed-login ban counter on flaky networks).
 final qbittorrentClientProvider =
     FutureProvider.family<QbittorrentClient, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final ConnectionResolver resolver =
-          ref.watch(connectionResolverProvider);
-      final Uri baseUrl = await resolver.resolve(instance);
-      final (String username, String password, String? apiKey) =
-          switch (instance.auth) {
-        InstanceAuthCookie(:final String username, :final String password) => (
-            username,
-            password,
-            null,
-          ),
-        // qBittorrent 5.2+ stateless key auth (Authorization: Bearer).
-        InstanceAuthApiKey(:final String apiKey) => ('', '', apiKey),
-        _ => ('', '', null),
-      };
-      final Map<String, String> customHeaders = mergeHeaders(
-        ref.watch(globalHeadersProvider),
-        instance.customHeaders,
-      );
-      final QbittorrentClient client = QbittorrentClient.create(
-        baseUrl: baseUrl,
-        username: username,
-        password: password,
-        apiKey: apiKey,
-        allowSelfSigned: instance.allowSelfSignedCerts,
-        customHeaders: customHeaders,
-      );
-      ref.onDispose(client.close);
-      return client;
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final ConnectionResolver resolver = ref.watch(connectionResolverProvider);
+  final Uri baseUrl = await resolver.resolve(instance);
+  final (String username, String password, String? apiKey) =
+      switch (instance.auth) {
+    InstanceAuthCookie(:final String username, :final String password) => (
+        username,
+        password,
+        null,
+      ),
+    // qBittorrent 5.2+ stateless key auth (Authorization: Bearer).
+    InstanceAuthApiKey(:final String apiKey) => ('', '', apiKey),
+    _ => ('', '', null),
+  };
+  final Map<String, String> customHeaders = mergeHeaders(
+    ref.watch(globalHeadersProvider),
+    instance.customHeaders,
+  );
+  final QbittorrentClient client = QbittorrentClient.create(
+    baseUrl: baseUrl,
+    username: username,
+    password: password,
+    apiKey: apiKey,
+    allowSelfSigned: instance.allowSelfSignedCerts,
+    customHeaders: customHeaders,
+  );
+  ref.onDispose(client.close);
+  return client;
+});
 
 enum QbitSortField {
   addedOn,
@@ -83,25 +82,42 @@ enum QbitSortField {
 extension QbitSortFieldExt on QbitSortField {
   String get displayName {
     switch (this) {
-      case QbitSortField.addedOn: return 'Added On';
-      case QbitSortField.name: return 'Name';
-      case QbitSortField.size: return 'Size';
-      case QbitSortField.progress: return 'Progress';
-      case QbitSortField.status: return 'Status';
-      case QbitSortField.seeds: return 'Seeds';
-      case QbitSortField.peers: return 'Peers';
-      case QbitSortField.dlSpeed: return 'Down Speed';
-      case QbitSortField.upSpeed: return 'Up Speed';
-      case QbitSortField.eta: return 'ETA';
-      case QbitSortField.ratio: return 'Ratio';
-      case QbitSortField.priority: return 'Priority';
-      case QbitSortField.category: return 'Category';
-      case QbitSortField.completedOn: return 'Completed On';
-      case QbitSortField.sessionDl: return 'Session Download';
-      case QbitSortField.sessionUp: return 'Session Upload';
+      case QbitSortField.addedOn:
+        return 'Added On';
+      case QbitSortField.name:
+        return 'Name';
+      case QbitSortField.size:
+        return 'Size';
+      case QbitSortField.progress:
+        return 'Progress';
+      case QbitSortField.status:
+        return 'Status';
+      case QbitSortField.seeds:
+        return 'Seeds';
+      case QbitSortField.peers:
+        return 'Peers';
+      case QbitSortField.dlSpeed:
+        return 'Down Speed';
+      case QbitSortField.upSpeed:
+        return 'Up Speed';
+      case QbitSortField.eta:
+        return 'ETA';
+      case QbitSortField.ratio:
+        return 'Ratio';
+      case QbitSortField.priority:
+        return 'Priority';
+      case QbitSortField.category:
+        return 'Category';
+      case QbitSortField.completedOn:
+        return 'Completed On';
+      case QbitSortField.sessionDl:
+        return 'Session Download';
+      case QbitSortField.sessionUp:
+        return 'Session Upload';
     }
   }
 }
+
 class QbitSortConfig {
   const QbitSortConfig({required this.field, required this.ascending});
   final QbitSortField field;
@@ -115,12 +131,15 @@ class QbitSortConfig {
   }
 }
 
-final qbitSortProvider = StateProvider.family<QbitSortConfig, Instance>((ref, instance) {
+final qbitSortProvider =
+    StateProvider.family<QbitSortConfig, Instance>((ref, instance) {
   return const QbitSortConfig(field: QbitSortField.addedOn, ascending: false);
 });
 
-final qbitFilterStatusProvider = StateProvider.autoDispose.family<String?, Instance>((ref, instance) => null);
-final qbitFilterCategoryProvider = StateProvider.autoDispose.family<String?, Instance>((ref, instance) => null);
+final qbitFilterStatusProvider = StateProvider.autoDispose
+    .family<String?, Instance>((ref, instance) => null);
+final qbitFilterCategoryProvider = StateProvider.autoDispose
+    .family<String?, Instance>((ref, instance) => null);
 
 /// Whether a torrent belongs to the given status filter bucket.
 ///
@@ -171,14 +190,14 @@ bool qbitStatusMatches(String status, QbitTorrent t) {
 /// goes away (autoDispose).
 final qbitRawTorrentsProvider =
     FutureProvider.autoDispose.family<List<QbitTorrent>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(qbitListPollInterval);
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getTorrents();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(qbitListPollInterval);
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getTorrents();
+});
 
 final qbitSearchProvider =
     StateProvider.autoDispose.family<String, Instance>((ref, instance) => '');
@@ -194,16 +213,18 @@ final qbitTorrentsProvider = Provider.autoDispose
       ref.watch(qbitSearchProvider(instance)).toLowerCase();
 
   final String? statusFilter = ref.watch(qbitFilterStatusProvider(instance));
-  final String? categoryFilter = ref.watch(qbitFilterCategoryProvider(instance));
+  final String? categoryFilter =
+      ref.watch(qbitFilterCategoryProvider(instance));
 
   return rawAsync.whenData((List<QbitTorrent> raw) {
     final List<QbitTorrent> torrents = List<QbitTorrent>.of(raw);
 
     if (searchQuery.isNotEmpty) {
       torrents.retainWhere(
-          (QbitTorrent t) => t.name.toLowerCase().contains(searchQuery),);
+        (QbitTorrent t) => t.name.toLowerCase().contains(searchQuery),
+      );
     }
-    
+
     if (statusFilter != null && statusFilter != 'all') {
       torrents.retainWhere(
         (QbitTorrent t) => qbitStatusMatches(statusFilter, t),
@@ -267,84 +288,84 @@ final qbitTorrentsProvider = Provider.autoDispose
 /// Global transfer stats for an instance. Polls with the list.
 final qbitTransferProvider =
     FutureProvider.autoDispose.family<QbitTransferInfo, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(qbitListPollInterval);
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getTransferInfo();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(qbitListPollInterval);
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getTransferInfo();
+});
 
 /// Category names defined on an instance. Fetched on demand (no polling -
 /// categories rarely change).
 final qbitCategoriesProvider =
     FutureProvider.autoDispose.family<List<String>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getCategories();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getCategories();
+});
 
 /// Detailed properties for one torrent, keyed by (instance, hash).
 final qbitPropertiesProvider = FutureProvider.autoDispose
-        .family<QbitTorrentProperties, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      ref.pollEvery(qbitDetailPollInterval);
-      final (Instance instance, String hash) = key;
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getProperties(hash);
-    });
+    .family<QbitTorrentProperties, (Instance, String)>((
+  Ref ref,
+  (Instance, String) key,
+) async {
+  ref.pollEvery(qbitDetailPollInterval);
+  final (Instance instance, String hash) = key;
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getProperties(hash);
+});
 
 /// File list for one torrent, keyed by (instance, hash).
 final qbitFilesProvider =
     FutureProvider.autoDispose.family<List<QbitFile>, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      ref.pollEvery(qbitDetailPollInterval);
-      final (Instance instance, String hash) = key;
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getFiles(hash);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  ref.pollEvery(qbitDetailPollInterval);
+  final (Instance instance, String hash) = key;
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getFiles(hash);
+});
 
 /// Tracker list for one torrent, keyed by (instance, hash).
 final qbitTrackersProvider =
     FutureProvider.autoDispose.family<List<QbitTracker>, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      ref.pollEvery(qbitDetailPollInterval);
-      final (Instance instance, String hash) = key;
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getTrackers(hash);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  ref.pollEvery(qbitDetailPollInterval);
+  final (Instance instance, String hash) = key;
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getTrackers(hash);
+});
 
 /// Holds the set of currently selected torrent hashes for multi-select actions.
 final qbitSelectionProvider =
     StateProvider.autoDispose.family<Set<String>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) {
-      return <String>{};
-    });
+  Ref ref,
+  Instance instance,
+) {
+  return <String>{};
+});
 
 /// Peers list for one torrent, keyed by (instance, hash).
 final qbitPeersProvider =
     FutureProvider.autoDispose.family<List<QbitPeer>, (Instance, String)>((
-      Ref ref,
-      (Instance, String) key,
-    ) async {
-      ref.pollEvery(qbitDetailPollInterval);
-      final (Instance instance, String hash) = key;
-      final QbittorrentClient client =
-          await ref.watch(qbittorrentClientProvider(instance).future);
-      return client.getPeers(hash);
-    });
+  Ref ref,
+  (Instance, String) key,
+) async {
+  ref.pollEvery(qbitDetailPollInterval);
+  final (Instance instance, String hash) = key;
+  final QbittorrentClient client =
+      await ref.watch(qbittorrentClientProvider(instance).future);
+  return client.getPeers(hash);
+});

--- a/services/service_qbittorrent/lib/src/torrent_detail_screen.dart
+++ b/services/service_qbittorrent/lib/src/torrent_detail_screen.dart
@@ -10,6 +10,7 @@ import 'models/qbit_torrent.dart';
 import 'qbittorrent_client.dart';
 import 'qbittorrent_home.dart' show fmtBytes, friendlyState;
 import 'qbittorrent_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Detail view for a single torrent: Overview / Files / Trackers / Peers tabs.
 ///
@@ -100,15 +101,22 @@ class TorrentDetailScreen extends ConsumerWidget {
                 }
               },
               itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                const PopupMenuItem<String>(value: 'pause', child: Text('Pause')),
-                const PopupMenuItem<String>(value: 'resume', child: Text('Resume')),
-                const PopupMenuItem<String>(value: 'forcestart', child: Text('Force Start')),
+                const PopupMenuItem<String>(
+                    value: 'pause', child: Text('Pause')),
+                const PopupMenuItem<String>(
+                    value: 'resume', child: Text('Resume')),
+                const PopupMenuItem<String>(
+                    value: 'forcestart', child: Text('Force Start')),
                 const PopupMenuDivider(),
-                const PopupMenuItem<String>(value: 'copy_magnet', child: Text('Copy Magnet Link')),
-                const PopupMenuItem<String>(value: 'copy_hash', child: Text('Copy Hash')),
+                const PopupMenuItem<String>(
+                    value: 'copy_magnet', child: Text('Copy Magnet Link')),
+                const PopupMenuItem<String>(
+                    value: 'copy_hash', child: Text('Copy Hash')),
                 const PopupMenuDivider(),
-                const PopupMenuItem<String>(value: 'recheck', child: Text('Force Recheck')),
-                const PopupMenuItem<String>(value: 'reannounce', child: Text('Force Reannounce')),
+                const PopupMenuItem<String>(
+                    value: 'recheck', child: Text('Force Recheck')),
+                const PopupMenuItem<String>(
+                    value: 'reannounce', child: Text('Force Reannounce')),
               ],
             ),
           ],
@@ -213,7 +221,8 @@ class _OverviewTab extends ConsumerWidget {
         ref.watch(qbitPropertiesProvider((instance, torrent.hash)));
     final Color accent = _accent(torrent.state, cs);
     final Color actionColor = accent == cs.outline ? cs.primary : accent;
-    final bool isPaused = torrent.state.contains('paused') || torrent.state.contains('stopped');
+    final bool isPaused =
+        torrent.state.contains('paused') || torrent.state.contains('stopped');
     final double progress = torrent.progress.clamp(0, 1).toDouble();
 
     return M3RefreshIndicator(
@@ -279,11 +288,11 @@ class _OverviewTab extends ConsumerWidget {
                         Expanded(
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(8),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress,
-                              minHeight: 8,
-                              color: accent,
-                              backgroundColor: cs.surfaceContainerHighest,
+                              activeColor: accent,
+                              trackColor: cs.surfaceContainerHighest,
                             ),
                           ),
                         ),
@@ -313,7 +322,8 @@ class _OverviewTab extends ConsumerWidget {
                         ),
                         const Spacer(),
                         if (progress < 1.0) ...<Widget>[
-                          Icon(Icons.schedule, size: 14, color: cs.onSurfaceVariant),
+                          Icon(Icons.schedule,
+                              size: 14, color: cs.onSurfaceVariant),
                           const SizedBox(width: 2),
                           Text(
                             _fmtEta(torrent.eta),
@@ -326,186 +336,217 @@ class _OverviewTab extends ConsumerWidget {
                     const SizedBox(height: Insets.lg),
                     Center(
                       child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      alignment: WrapAlignment.center,
-                      children: <Widget>[
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: actionColor.withValues(alpha: 0.15),
-                            foregroundColor: actionColor,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          ),
-                          icon: Icon(isPaused ? Icons.play_arrow : Icons.pause, size: 18),
-                          label: Text(isPaused ? 'Resume' : 'Pause'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            try {
-                              final QbittorrentClient client = await ref.read(
-                                qbittorrentClientProvider(instance).future,
-                              );
-                              if (isPaused) {
-                                await client.resume(<String>[torrent.hash]);
-                              } else {
-                                await client.pause(<String>[torrent.hash]);
+                        spacing: 8.0,
+                        runSpacing: 8.0,
+                        alignment: WrapAlignment.center,
+                        children: <Widget>[
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor:
+                                  actionColor.withValues(alpha: 0.15),
+                              foregroundColor: actionColor,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8),
+                            ),
+                            icon: Icon(
+                                isPaused ? Icons.play_arrow : Icons.pause,
+                                size: 18),
+                            label: Text(isPaused ? 'Resume' : 'Pause'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final QbittorrentClient client = await ref.read(
+                                  qbittorrentClientProvider(instance).future,
+                                );
+                                if (isPaused) {
+                                  await client.resume(<String>[torrent.hash]);
+                                } else {
+                                  await client.pause(<String>[torrent.hash]);
+                                }
+                                if (!context.mounted) return;
+                                ref.invalidate(
+                                    qbitRawTorrentsProvider(instance));
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Action failed')),
+                                );
                               }
-                              if (!context.mounted) return;
-                              ref.invalidate(qbitRawTorrentsProvider(instance));
-                            } catch (_) {
+                            },
+                          ),
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor:
+                                  actionColor.withValues(alpha: 0.15),
+                              foregroundColor: actionColor,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8),
+                            ),
+                            icon: const Icon(Icons.fast_forward, size: 18),
+                            label: const Text('Force Start'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final QbittorrentClient client = await ref.read(
+                                  qbittorrentClientProvider(instance).future,
+                                );
+                                await client.setForceStart(
+                                  <String>[torrent.hash],
+                                  value: true,
+                                );
+                                if (!context.mounted) return;
+                                ref.invalidate(
+                                    qbitRawTorrentsProvider(instance));
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Action failed')),
+                                );
+                              }
+                            },
+                          ),
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor: cs.surfaceContainerHighest,
+                              foregroundColor: cs.onSurfaceVariant,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8),
+                            ),
+                            icon: const Icon(Icons.link, size: 18),
+                            label: const Text('Magnet'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              final String magnet = torrent.magnetUri.isNotEmpty
+                                  ? torrent.magnetUri
+                                  : 'magnet:?xt=urn:btih:${torrent.hash}&dn=${Uri.encodeComponent(torrent.name)}';
+                              await Clipboard.setData(
+                                  ClipboardData(text: magnet));
                               messenger.showSnackBar(
-                                const SnackBar(content: Text('Action failed')),
+                                const SnackBar(
+                                  content: Text('Magnet link copied'),
+                                ),
                               );
-                            }
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: actionColor.withValues(alpha: 0.15),
-                            foregroundColor: actionColor,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                            },
                           ),
-                          icon: const Icon(Icons.fast_forward, size: 18),
-                          label: const Text('Force Start'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            try {
-                              final QbittorrentClient client = await ref.read(
-                                qbittorrentClientProvider(instance).future,
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor: cs.surfaceContainerHighest,
+                              foregroundColor: cs.onSurfaceVariant,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8),
+                            ),
+                            icon: const Icon(Icons.tag, size: 18),
+                            label: const Text('Hash'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              await Clipboard.setData(
+                                ClipboardData(text: torrent.hash),
                               );
-                              await client.setForceStart(
-                                <String>[torrent.hash],
-                                value: true,
-                              );
-                              if (!context.mounted) return;
-                              ref.invalidate(qbitRawTorrentsProvider(instance));
-                            } catch (_) {
                               messenger.showSnackBar(
-                                const SnackBar(content: Text('Action failed')),
+                                const SnackBar(
+                                  content: Text('Torrent hash copied'),
+                                ),
                               );
-                            }
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: cs.surfaceContainerHighest,
-                            foregroundColor: cs.onSurfaceVariant,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                            },
                           ),
-                          icon: const Icon(Icons.link, size: 18),
-                          label: const Text('Magnet'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            final String magnet = torrent.magnetUri.isNotEmpty
-                                ? torrent.magnetUri
-                                : 'magnet:?xt=urn:btih:${torrent.hash}&dn=${Uri.encodeComponent(torrent.name)}';
-                            await Clipboard.setData(ClipboardData(text: magnet));
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text('Magnet link copied'),
-                              ),
-                            );
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: cs.surfaceContainerHighest,
-                            foregroundColor: cs.onSurfaceVariant,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          ),
-                          icon: const Icon(Icons.tag, size: 18),
-                          label: const Text('Hash'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            await Clipboard.setData(
-                              ClipboardData(text: torrent.hash),
-                            );
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text('Torrent hash copied'),
-                              ),
-                            );
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: cs.surfaceContainerHighest,
-                            foregroundColor: cs.onSurfaceVariant,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          ),
-                          icon: const Icon(Icons.delete, size: 18),
-                          label: const Text('Delete'),
-                          onPressed: () async {
-                            final bool? shouldDeleteFiles = await showDialog<bool>(
-                              context: context,
-                              builder: (BuildContext context) {
-                                bool deleteFiles = false;
-                                return StatefulBuilder(
-                                  builder: (BuildContext context, StateSetter setState) {
-                                    return AlertDialog(
-                                      title: const Text('Delete Torrent'),
-                                      content: Column(
-                                        mainAxisSize: MainAxisSize.min,
-                                        crossAxisAlignment: CrossAxisAlignment.start,
-                                        children: <Widget>[
-                                          const Text('Are you sure you want to delete this torrent?'),
-                                          const SizedBox(height: 16),
-                                          CheckboxListTile(
-                                            value: deleteFiles,
-                                            onChanged: (bool? val) {
-                                              if (val != null) {
-                                                setState(() => deleteFiles = val);
-                                              }
-                                            },
-                                            title: const Text('Also delete files'),
-                                            contentPadding: EdgeInsets.zero,
-                                            controlAffinity: ListTileControlAffinity.leading,
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor: cs.surfaceContainerHighest,
+                              foregroundColor: cs.onSurfaceVariant,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8),
+                            ),
+                            icon: const Icon(Icons.delete, size: 18),
+                            label: const Text('Delete'),
+                            onPressed: () async {
+                              final bool? shouldDeleteFiles =
+                                  await showDialog<bool>(
+                                context: context,
+                                builder: (BuildContext context) {
+                                  bool deleteFiles = false;
+                                  return StatefulBuilder(
+                                    builder: (BuildContext context,
+                                        StateSetter setState) {
+                                      return AlertDialog(
+                                        title: const Text('Delete Torrent'),
+                                        content: Column(
+                                          mainAxisSize: MainAxisSize.min,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: <Widget>[
+                                            const Text(
+                                                'Are you sure you want to delete this torrent?'),
+                                            const SizedBox(height: 16),
+                                            CheckboxListTile(
+                                              value: deleteFiles,
+                                              onChanged: (bool? val) {
+                                                if (val != null) {
+                                                  setState(
+                                                      () => deleteFiles = val);
+                                                }
+                                              },
+                                              title: const Text(
+                                                  'Also delete files'),
+                                              contentPadding: EdgeInsets.zero,
+                                              controlAffinity:
+                                                  ListTileControlAffinity
+                                                      .leading,
+                                            ),
+                                          ],
+                                        ),
+                                        actions: <Widget>[
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.of(context).pop(),
+                                            child: const Text('Cancel'),
+                                          ),
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.of(context)
+                                                    .pop(deleteFiles),
+                                            style: TextButton.styleFrom(
+                                                foregroundColor:
+                                                    Theme.of(context)
+                                                        .colorScheme
+                                                        .error),
+                                            child: const Text('Delete'),
                                           ),
                                         ],
-                                      ),
-                                      actions: <Widget>[
-                                        TextButton(
-                                          onPressed: () => Navigator.of(context).pop(),
-                                          child: const Text('Cancel'),
-                                        ),
-                                        TextButton(
-                                          onPressed: () => Navigator.of(context).pop(deleteFiles),
-                                          style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
-                                          child: const Text('Delete'),
-                                        ),
-                                      ],
-                                    );
-                                  },
-                                );
-                              },
-                            );
-                            if (shouldDeleteFiles == null) return;
-                            if (!context.mounted) return;
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            try {
-                              final QbittorrentClient client = await ref.read(
-                                qbittorrentClientProvider(instance).future,
+                                      );
+                                    },
+                                  );
+                                },
                               );
-                              await client.delete(
-                                <String>[torrent.hash],
-                                deleteFiles: shouldDeleteFiles,
-                              );
+                              if (shouldDeleteFiles == null) return;
                               if (!context.mounted) return;
-                              ref.invalidate(qbitRawTorrentsProvider(instance));
-                              Navigator.of(context).pop();
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(content: Text('Action failed')),
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final QbittorrentClient client = await ref.read(
+                                  qbittorrentClientProvider(instance).future,
+                                );
+                                await client.delete(
+                                  <String>[torrent.hash],
+                                  deleteFiles: shouldDeleteFiles,
+                                );
+                                if (!context.mounted) return;
+                                ref.invalidate(
+                                    qbitRawTorrentsProvider(instance));
+                                Navigator.of(context).pop();
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Action failed')),
+                                );
+                              }
+                            },
+                          ),
+                        ],
+                      ),
                     ),
                   ],
                 ),
@@ -532,7 +573,8 @@ class _OverviewTab extends ConsumerWidget {
                   ('Save path', p.savePath),
                   ('Added', date(p.additionDate)),
                   ('Completed', date(p.completionDate)),
-                  if (torrent.category.isNotEmpty) ('Category', torrent.category),
+                  if (torrent.category.isNotEmpty)
+                    ('Category', torrent.category),
                   if (p.comment.isNotEmpty) ('Comment', p.comment),
                 ],
               ),
@@ -604,8 +646,8 @@ class _SectionCard extends StatelessWidget {
         children: <Widget>[
           Text(
             title,
-            style:
-                theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            style: theme.textTheme.titleMedium
+                ?.copyWith(fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: Insets.sm),
           for (final (String label, String value) in rows)
@@ -688,7 +730,8 @@ class _FileNode {
   final bool isCollapsed;
 }
 
-List<_FileNode> _buildFileTree(List<QbitFile> files, Set<String> collapsedPaths) {
+List<_FileNode> _buildFileTree(
+    List<QbitFile> files, Set<String> collapsedPaths) {
   final _BuilderNode root = _BuilderNode('', '', -1, false);
 
   for (final QbitFile f in files) {
@@ -701,7 +744,8 @@ List<_FileNode> _buildFileTree(List<QbitFile> files, Set<String> collapsedPaths)
       currentPath = currentPath.isEmpty ? part : '$currentPath/$part';
 
       final bool isFile = i == parts.length - 1;
-      current = current.children.putIfAbsent(part, () => _BuilderNode(part, currentPath, i, isFile));
+      current = current.children
+          .putIfAbsent(part, () => _BuilderNode(part, currentPath, i, isFile));
 
       current.size += f.size;
       current.downloaded += f.size * f.progress;
@@ -739,7 +783,8 @@ class _FilesTab extends ConsumerStatefulWidget {
   ConsumerState<_FilesTab> createState() => _FilesTabState();
 }
 
-class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveClientMixin {
+class _FilesTabState extends ConsumerState<_FilesTab>
+    with AutomaticKeepAliveClientMixin {
   final Set<String> _collapsedPaths = <String>{};
 
   @override
@@ -758,7 +803,8 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
           ref.invalidate(qbitFilesProvider((widget.instance, widget.hash))),
       child: AsyncValueView<List<QbitFile>>(
         value: files,
-        onRetry: () => ref.invalidate(qbitFilesProvider((widget.instance, widget.hash))),
+        onRetry: () =>
+            ref.invalidate(qbitFilesProvider((widget.instance, widget.hash))),
         data: (List<QbitFile> list) {
           if (list.isEmpty) {
             return const EmptyView(
@@ -776,15 +822,17 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
               final _FileNode f = nodes[index];
               final Color barColor = f.isWanted ? cs.primary : cs.outline;
               return InkWell(
-                onTap: f.isFile ? null : () {
-                  setState(() {
-                    if (f.isCollapsed) {
-                      _collapsedPaths.remove(f.fullPath);
-                    } else {
-                      _collapsedPaths.add(f.fullPath);
-                    }
-                  });
-                },
+                onTap: f.isFile
+                    ? null
+                    : () {
+                        setState(() {
+                          if (f.isCollapsed) {
+                            _collapsedPaths.remove(f.fullPath);
+                          } else {
+                            _collapsedPaths.add(f.fullPath);
+                          }
+                        });
+                      },
                 child: Padding(
                   padding: EdgeInsets.fromLTRB(
                     Insets.md + f.depth * 16.0,
@@ -796,7 +844,9 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                     children: <Widget>[
                       if (!f.isFile)
                         Icon(
-                          f.isCollapsed ? Icons.keyboard_arrow_right : Icons.keyboard_arrow_down,
+                          f.isCollapsed
+                              ? Icons.keyboard_arrow_right
+                              : Icons.keyboard_arrow_down,
                           size: 20,
                           color: cs.onSurfaceVariant,
                         )
@@ -814,7 +864,9 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                         child: Icon(
                           f.isFile
                               ? Icons.insert_drive_file_outlined
-                              : (f.isCollapsed ? Icons.folder_outlined : Icons.folder_open_outlined),
+                              : (f.isCollapsed
+                                  ? Icons.folder_outlined
+                                  : Icons.folder_open_outlined),
                           size: 18,
                           color: cs.onSurfaceVariant,
                         ),
@@ -833,11 +885,11 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                             const SizedBox(height: 4),
                             ClipRRect(
                               borderRadius: BorderRadius.circular(6),
-                              child: LinearProgressIndicator(
+                              child: LinearProgressIndicatorM3E(
+                                shape: ProgressM3EShape.flat,
                                 value: f.progress.clamp(0, 1).toDouble(),
-                                minHeight: 5,
-                                color: barColor,
-                                backgroundColor: cs.surfaceContainerHighest,
+                                activeColor: barColor,
+                                trackColor: cs.surfaceContainerHighest,
                               ),
                             ),
                             const SizedBox(height: 2),
@@ -853,14 +905,16 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                       Checkbox(
                         value: f.isWanted,
                         onChanged: (bool? v) async {
-                          final QbittorrentClient client = await ref
-                              .read(qbittorrentClientProvider(widget.instance).future);
+                          final QbittorrentClient client = await ref.read(
+                              qbittorrentClientProvider(widget.instance)
+                                  .future);
                           await client.setFilePriority(
                             widget.hash,
                             f.fileIndices,
                             (v ?? false) ? 1 : 0,
                           );
-                          ref.invalidate(qbitFilesProvider((widget.instance, widget.hash)));
+                          ref.invalidate(qbitFilesProvider(
+                              (widget.instance, widget.hash)));
                         },
                       ),
                     ],
@@ -896,9 +950,8 @@ class _TrackersTab extends ConsumerWidget {
         onRetry: () => ref.invalidate(qbitTrackersProvider((instance, hash))),
         data: (List<QbitTracker> list) {
           // Hide qBittorrent's synthetic DHT/PeX/LSD pseudo-trackers.
-          final List<QbitTracker> real = list
-              .where((QbitTracker t) => !t.url.startsWith('** '))
-              .toList();
+          final List<QbitTracker> real =
+              list.where((QbitTracker t) => !t.url.startsWith('** ')).toList();
           if (real.isEmpty) {
             return const EmptyView(
               icon: Icons.dns_outlined,
@@ -916,7 +969,11 @@ class _TrackersTab extends ConsumerWidget {
                 2 => (cs.tertiary, Icons.check_circle, 'Working'),
                 3 => (cs.primary, Icons.sync, 'Updating'),
                 4 => (cs.error, Icons.error_outline, 'Not working'),
-                1 => (cs.outline, Icons.radio_button_unchecked, 'Not contacted'),
+                1 => (
+                    cs.outline,
+                    Icons.radio_button_unchecked,
+                    'Not contacted'
+                  ),
                 0 => (cs.outline, Icons.block, 'Disabled'),
                 _ => (cs.outline, Icons.help_outline, 'Unknown'),
               };
@@ -1053,11 +1110,11 @@ class _PeersTab extends ConsumerWidget {
                     const SizedBox(height: Insets.sm),
                     ClipRRect(
                       borderRadius: BorderRadius.circular(6),
-                      child: LinearProgressIndicator(
+                      child: LinearProgressIndicatorM3E(
+                        shape: ProgressM3EShape.flat,
                         value: p.progress.clamp(0, 1).toDouble(),
-                        minHeight: 5,
-                        color: cs.primary,
-                        backgroundColor: cs.surfaceContainerHighest,
+                        activeColor: cs.primary,
+                        trackColor: cs.surfaceContainerHighest,
                       ),
                     ),
                     const SizedBox(height: Insets.sm),

--- a/services/service_qbittorrent/pubspec.yaml
+++ b/services/service_qbittorrent/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   collection: ^1.18.0
   cookie_jar: ^4.0.8
   core_models:

--- a/services/service_radarr/lib/src/home/activity_tab.dart
+++ b/services/service_radarr/lib/src/home/activity_tab.dart
@@ -9,6 +9,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
 
 import '../../service_radarr.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class ActivityTab extends ConsumerStatefulWidget {
   const ActivityTab({required this.instance, super.key});
@@ -41,8 +42,11 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
     _tabController = TabController(length: 3, vsync: this);
     _tabController.addListener(() {
       if (_tabController.indexIsChanging) {
-        ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state = {};
-        ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+        ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state =
+            {};
+        ref
+            .read(radarrBlocklistSelectionProvider(widget.instance).notifier)
+            .state = {};
         setState(() {});
       }
     });
@@ -88,8 +92,10 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final grouped = ref.watch(radarrActivityGroupedProvider(widget.instance));
-    final queueSelection = ref.watch(radarrQueueSelectionProvider(widget.instance));
-    final blocklistSelection = ref.watch(radarrBlocklistSelectionProvider(widget.instance));
+    final queueSelection =
+        ref.watch(radarrQueueSelectionProvider(widget.instance));
+    final blocklistSelection =
+        ref.watch(radarrBlocklistSelectionProvider(widget.instance));
     final activeSelection = _tabController.index == 0
         ? queueSelection
         : _tabController.index == 2
@@ -116,13 +122,20 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
               selectedIds: activeSelection,
               isQueue: _tabController.index == 0,
               onClear: () {
-                ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                ref
+                    .read(
+                        radarrQueueSelectionProvider(widget.instance).notifier)
+                    .state = {};
+                ref
+                    .read(radarrBlocklistSelectionProvider(widget.instance)
+                        .notifier)
+                    .state = {};
               },
             )
           : null,
       body: NestedScrollView(
-        headerSliverBuilder: (BuildContext innerContext, bool innerBoxIsScrolled) {
+        headerSliverBuilder:
+            (BuildContext innerContext, bool innerBoxIsScrolled) {
           return <Widget>[
             SliverAppBar(
               floating: true,
@@ -138,8 +151,15 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                   ? IconButton(
                       icon: const Icon(Icons.close),
                       onPressed: () {
-                        ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                        ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                        ref
+                            .read(radarrQueueSelectionProvider(widget.instance)
+                                .notifier)
+                            .state = {};
+                        ref
+                            .read(radarrBlocklistSelectionProvider(
+                                    widget.instance)
+                                .notifier)
+                            .state = {};
                       },
                     )
                   : IconButton(
@@ -156,55 +176,59 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                       ),
                     )
                   : SearchBar(
-                focusNode: _searchFocusNode,
-                controller: _searchController,
-                hintText: 'Search activity...',
-                onTapOutside: (event) {
-                  if (_searchFocusNode.hasFocus) {
-                    _searchFocusNode.unfocus();
-                  }
-                },
-                elevation: const WidgetStatePropertyAll<double>(0),
-                backgroundColor: WidgetStatePropertyAll<Color>(
-                  theme.colorScheme.surfaceContainerHigh,
-                ),
-                trailing: <Widget>[
-                  if (_searchController.text.isNotEmpty)
-                    IconButton(
-                      icon: const Icon(Icons.clear),
-                      onPressed: () {
-                        setState(() {
-                          _searchController.clear();
-                        });
+                      focusNode: _searchFocusNode,
+                      controller: _searchController,
+                      hintText: 'Search activity...',
+                      onTapOutside: (event) {
+                        if (_searchFocusNode.hasFocus) {
+                          _searchFocusNode.unfocus();
+                        }
+                      },
+                      elevation: const WidgetStatePropertyAll<double>(0),
+                      backgroundColor: WidgetStatePropertyAll<Color>(
+                        theme.colorScheme.surfaceContainerHigh,
+                      ),
+                      trailing: <Widget>[
+                        if (_searchController.text.isNotEmpty)
+                          IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              setState(() {
+                                _searchController.clear();
+                              });
+                              ref
+                                  .read(
+                                    radarrActivitySearchQueryProvider(
+                                      widget.instance,
+                                    ).notifier,
+                                  )
+                                  .state = '';
+                              _updateSearchActiveState();
+                            },
+                          ),
+                      ],
+                      onChanged: (String value) {
+                        setState(() {});
                         ref
                             .read(
-                              radarrActivitySearchQueryProvider(
-                                widget.instance,
-                              ).notifier,
+                              radarrActivitySearchQueryProvider(widget.instance)
+                                  .notifier,
                             )
-                            .state = '';
+                            .state = value;
                         _updateSearchActiveState();
                       },
                     ),
-                ],
-                onChanged: (String value) {
-                  setState(() {});
-                  ref
-                      .read(
-                        radarrActivitySearchQueryProvider(widget.instance)
-                            .notifier,
-                      )
-                      .state = value;
-                  _updateSearchActiveState();
-                },
-              ),
               actions: <Widget>[
                 if (!isSelecting) ...[
                   IconButton(
                     icon: Icon(
-                      grouped ? Icons.format_list_bulleted : Icons.group_work_outlined,
+                      grouped
+                          ? Icons.format_list_bulleted
+                          : Icons.group_work_outlined,
                     ),
-                    tooltip: grouped ? 'Switch to plain list' : 'Switch to grouped view',
+                    tooltip: grouped
+                        ? 'Switch to plain list'
+                        : 'Switch to grouped view',
                     onPressed: () {
                       ref
                           .read(
@@ -259,14 +283,17 @@ class _QueueView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final queueAsync = ref.watch(radarrQueueProvider(instance));
-    final searchQuery = ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return queueAsync.when(
       data: (List<RadarrQueueItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.title?.toLowerCase().contains(searchQuery) ?? false;
-          final movieMatch = item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.title?.toLowerCase().contains(searchQuery) ?? false;
+          final movieMatch =
+              item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || movieMatch;
         }).toList();
 
@@ -336,7 +363,8 @@ class _QueueCard extends ConsumerWidget {
 
     String? posterUrl;
     if (item.movie?.images != null && api != null) {
-      final img = item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -360,7 +388,8 @@ class _QueueCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(16),
         onTap: () {
           if (selection.isNotEmpty) {
-            final notifier = ref.read(radarrQueueSelectionProvider(instance).notifier);
+            final notifier =
+                ref.read(radarrQueueSelectionProvider(instance).notifier);
             if (isSelected) {
               notifier.state = selection.where((id) => id != item.id).toSet();
             } else {
@@ -371,7 +400,8 @@ class _QueueCard extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          final notifier = ref.read(radarrQueueSelectionProvider(instance).notifier);
+          final notifier =
+              ref.read(radarrQueueSelectionProvider(instance).notifier);
           if (isSelected) {
             notifier.state = selection.where((id) => id != item.id).toSet();
           } else {
@@ -433,10 +463,12 @@ class _QueueCard extends ConsumerWidget {
                         Expanded(
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress,
-                              backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                              color: item.status == 'warning'
+                              trackColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                              activeColor: item.status == 'warning'
                                   ? theme.colorScheme.error
                                   : theme.colorScheme.primary,
                             ),
@@ -461,7 +493,8 @@ class _QueueCard extends ConsumerWidget {
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
                         ),
-                        if (item.timeleft != null && item.timeleft != '00:00:00')
+                        if (item.timeleft != null &&
+                            item.timeleft != '00:00:00')
                           Text(
                             'ETA: ${item.timeleft}',
                             style: theme.textTheme.bodySmall?.copyWith(
@@ -546,10 +579,12 @@ class _QueueCard extends ConsumerWidget {
       context: context,
       builder: (context) {
         return AlertDialog(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
           title: Text(
             'Queue Details',
-            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            style: theme.textTheme.titleLarge
+                ?.copyWith(fontWeight: FontWeight.bold),
           ),
           content: SingleChildScrollView(
             child: Column(
@@ -559,11 +594,17 @@ class _QueueCard extends ConsumerWidget {
                 _DetailRow(label: 'Title', value: i.title ?? 'No title'),
                 _DetailRow(label: 'Movie', value: i.movie?.title ?? 'Unknown'),
                 _DetailRow(label: 'Status', value: i.status ?? 'Unknown'),
-                _DetailRow(label: 'Tracked State', value: i.trackedDownloadState ?? 'None'),
-                _DetailRow(label: 'Download Client', value: i.downloadClient ?? 'Unknown'),
-                _DetailRow(label: 'Download ID', value: i.downloadId ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Tracked State',
+                    value: i.trackedDownloadState ?? 'None'),
+                _DetailRow(
+                    label: 'Download Client',
+                    value: i.downloadClient ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Download ID', value: i.downloadId ?? 'Unknown'),
                 _DetailRow(label: 'Indexer', value: i.indexer ?? 'Unknown'),
-                _DetailRow(label: 'Output Path', value: i.outputPath ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Output Path', value: i.outputPath ?? 'Unknown'),
               ],
             ),
           ),
@@ -671,14 +712,17 @@ class _HistoryView extends ConsumerWidget {
     final theme = Theme.of(context);
     final historyAsync = ref.watch(radarrHistoryProvider(instance));
     final grouped = ref.watch(radarrActivityGroupedProvider(instance));
-    final searchQuery = ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return historyAsync.when(
       data: (List<RadarrHistoryItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final movieMatch = item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final movieMatch =
+              item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || movieMatch;
         }).toList();
 
@@ -705,7 +749,8 @@ class _HistoryView extends ConsumerWidget {
         }
 
         if (grouped) {
-          final groupedMap = groupBy(filteredItems, (RadarrHistoryItem item) => item.movie?.id ?? 0);
+          final groupedMap = groupBy(
+              filteredItems, (RadarrHistoryItem item) => item.movie?.id ?? 0);
           final keys = groupedMap.keys.toList();
           return ListView.builder(
             padding: const EdgeInsets.all(Insets.md),
@@ -796,35 +841,38 @@ void _showHistoryDetails(
 
   void addRow(List<Widget> rows, String label, String? value) {
     if (value == null || value.isEmpty) return;
-    rows.add(Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 140,
-            child: Text(
-              label,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+    rows.add(
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 140,
+              child: Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: theme.textTheme.bodySmall?.copyWith(
-                fontWeight: FontWeight.w500,
+            Expanded(
+              child: Text(
+                value,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
-    ),);
+    );
   }
 
   final date = DateTime.tryParse(item.date ?? '')?.toLocal();
-  final formattedDate = date != null ? DateFormat.yMMMd().add_jm().format(date) : null;
+  final formattedDate =
+      date != null ? DateFormat.yMMMd().add_jm().format(date) : null;
 
   final rows = <Widget>[];
   addRow(rows, 'Movie', item.movie?.title);
@@ -840,8 +888,7 @@ void _showHistoryDetails(
     });
   }
 
-  final bool canMarkFailed =
-      (item.eventType ?? '').toLowerCase() == 'grabbed';
+  final bool canMarkFailed = (item.eventType ?? '').toLowerCase() == 'grabbed';
 
   showModalBottomSheet<void>(
     context: context,
@@ -871,7 +918,8 @@ void _showHistoryDetails(
             padding: const EdgeInsets.symmetric(horizontal: 20),
             child: Text(
               'History Details',
-              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.titleLarge
+                  ?.copyWith(fontWeight: FontWeight.bold),
             ),
           ),
           const SizedBox(height: 12),
@@ -894,8 +942,8 @@ void _showHistoryDetails(
                           ScaffoldMessenger.of(context);
                       Navigator.of(ctx).pop();
                       try {
-                        final api = await ref
-                            .read(radarrApiProvider(instance).future);
+                        final api =
+                            await ref.read(radarrApiProvider(instance).future);
                         await api.failHistoryItem(item.id);
                         if (!context.mounted) return;
                         ref.invalidate(radarrHistoryProvider(instance));
@@ -937,7 +985,8 @@ Future<void> _confirmDeleteBlocklistItem(
     context: context,
     builder: (context) => AlertDialog(
       title: const Text('Delete from Blocklist?'),
-      content: const Text('Are you sure you want to remove this entry from your blocklist?'),
+      content: const Text(
+          'Are you sure you want to remove this entry from your blocklist?'),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context, false),
@@ -984,14 +1033,16 @@ class _HistoryCard extends ConsumerWidget {
 
     String? posterUrl;
     if (item.movie?.images != null && api != null) {
-      final img = item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
     }
 
     final date = DateTime.tryParse(item.date ?? '')?.toLocal();
-    final String formattedDate = date != null ? DateFormat.yMMMd().add_jm().format(date) : '';
+    final String formattedDate =
+        date != null ? DateFormat.yMMMd().add_jm().format(date) : '';
 
     return Card(
       elevation: 0,
@@ -1133,7 +1184,8 @@ class _GroupedHistoryCard extends ConsumerStatefulWidget {
   final List<RadarrHistoryItem> items;
 
   @override
-  ConsumerState<_GroupedHistoryCard> createState() => _GroupedHistoryCardState();
+  ConsumerState<_GroupedHistoryCard> createState() =>
+      _GroupedHistoryCardState();
 }
 
 class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
@@ -1146,7 +1198,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
 
     String? posterUrl;
     if (widget.movie?.images != null && api != null) {
-      final img = widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -1187,11 +1240,14 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                               ),
                               errorWidget: (context, url, err) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
-                                child: const Icon(Icons.movie_outlined, size: 18),
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                                child:
+                                    const Icon(Icons.movie_outlined, size: 18),
                               ),
                             )
                           : Container(
@@ -1225,7 +1281,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1258,7 +1315,9 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                 itemBuilder: (context, index) {
                   final item = widget.items[index];
                   final date = DateTime.tryParse(item.date ?? '')?.toLocal();
-                  final String formattedDate = date != null ? DateFormat.yMMMd().add_jm().format(date) : '';
+                  final String formattedDate = date != null
+                      ? DateFormat.yMMMd().add_jm().format(date)
+                      : '';
                   return Padding(
                     padding: const EdgeInsets.symmetric(vertical: 6),
                     child: Row(
@@ -1290,7 +1349,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                         ),
                         IconButton(
                           icon: const Icon(Icons.info_outline, size: 20),
-                          onPressed: () => _showHistoryDetails(context, ref, widget.instance, item),
+                          onPressed: () => _showHistoryDetails(
+                              context, ref, widget.instance, item),
                         ),
                       ],
                     ),
@@ -1315,14 +1375,17 @@ class _BlocklistView extends ConsumerWidget {
     final theme = Theme.of(context);
     final blocklistAsync = ref.watch(radarrBlocklistProvider(instance));
     final grouped = ref.watch(radarrActivityGroupedProvider(instance));
-    final searchQuery = ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return blocklistAsync.when(
       data: (List<RadarrBlocklistItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final movieMatch = item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final movieMatch =
+              item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || movieMatch;
         }).toList();
 
@@ -1349,7 +1412,8 @@ class _BlocklistView extends ConsumerWidget {
         }
 
         if (grouped) {
-          final groupedMap = groupBy(filteredItems, (RadarrBlocklistItem item) => item.movie?.id ?? 0);
+          final groupedMap = groupBy(
+              filteredItems, (RadarrBlocklistItem item) => item.movie?.id ?? 0);
           final keys = groupedMap.keys.toList();
           return ListView.builder(
             padding: const EdgeInsets.all(Insets.md),
@@ -1406,7 +1470,8 @@ class _BlocklistCard extends ConsumerWidget {
 
     String? posterUrl;
     if (item.movie?.images != null && api != null) {
-      final img = item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -1430,7 +1495,8 @@ class _BlocklistCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(16),
         onTap: () {
           if (selection.isNotEmpty) {
-            final notifier = ref.read(radarrBlocklistSelectionProvider(instance).notifier);
+            final notifier =
+                ref.read(radarrBlocklistSelectionProvider(instance).notifier);
             if (isSelected) {
               notifier.state = selection.where((id) => id != item.id).toSet();
             } else {
@@ -1439,7 +1505,8 @@ class _BlocklistCard extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          final notifier = ref.read(radarrBlocklistSelectionProvider(instance).notifier);
+          final notifier =
+              ref.read(radarrBlocklistSelectionProvider(instance).notifier);
           if (isSelected) {
             notifier.state = selection.where((id) => id != item.id).toSet();
           } else {
@@ -1532,7 +1599,8 @@ class _BlocklistCard extends ConsumerWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Delete from Blocklist?'),
-        content: const Text('Are you sure you want to remove this entry from your blocklist?'),
+        content: const Text(
+            'Are you sure you want to remove this entry from your blocklist?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -1572,7 +1640,8 @@ class _GroupedBlocklistCard extends ConsumerStatefulWidget {
   final List<RadarrBlocklistItem> items;
 
   @override
-  ConsumerState<_GroupedBlocklistCard> createState() => _GroupedBlocklistCardState();
+  ConsumerState<_GroupedBlocklistCard> createState() =>
+      _GroupedBlocklistCardState();
 }
 
 class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
@@ -1582,15 +1651,18 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final api = ref.watch(radarrApiProvider(widget.instance)).value;
-    final selection = ref.watch(radarrBlocklistSelectionProvider(widget.instance));
+    final selection =
+        ref.watch(radarrBlocklistSelectionProvider(widget.instance));
     final isSelecting = selection.isNotEmpty;
     final groupIds = widget.items.map((i) => i.id).toList();
     final isGroupSelected = groupIds.every(selection.contains);
 
     void toggleGroupSelection() {
-      final notifier = ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier);
+      final notifier =
+          ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier);
       if (isGroupSelected) {
-        notifier.state = selection.where((id) => !groupIds.contains(id)).toSet();
+        notifier.state =
+            selection.where((id) => !groupIds.contains(id)).toSet();
       } else {
         notifier.state = {...selection, ...groupIds};
       }
@@ -1598,7 +1670,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
 
     String? posterUrl;
     if (widget.movie?.images != null && api != null) {
-      final img = widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -1649,20 +1722,26 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   placeholder: (context, url) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
                                   ),
                                   errorWidget: (context, url, err) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
-                                    child: const Icon(Icons.movie_outlined, size: 18),
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
+                                    child: const Icon(Icons.movie_outlined,
+                                        size: 18),
                                   ),
                                 )
                               : Container(
-                                  color: theme.colorScheme.surfaceContainerHighest,
-                                  child: const Icon(Icons.movie_outlined, size: 18),
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  child: const Icon(Icons.movie_outlined,
+                                      size: 18),
                                 ),
                           if (isGroupSelected)
                             Container(
-                              color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                              color: theme.colorScheme.primary
+                                  .withValues(alpha: 0.25),
                               child: Center(
                                 child: Container(
                                   padding: const EdgeInsets.all(3),
@@ -1707,7 +1786,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.errorContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1742,9 +1822,12 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   final isItemSelected = selection.contains(item.id);
 
                   void toggleItemSelection() {
-                    final notifier = ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier);
+                    final notifier = ref.read(
+                        radarrBlocklistSelectionProvider(widget.instance)
+                            .notifier);
                     if (isItemSelected) {
-                      notifier.state = selection.where((id) => id != item.id).toSet();
+                      notifier.state =
+                          selection.where((id) => id != item.id).toSet();
                     } else {
                       notifier.state = {...selection, item.id};
                     }
@@ -1780,7 +1863,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
                               ),
-                              if (item.message != null && item.message!.isNotEmpty) ...[
+                              if (item.message != null &&
+                                  item.message!.isNotEmpty) ...[
                                 const SizedBox(height: 2),
                                 Text(
                                   item.message!,
@@ -1802,7 +1886,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                               color: theme.colorScheme.error,
                               size: 20,
                             ),
-                            onPressed: () => _confirmDeleteBlocklistItem(context, ref, widget.instance, item),
+                            onPressed: () => _confirmDeleteBlocklistItem(
+                                context, ref, widget.instance, item),
                           ),
                       ],
                     ),
@@ -1908,7 +1993,8 @@ class _ActivityBulkActionsBar extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Text('Are you sure you want to cancel the selected downloads?'),
+              const Text(
+                  'Are you sure you want to cancel the selected downloads?'),
               CheckboxListTile(
                 title: const Text('Add releases to blocklist'),
                 value: blocklist,
@@ -1953,7 +2039,8 @@ class _ActivityBulkActionsBar extends StatelessWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: Text('Remove ${selectedIds.length} Entries?'),
-        content: const Text('Are you sure you want to remove the selected entries from the blocklist?'),
+        content: const Text(
+            'Are you sure you want to remove the selected entries from the blocklist?'),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -2042,7 +2129,8 @@ class _QueueBulkGrabDialog extends ConsumerWidget {
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Forced grab successfully triggered')),
+              const SnackBar(
+                  content: Text('Forced grab successfully triggered')),
             );
           },
           child: const Text('Force Grab'),

--- a/services/service_radarr/lib/src/home/manual_import_dialog.dart
+++ b/services/service_radarr/lib/src/home/manual_import_dialog.dart
@@ -16,13 +16,15 @@ void showManualImportFlow(
   WidgetRef ref,
   Instance instance,
 ) {
-  unawaited(showDialog<void>(
-    context: context,
-    barrierDismissible: false,
-    builder: (BuildContext context) => _ManualImportSetupDialog(
-      instance: instance,
+  unawaited(
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) => _ManualImportSetupDialog(
+        instance: instance,
+      ),
     ),
-  ),);
+  );
 }
 
 class _ManualImportSetupDialog extends ConsumerStatefulWidget {
@@ -67,9 +69,8 @@ class __ManualImportSetupDialogState
       setState(() {
         _pathController.text = selectedPath;
       });
-      ref
-          .read(radarrManualImportPathProvider(widget.instance).notifier)
-          .state = selectedPath;
+      ref.read(radarrManualImportPathProvider(widget.instance).notifier).state =
+          selectedPath;
     }
   }
 
@@ -86,37 +87,39 @@ class __ManualImportSetupDialogState
 
     // Show loading overlay
     final NavigatorState nav = Navigator.of(context, rootNavigator: true);
-    unawaited(showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext dialogContext) => PopScope<Object?>(
-        canPop: false,
-        child: Center(
-          child: Card(
-            margin: const EdgeInsets.symmetric(horizontal: 32),
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  const ExpressiveProgressIndicator(),
-                  const SizedBox(height: 16),
-                  const Text('Scanning files...'),
-                  const SizedBox(height: 16),
-                  TextButton(
-                    onPressed: () {
-                      cancelToken.cancel('User cancelled scan');
-                      nav.pop();
-                    },
-                    child: const Text('Cancel'),
-                  ),
-                ],
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext dialogContext) => PopScope<Object?>(
+          canPop: false,
+          child: Center(
+            child: Card(
+              margin: const EdgeInsets.symmetric(horizontal: 32),
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    const ExpressiveProgressIndicator(),
+                    const SizedBox(height: 16),
+                    const Text('Scanning files...'),
+                    const SizedBox(height: 16),
+                    TextButton(
+                      onPressed: () {
+                        cancelToken.cancel('User cancelled scan');
+                        nav.pop();
+                      },
+                      child: const Text('Cancel'),
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
       ),
-    ),);
+    );
 
     List<dynamic> scanResults;
     try {
@@ -146,7 +149,8 @@ class __ManualImportSetupDialogState
         context: context,
         builder: (BuildContext context) => AlertDialog(
           title: const Text('No Files Found'),
-          content: Text('No videos were found in "$folder" that are eligible for import.'),
+          content: Text(
+              'No videos were found in "$folder" that are eligible for import.'),
           actions: <Widget>[
             TextButton(
               onPressed: () => Navigator.pop(context),
@@ -163,15 +167,17 @@ class __ManualImportSetupDialogState
     // shell rebuilds and does not depend on the just-popped dialog's context.
     nav.pop();
 
-    unawaited(nav.push<void>(
-      MaterialPageRoute<void>(
-        builder: (BuildContext context) => _ManualImportMappingScreen(
-          instance: widget.instance,
-          folderPath: folder,
-          initialFiles: scanResults,
+    unawaited(
+      nav.push<void>(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => _ManualImportMappingScreen(
+            instance: widget.instance,
+            folderPath: folder,
+            initialFiles: scanResults,
+          ),
         ),
       ),
-    ),);
+    );
   }
 
   @override
@@ -199,7 +205,8 @@ class __ManualImportSetupDialogState
                     ),
                     onChanged: (String val) {
                       ref
-                          .read(radarrManualImportPathProvider(widget.instance).notifier)
+                          .read(radarrManualImportPathProvider(widget.instance)
+                              .notifier)
                           .state = val;
                     },
                   ),
@@ -232,7 +239,8 @@ class __ManualImportSetupDialogState
               onChanged: (String? val) {
                 if (val != null) {
                   ref
-                      .read(radarrManualImportModeProvider(widget.instance).notifier)
+                      .read(radarrManualImportModeProvider(widget.instance)
+                          .notifier)
                       .state = val;
                 }
               },
@@ -245,7 +253,8 @@ class __ManualImportSetupDialogState
               value: filterExisting,
               onChanged: (bool val) {
                 ref
-                    .read(radarrManualImportFilterProvider(widget.instance).notifier)
+                    .read(radarrManualImportFilterProvider(widget.instance)
+                        .notifier)
                     .state = val;
               },
             ),
@@ -390,7 +399,8 @@ class __DirectoryBrowserDialogState
                     if (segments.isNotEmpty && !isWindows)
                       Text('/', style: theme.textTheme.bodyMedium),
                     for (int i = 0; i < segments.length; i++) ...<Widget>[
-                      if (i > 0) Text(separator, style: theme.textTheme.bodyMedium),
+                      if (i > 0)
+                        Text(separator, style: theme.textTheme.bodyMedium),
                       TextButton(
                         style: TextButton.styleFrom(
                           minimumSize: Size.zero,
@@ -401,7 +411,8 @@ class __DirectoryBrowserDialogState
                           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                         ),
                         onPressed: () {
-                          final List<String> subSegments = segments.sublist(0, i + 1);
+                          final List<String> subSegments =
+                              segments.sublist(0, i + 1);
                           final String target = isWindows
                               ? subSegments.join('\\')
                               : '/${subSegments.join('/')}';
@@ -462,7 +473,8 @@ class __DirectoryBrowserDialogState
                       : _directories.isEmpty
                           ? const Center(child: Text('No directories found.'))
                           : ListView.builder(
-                              itemCount: _directories.length + (segments.isNotEmpty ? 1 : 0),
+                              itemCount: _directories.length +
+                                  (segments.isNotEmpty ? 1 : 0),
                               itemBuilder: (BuildContext context, int index) {
                                 if (segments.isNotEmpty && index == 0) {
                                   return ListTile(
@@ -472,15 +484,20 @@ class __DirectoryBrowserDialogState
                                   );
                                 }
 
-                                final int dataIndex = segments.isNotEmpty ? index - 1 : index;
-                                final dir = _directories[dataIndex] as Map<String, dynamic>;
-                                final String name = (dir['name'] as String?) ?? 'Unknown';
-                                final String fullPath = (dir['path'] as String?) ?? '';
+                                final int dataIndex =
+                                    segments.isNotEmpty ? index - 1 : index;
+                                final dir = _directories[dataIndex]
+                                    as Map<String, dynamic>;
+                                final String name =
+                                    (dir['name'] as String?) ?? 'Unknown';
+                                final String fullPath =
+                                    (dir['path'] as String?) ?? '';
 
                                 return ListTile(
                                   leading: const Icon(Icons.folder),
                                   title: Text(name),
-                                  trailing: const Icon(Icons.chevron_right, size: 16),
+                                  trailing:
+                                      const Icon(Icons.chevron_right, size: 16),
                                   onTap: () {
                                     _navigateTo(fullPath);
                                   },
@@ -497,7 +514,8 @@ class __DirectoryBrowserDialogState
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: _loading ? null : () => Navigator.pop(context, _currentPath),
+          onPressed:
+              _loading ? null : () => Navigator.pop(context, _currentPath),
           child: const Text('Select Folder'),
         ),
       ],
@@ -558,29 +576,31 @@ class __ManualImportMappingScreenState
     final f = _files[index] as Map<String, dynamic>;
 
     final NavigatorState nav = Navigator.of(context, rootNavigator: true);
-    unawaited(showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext dialogContext) => const PopScope<Object?>(
-        canPop: false,
-        child: Center(
-          child: Card(
-            margin: EdgeInsets.symmetric(horizontal: 32),
-            child: Padding(
-              padding: EdgeInsets.all(24.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  ExpressiveProgressIndicator(),
-                  SizedBox(height: 16),
-                  Text('Loading library movies...'),
-                ],
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext dialogContext) => const PopScope<Object?>(
+          canPop: false,
+          child: Center(
+            child: Card(
+              margin: EdgeInsets.symmetric(horizontal: 32),
+              child: Padding(
+                padding: EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    ExpressiveProgressIndicator(),
+                    SizedBox(height: 16),
+                    Text('Loading library movies...'),
+                  ],
+                ),
               ),
             ),
           ),
         ),
       ),
-    ),);
+    );
 
     try {
       final api = await ref.read(radarrApiProvider(widget.instance).future);
@@ -618,7 +638,8 @@ class __ManualImportMappingScreenState
   Future<void> _executeImport() async {
     if (_selectedPaths.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Please select at least one file to import.')),
+        const SnackBar(
+            content: Text('Please select at least one file to import.')),
       );
       return;
     }
@@ -633,7 +654,9 @@ class __ManualImportMappingScreenState
       final List<Map<String, dynamic>> payload = <Map<String, dynamic>>[];
 
       for (final String path in _selectedPaths) {
-        final f = _files.firstWhere((x) => (x as Map<String, dynamic>)['path'] == path) as Map<String, dynamic>;
+        final f = _files
+                .firstWhere((x) => (x as Map<String, dynamic>)['path'] == path)
+            as Map<String, dynamic>;
         final movie = f['movie'] as Map<String, dynamic>?;
 
         if (movie == null) continue;
@@ -719,10 +742,12 @@ class __ManualImportMappingScreenState
                     itemBuilder: (BuildContext context, int index) {
                       final f = _files[index] as Map<String, dynamic>;
                       final String pathStr = (f['path'] as String?) ?? '';
-                      final String relativePath = (f['relativePath'] as String?) ?? pathStr;
+                      final String relativePath =
+                          (f['relativePath'] as String?) ?? pathStr;
                       final int bytes = (f['size'] as int?) ?? 0;
                       final movie = f['movie'] as Map<String, dynamic>?;
-                      final List<dynamic>? rejections = f['rejections'] as List<dynamic>?;
+                      final List<dynamic>? rejections =
+                          f['rejections'] as List<dynamic>?;
                       final bool isSelected = _selectedPaths.contains(pathStr);
 
                       String qName = 'Unknown Quality';
@@ -743,7 +768,8 @@ class __ManualImportMappingScreenState
                           side: BorderSide(
                             color: isSelected
                                 ? theme.colorScheme.primary
-                                : theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+                                : theme.colorScheme.outlineVariant
+                                    .withValues(alpha: 0.5),
                             width: isSelected ? 2.0 : 1.0,
                           ),
                           borderRadius: BorderRadius.circular(12),
@@ -771,11 +797,13 @@ class __ManualImportMappingScreenState
                                   ),
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: <Widget>[
                                         Text(
                                           relativePath,
-                                          style: theme.textTheme.bodyMedium?.copyWith(
+                                          style: theme.textTheme.bodyMedium
+                                              ?.copyWith(
                                             fontWeight: FontWeight.bold,
                                           ),
                                           maxLines: 2,
@@ -784,8 +812,10 @@ class __ManualImportMappingScreenState
                                         const SizedBox(height: 2),
                                         Text(
                                           '${_formatSize(bytes)} • $qName',
-                                          style: theme.textTheme.bodySmall?.copyWith(
-                                            color: theme.colorScheme.onSurfaceVariant,
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                            color: theme
+                                                .colorScheme.onSurfaceVariant,
                                           ),
                                         ),
                                       ],
@@ -794,15 +824,18 @@ class __ManualImportMappingScreenState
                                 ],
                               ),
                               const Divider(height: 16),
-                              if (rejections != null && rejections.isNotEmpty) ...<Widget>[
+                              if (rejections != null &&
+                                  rejections.isNotEmpty) ...<Widget>[
                                 Container(
                                   padding: const EdgeInsets.all(8),
                                   margin: const EdgeInsets.only(bottom: 12),
                                   decoration: BoxDecoration(
-                                    color: theme.colorScheme.errorContainer.withValues(alpha: 0.2),
+                                    color: theme.colorScheme.errorContainer
+                                        .withValues(alpha: 0.2),
                                     borderRadius: BorderRadius.circular(8),
                                     border: Border.all(
-                                      color: theme.colorScheme.error.withValues(alpha: 0.4),
+                                      color: theme.colorScheme.error
+                                          .withValues(alpha: 0.4),
                                     ),
                                   ),
                                   child: Row(
@@ -819,8 +852,10 @@ class __ManualImportMappingScreenState
                                               .cast<Map<String, dynamic>>()
                                               .map((r) => r['reason'] as String)
                                               .join(', '),
-                                          style: theme.textTheme.bodySmall?.copyWith(
-                                            color: theme.colorScheme.onErrorContainer,
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                            color: theme
+                                                .colorScheme.onErrorContainer,
                                           ),
                                         ),
                                       ),
@@ -833,14 +868,16 @@ class __ManualImportMappingScreenState
                                 runSpacing: 8,
                                 children: <Widget>[
                                   ActionChip(
-                                    avatar: const Icon(Icons.movie_outlined, size: 14),
+                                    avatar: const Icon(Icons.movie_outlined,
+                                        size: 14),
                                     label: Text(
                                       movie != null
                                           ? (movie['title'] as String)
                                           : 'Select Movie',
                                     ),
                                     backgroundColor: movie == null
-                                        ? theme.colorScheme.errorContainer.withValues(alpha: 0.3)
+                                        ? theme.colorScheme.errorContainer
+                                            .withValues(alpha: 0.3)
                                         : null,
                                     onPressed: () => _selectMovieForFile(index),
                                   ),
@@ -859,7 +896,8 @@ class __ManualImportMappingScreenState
               color: theme.colorScheme.surfaceContainer,
               border: Border(
                 top: BorderSide(
-                  color: theme.colorScheme.outlineVariant.withValues(alpha: 0.3),
+                  color:
+                      theme.colorScheme.outlineVariant.withValues(alpha: 0.3),
                 ),
               ),
             ),
@@ -950,7 +988,8 @@ class _MoviePickerDialogState extends State<_MoviePickerDialog> {
                   final RadarrMovie m = _filtered[index];
                   return ListTile(
                     title: Text(m.title),
-                    subtitle: Text('${m.studio ?? 'Unknown'} • ${m.year ?? ''}'),
+                    subtitle:
+                        Text('${m.studio ?? 'Unknown'} • ${m.year ?? ''}'),
                     onTap: () {
                       Navigator.pop(context, m);
                     },

--- a/services/service_radarr/lib/src/home/movies_tab.dart
+++ b/services/service_radarr/lib/src/home/movies_tab.dart
@@ -127,14 +127,18 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
               instance: widget.instance,
               selectedIds: selection,
               onClear: () {
-                ref.read(radarrMoviesSelectionProvider(widget.instance).notifier).state = {};
+                ref
+                    .read(
+                        radarrMoviesSelectionProvider(widget.instance).notifier)
+                    .state = {};
               },
             )
           : null,
-      floatingActionButton: !isSelecting && ref.watch(
-                radarrActiveTabBarIndexProvider(widget.instance),
-              ) ==
-              0
+      floatingActionButton: !isSelecting &&
+              ref.watch(
+                    radarrActiveTabBarIndexProvider(widget.instance),
+                  ) ==
+                  0
           ? Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.end,
@@ -179,8 +183,7 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
         behavior: HitTestBehavior.translucent,
         child: AsyncValueView<List<RadarrMovie>>(
           value: filtered,
-          onRetry: () =>
-              ref.invalidate(radarrMoviesProvider(widget.instance)),
+          onRetry: () => ref.invalidate(radarrMoviesProvider(widget.instance)),
           data: (List<RadarrMovie> list) {
             return M3RefreshIndicator(
               onRefresh: () async {
@@ -203,7 +206,11 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                         ? IconButton(
                             icon: const Icon(Icons.close),
                             onPressed: () {
-                              ref.read(radarrMoviesSelectionProvider(widget.instance).notifier).state = {};
+                              ref
+                                  .read(radarrMoviesSelectionProvider(
+                                          widget.instance)
+                                      .notifier)
+                                  .state = {};
                             },
                           )
                         : IconButton(
@@ -271,7 +278,9 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                               tooltip: 'Select all',
                               onPressed: () {
                                 ref
-                                    .read(radarrMoviesSelectionProvider(widget.instance).notifier)
+                                    .read(radarrMoviesSelectionProvider(
+                                            widget.instance)
+                                        .notifier)
                                     .state = list.map((m) => m.id).toSet();
                               },
                             )
@@ -281,7 +290,9 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                               tooltip: 'Deselect all',
                               onPressed: () {
                                 ref
-                                    .read(radarrMoviesSelectionProvider(widget.instance).notifier)
+                                    .read(radarrMoviesSelectionProvider(
+                                            widget.instance)
+                                        .notifier)
                                     .state = {};
                               },
                             ),
@@ -340,8 +351,8 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                         delegate: SliverChildBuilderDelegate(
                           (BuildContext context, int index) {
                             final RadarrMovie m = list[index];
-                            final RadarrImage? poster = m.images
-                                .firstWhereOrNull(
+                            final RadarrImage? poster =
+                                m.images.firstWhereOrNull(
                               (RadarrImage i) => i.coverType == 'poster',
                             );
                             final isSelected = selection.contains(m.id);
@@ -352,18 +363,28 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                                   : api?.posterUrl(poster, width: 500),
                               selected: isSelected,
                               onLongPress: () {
-                                final notifier = ref.read(radarrMoviesSelectionProvider(widget.instance).notifier);
+                                final notifier = ref.read(
+                                    radarrMoviesSelectionProvider(
+                                            widget.instance)
+                                        .notifier);
                                 if (isSelected) {
-                                  notifier.state = selection.where((id) => id != m.id).toSet();
+                                  notifier.state = selection
+                                      .where((id) => id != m.id)
+                                      .toSet();
                                 } else {
                                   notifier.state = {...selection, m.id};
                                 }
                               },
                               onTap: () {
                                 if (isSelecting) {
-                                  final notifier = ref.read(radarrMoviesSelectionProvider(widget.instance).notifier);
+                                  final notifier = ref.read(
+                                      radarrMoviesSelectionProvider(
+                                              widget.instance)
+                                          .notifier);
                                   if (isSelected) {
-                                    notifier.state = selection.where((id) => id != m.id).toSet();
+                                    notifier.state = selection
+                                        .where((id) => id != m.id)
+                                        .toSet();
                                   } else {
                                     notifier.state = {...selection, m.id};
                                   }
@@ -399,17 +420,21 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                           (BuildContext context, int index) {
                             final RadarrMovie m = list[index];
                             return Padding(
-                              padding:
-                                  const EdgeInsets.only(bottom: Insets.md),
+                              padding: const EdgeInsets.only(bottom: Insets.md),
                               child: _MovieBannerCard(
                                 instance: widget.instance,
                                 movie: m,
                                 selected: selection.contains(m.id),
                                 onLongPress: () {
                                   final isSelected = selection.contains(m.id);
-                                  final notifier = ref.read(radarrMoviesSelectionProvider(widget.instance).notifier);
+                                  final notifier = ref.read(
+                                      radarrMoviesSelectionProvider(
+                                              widget.instance)
+                                          .notifier);
                                   if (isSelected) {
-                                    notifier.state = selection.where((id) => id != m.id).toSet();
+                                    notifier.state = selection
+                                        .where((id) => id != m.id)
+                                        .toSet();
                                   } else {
                                     notifier.state = {...selection, m.id};
                                   }
@@ -417,9 +442,14 @@ class _MoviesTabState extends ConsumerState<MoviesTab>
                                 onTap: () {
                                   final isSelected = selection.contains(m.id);
                                   if (isSelecting) {
-                                    final notifier = ref.read(radarrMoviesSelectionProvider(widget.instance).notifier);
+                                    final notifier = ref.read(
+                                        radarrMoviesSelectionProvider(
+                                                widget.instance)
+                                            .notifier);
                                     if (isSelected) {
-                                      notifier.state = selection.where((id) => id != m.id).toSet();
+                                      notifier.state = selection
+                                          .where((id) => id != m.id)
+                                          .toSet();
                                     } else {
                                       notifier.state = {...selection, m.id};
                                     }
@@ -496,7 +526,8 @@ class _MovieCard extends StatelessWidget {
                   if (selected)
                     Positioned.fill(
                       child: Container(
-                        color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                        color:
+                            theme.colorScheme.primary.withValues(alpha: 0.25),
                         child: Center(
                           child: Container(
                             padding: const EdgeInsets.all(6),
@@ -709,7 +740,8 @@ class _MovieBannerCard extends ConsumerWidget {
                                 errorWidget: (_, __, ___) => Container(
                                   color:
                                       theme.colorScheme.surfaceContainerHighest,
-                                  child: const Icon(Icons.movie_outlined, size: 20),
+                                  child: const Icon(Icons.movie_outlined,
+                                      size: 20),
                                 ),
                               ),
                             )
@@ -948,7 +980,8 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final profilesAsync = ref.watch(radarrQualityProfilesProvider(widget.instance));
+    final profilesAsync =
+        ref.watch(radarrQualityProfilesProvider(widget.instance));
     final foldersAsync = ref.watch(radarrRootFoldersProvider(widget.instance));
 
     return AlertDialog(
@@ -981,10 +1014,12 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
                 ),
                 items: [
                   const DropdownMenuItem(child: Text('Keep current')),
-                  ...profiles.map((p) => DropdownMenuItem(
-                        value: p['id'] as int,
-                        child: Text(p['name'] as String),
-                      ),),
+                  ...profiles.map(
+                    (p) => DropdownMenuItem(
+                      value: p['id'] as int,
+                      child: Text(p['name'] as String),
+                    ),
+                  ),
                 ],
                 onChanged: (val) => setState(() => _qualityProfileId = val),
               ),
@@ -1004,10 +1039,12 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
                 ),
                 items: [
                   const DropdownMenuItem(child: Text('Keep current')),
-                  ...folders.map((f) => DropdownMenuItem(
-                        value: f['path'] as String,
-                        child: Text(f['path'] as String),
-                      ),),
+                  ...folders.map(
+                    (f) => DropdownMenuItem(
+                      value: f['path'] as String,
+                      child: Text(f['path'] as String),
+                    ),
+                  ),
                 ],
                 onChanged: (val) => setState(() => _rootFolderPath = val),
               ),
@@ -1044,21 +1081,24 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
             final payload = <String, dynamic>{
               'movieIds': widget.selectedIds.toList(),
               if (_monitored != null) 'monitored': _monitored,
-              if (_qualityProfileId != null) 'qualityProfileId': _qualityProfileId,
+              if (_qualityProfileId != null)
+                'qualityProfileId': _qualityProfileId,
               if (_rootFolderPath != null) 'rootFolderPath': _rootFolderPath,
               // Changing the root folder without moveFiles orphans the
               // files on disk, so send the user's explicit choice.
               if (_rootFolderPath != null) 'moveFiles': _moveFiles,
             };
 
-            unawaited(showDialog<void>(
-              context: context,
-              barrierDismissible: false,
-              builder: (ctx) => const PopScope<Object?>(
-                canPop: false,
-                child: Center(child: ExpressiveProgressIndicator()),
+            unawaited(
+              showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (ctx) => const PopScope<Object?>(
+                  canPop: false,
+                  child: Center(child: ExpressiveProgressIndicator()),
+                ),
               ),
-            ),);
+            );
 
             Object? error;
             try {
@@ -1079,7 +1119,9 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
               return;
             }
             ref.invalidate(radarrMoviesProvider(widget.instance));
-            ref.read(radarrMoviesSelectionProvider(widget.instance).notifier).state = {};
+            ref
+                .read(radarrMoviesSelectionProvider(widget.instance).notifier)
+                .state = {};
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
@@ -1117,7 +1159,8 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('Are you sure you want to delete these movies? This action cannot be undone.'),
+          const Text(
+              'Are you sure you want to delete these movies? This action cannot be undone.'),
           const SizedBox(height: 16),
           CheckboxListTile(
             title: const Text('Delete all files from disk'),
@@ -1140,20 +1183,23 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
           onPressed: () async {
             final NavigatorState nav =
                 Navigator.of(context, rootNavigator: true);
-            unawaited(showDialog<void>(
-              context: context,
-              barrierDismissible: false,
-              builder: (ctx) => const PopScope<Object?>(
-                canPop: false,
-                child: Center(child: ExpressiveProgressIndicator()),
+            unawaited(
+              showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (ctx) => const PopScope<Object?>(
+                  canPop: false,
+                  child: Center(child: ExpressiveProgressIndicator()),
+                ),
               ),
-            ),);
+            );
 
             Object? error;
             try {
               final api =
                   await ref.read(radarrApiProvider(widget.instance).future);
-              await api.bulkDeleteMovies(widget.selectedIds.toList(), deleteFiles: _deleteFiles);
+              await api.bulkDeleteMovies(widget.selectedIds.toList(),
+                  deleteFiles: _deleteFiles);
             } catch (e) {
               error = e;
             } finally {
@@ -1168,7 +1214,9 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
               return;
             }
             ref.invalidate(radarrMoviesProvider(widget.instance));
-            ref.read(radarrMoviesSelectionProvider(widget.instance).notifier).state = {};
+            ref
+                .read(radarrMoviesSelectionProvider(widget.instance).notifier)
+                .state = {};
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
@@ -1218,35 +1266,50 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                     label: const Text('All Status'),
                     selected: filter == RadarrMovieFilter.all,
                     onSelected: (val) {
-                      if (val) ref.read(radarrMovieFilterProvider(instance).notifier).state = RadarrMovieFilter.all;
+                      if (val)
+                        ref
+                            .read(radarrMovieFilterProvider(instance).notifier)
+                            .state = RadarrMovieFilter.all;
                     },
                   ),
                   ChoiceChip(
                     label: const Text('Downloaded Only'),
                     selected: filter == RadarrMovieFilter.downloaded,
                     onSelected: (val) {
-                      if (val) ref.read(radarrMovieFilterProvider(instance).notifier).state = RadarrMovieFilter.downloaded;
+                      if (val)
+                        ref
+                            .read(radarrMovieFilterProvider(instance).notifier)
+                            .state = RadarrMovieFilter.downloaded;
                     },
                   ),
                   ChoiceChip(
                     label: const Text('Missing Only'),
                     selected: filter == RadarrMovieFilter.missing,
                     onSelected: (val) {
-                      if (val) ref.read(radarrMovieFilterProvider(instance).notifier).state = RadarrMovieFilter.missing;
+                      if (val)
+                        ref
+                            .read(radarrMovieFilterProvider(instance).notifier)
+                            .state = RadarrMovieFilter.missing;
                     },
                   ),
                   ChoiceChip(
                     label: const Text('Monitored Only'),
                     selected: filter == RadarrMovieFilter.monitoredOnly,
                     onSelected: (val) {
-                      if (val) ref.read(radarrMovieFilterProvider(instance).notifier).state = RadarrMovieFilter.monitoredOnly;
+                      if (val)
+                        ref
+                            .read(radarrMovieFilterProvider(instance).notifier)
+                            .state = RadarrMovieFilter.monitoredOnly;
                     },
                   ),
                   ChoiceChip(
                     label: const Text('Unmonitored Only'),
                     selected: filter == RadarrMovieFilter.unmonitoredOnly,
                     onSelected: (val) {
-                      if (val) ref.read(radarrMovieFilterProvider(instance).notifier).state = RadarrMovieFilter.unmonitoredOnly;
+                      if (val)
+                        ref
+                            .read(radarrMovieFilterProvider(instance).notifier)
+                            .state = RadarrMovieFilter.unmonitoredOnly;
                     },
                   ),
                 ],
@@ -1269,10 +1332,19 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                     onSelected: (val) {
                       if (val) {
                         if (sortOption == RadarrMovieSortField.title) {
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = !sortAscending;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = !sortAscending;
                         } else {
-                          ref.read(radarrMovieSortFieldProvider(instance).notifier).state = RadarrMovieSortField.title;
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = true;
+                          ref
+                              .read(radarrMovieSortFieldProvider(instance)
+                                  .notifier)
+                              .state = RadarrMovieSortField.title;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = true;
                         }
                       }
                     },
@@ -1283,10 +1355,19 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                     onSelected: (val) {
                       if (val) {
                         if (sortOption == RadarrMovieSortField.year) {
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = !sortAscending;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = !sortAscending;
                         } else {
-                          ref.read(radarrMovieSortFieldProvider(instance).notifier).state = RadarrMovieSortField.year;
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = false;
+                          ref
+                              .read(radarrMovieSortFieldProvider(instance)
+                                  .notifier)
+                              .state = RadarrMovieSortField.year;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = false;
                         }
                       }
                     },
@@ -1297,10 +1378,19 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                     onSelected: (val) {
                       if (val) {
                         if (sortOption == RadarrMovieSortField.added) {
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = !sortAscending;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = !sortAscending;
                         } else {
-                          ref.read(radarrMovieSortFieldProvider(instance).notifier).state = RadarrMovieSortField.added;
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = false;
+                          ref
+                              .read(radarrMovieSortFieldProvider(instance)
+                                  .notifier)
+                              .state = RadarrMovieSortField.added;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = false;
                         }
                       }
                     },
@@ -1311,24 +1401,44 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                     onSelected: (val) {
                       if (val) {
                         if (sortOption == RadarrMovieSortField.sizeOnDisk) {
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = !sortAscending;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = !sortAscending;
                         } else {
-                          ref.read(radarrMovieSortFieldProvider(instance).notifier).state = RadarrMovieSortField.sizeOnDisk;
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = false;
+                          ref
+                              .read(radarrMovieSortFieldProvider(instance)
+                                  .notifier)
+                              .state = RadarrMovieSortField.sizeOnDisk;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = false;
                         }
                       }
                     },
                   ),
                   ChoiceChip(
                     label: const Text('Monitored Status'),
-                    selected: sortOption == RadarrMovieSortField.monitoredStatus,
+                    selected:
+                        sortOption == RadarrMovieSortField.monitoredStatus,
                     onSelected: (val) {
                       if (val) {
-                        if (sortOption == RadarrMovieSortField.monitoredStatus) {
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = !sortAscending;
+                        if (sortOption ==
+                            RadarrMovieSortField.monitoredStatus) {
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = !sortAscending;
                         } else {
-                          ref.read(radarrMovieSortFieldProvider(instance).notifier).state = RadarrMovieSortField.monitoredStatus;
-                          ref.read(radarrMovieSortAscendingProvider(instance).notifier).state = true;
+                          ref
+                              .read(radarrMovieSortFieldProvider(instance)
+                                  .notifier)
+                              .state = RadarrMovieSortField.monitoredStatus;
+                          ref
+                              .read(radarrMovieSortAscendingProvider(instance)
+                                  .notifier)
+                              .state = true;
                         }
                       }
                     },

--- a/services/service_radarr/lib/src/home/settings/connect_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/connect_settings_screen.dart
@@ -13,7 +13,9 @@ class ConnectSettingsScreen extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectNotificationPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(radarrNotificationSchemaProvider(instance));
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
@@ -56,7 +58,8 @@ class ConnectSettingsScreen extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showNotificationEditorDialog(context, ref, preset, isNew: true);
+                        _showNotificationEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -70,8 +73,11 @@ class ConnectSettingsScreen extends ConsumerWidget {
   }
 
   Future<void> _showNotificationEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> notification,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> notification, {
+    bool isNew = false,
+  }) async {
     final fields = (notification['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -82,28 +88,33 @@ class ConnectSettingsScreen extends ConsumerWidget {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          title: Text(isNew ? 'Add ${notification['name']}' : 'Edit ${notification['name']}'),
+          title: Text(isNew
+              ? 'Add ${notification['name']}'
+              : 'Edit ${notification['name']}'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(radarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(radarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(notification);
                   payload['fields'] = updatedFields;
                   await api.testNotification(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(radarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(radarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(notification);
                     payload['fields'] = updatedFields;
 
                     if (isNew) {
                       await api.createNotification(payload);
                     } else {
-                      await api.updateNotification(payload, payload['id'] as int);
+                      await api.updateNotification(
+                          payload, payload['id'] as int);
                     }
 
                     ref.invalidate(radarrNotificationsProvider(instance));
@@ -111,14 +122,16 @@ class ConnectSettingsScreen extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text('Notification ${isNew ? 'added' : 'updated'}!'),
+                          content: Text(
+                              'Notification ${isNew ? 'added' : 'updated'}!'),
                         ),
                       );
                     }
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to save notification: $e')),
+                        SnackBar(
+                            content: Text('Failed to save notification: $e')),
                       );
                     }
                   }
@@ -132,7 +145,11 @@ class ConnectSettingsScreen extends ConsumerWidget {
   }
 
   Future<void> _deleteNotification(
-      BuildContext context, WidgetRef ref, int id, String name,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+    String name,
+  ) async {
     final confirmed = await confirmDelete(context, 'Notification "$name"');
     if (!confirmed) return;
 
@@ -175,7 +192,8 @@ class ConnectSettingsScreen extends ConsumerWidget {
         data: (notifications) {
           if (notifications.isEmpty) {
             return const Center(
-              child: Text('No connection notifications configured. Tap + to add one.'),
+              child: Text(
+                  'No connection notifications configured. Tap + to add one.'),
             );
           }
 
@@ -192,18 +210,22 @@ class ConnectSettingsScreen extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(name,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: Text('Type: $impl'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showNotificationEditorDialog(context, ref, n),
+                        onPressed: () =>
+                            _showNotificationEditorDialog(context, ref, n),
                       ),
                       IconButton(
-                        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
-                        onPressed: () => _deleteNotification(context, ref, id, name),
+                        icon: Icon(Icons.delete_outline,
+                            color: theme.colorScheme.error),
+                        onPressed: () =>
+                            _deleteNotification(context, ref, id, name),
                       ),
                     ],
                   ),

--- a/services/service_radarr/lib/src/home/settings/download_clients_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/download_clients_screen.dart
@@ -68,7 +68,9 @@ class _DownloadClientsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectClientPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(radarrDownloadClientSchemaProvider(instance));
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
@@ -111,7 +113,8 @@ class _DownloadClientsTab extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showClientEditorDialog(context, ref, preset, isNew: true);
+                        _showClientEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -125,8 +128,11 @@ class _DownloadClientsTab extends ConsumerWidget {
   }
 
   Future<void> _showClientEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> client,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> client, {
+    bool isNew = false,
+  }) async {
     final fields = (client['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -137,28 +143,32 @@ class _DownloadClientsTab extends ConsumerWidget {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          title: Text(isNew ? 'Add ${client['name']}' : 'Edit ${client['name']}'),
+          title:
+              Text(isNew ? 'Add ${client['name']}' : 'Edit ${client['name']}'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(radarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(radarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(client);
                   payload['fields'] = updatedFields;
                   await api.testDownloadClient(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(radarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(radarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(client);
                     payload['fields'] = updatedFields;
 
                     if (isNew) {
                       await api.createDownloadClient(payload);
                     } else {
-                      await api.updateDownloadClient(payload, payload['id'] as int);
+                      await api.updateDownloadClient(
+                          payload, payload['id'] as int);
                     }
 
                     ref.invalidate(radarrDownloadClientsProvider(instance));
@@ -166,14 +176,17 @@ class _DownloadClientsTab extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text('Download client ${isNew ? 'added' : 'updated'}!'),
+                          content: Text(
+                              'Download client ${isNew ? 'added' : 'updated'}!'),
                         ),
                       );
                     }
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to save download client: $e')),
+                        SnackBar(
+                            content:
+                                Text('Failed to save download client: $e')),
                       );
                     }
                   }
@@ -187,7 +200,11 @@ class _DownloadClientsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteClient(
-      BuildContext context, WidgetRef ref, int id, String name,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+    String name,
+  ) async {
     final confirmed = await confirmDelete(context, 'Download Client "$name"');
     if (!confirmed) return;
 
@@ -244,17 +261,20 @@ class _DownloadClientsTab extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(name,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: Text('Protocol: ${proto.toUpperCase()}'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showClientEditorDialog(context, ref, c),
+                        onPressed: () =>
+                            _showClientEditorDialog(context, ref, c),
                       ),
                       IconButton(
-                        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+                        icon: Icon(Icons.delete_outline,
+                            color: theme.colorScheme.error),
                         onPressed: () => _deleteClient(context, ref, id, name),
                       ),
                     ],
@@ -275,11 +295,17 @@ class _RemotePathMappingsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showMappingDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? mapping,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? mapping,
+  ]) async {
     final isEdit = mapping != null;
-    final hostController = TextEditingController(text: mapping?['host'] as String? ?? '');
-    final remoteController = TextEditingController(text: mapping?['remotePath'] as String? ?? '');
-    final localController = TextEditingController(text: mapping?['localPath'] as String? ?? '');
+    final hostController =
+        TextEditingController(text: mapping?['host'] as String? ?? '');
+    final remoteController =
+        TextEditingController(text: mapping?['remotePath'] as String? ?? '');
+    final localController =
+        TextEditingController(text: mapping?['localPath'] as String? ?? '');
 
     await showDialog<void>(
       context: context,
@@ -325,7 +351,8 @@ class _RemotePathMappingsTab extends ConsumerWidget {
             ElevatedButton(
               onPressed: () async {
                 try {
-                  final api = await ref.read(radarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(radarrApiProvider(instance).future);
                   final payload = mapping != null
                       ? Map<String, dynamic>.from(mapping)
                       : <String, dynamic>{};
@@ -335,7 +362,8 @@ class _RemotePathMappingsTab extends ConsumerWidget {
                   payload['localPath'] = localController.text.trim();
 
                   if (isEdit) {
-                    await api.updateRemotePathMapping(payload, payload['id'] as int);
+                    await api.updateRemotePathMapping(
+                        payload, payload['id'] as int);
                   } else {
                     await api.createRemotePathMapping(payload);
                   }
@@ -364,7 +392,11 @@ class _RemotePathMappingsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteMapping(
-      BuildContext context, WidgetRef ref, int id, String host,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+    String host,
+  ) async {
     final confirmed = await confirmDelete(context, 'Path Mapping for "$host"');
     if (!confirmed) return;
 
@@ -401,7 +433,8 @@ class _RemotePathMappingsTab extends ConsumerWidget {
         error: (err, _) => Center(child: Text('Error: $err')),
         data: (mappings) {
           if (mappings.isEmpty) {
-            return const Center(child: Text('No path mappings configured. Tap + to add one.'));
+            return const Center(
+                child: Text('No path mappings configured. Tap + to add one.'));
           }
 
           return ListView.builder(
@@ -431,7 +464,8 @@ class _RemotePathMappingsTab extends ConsumerWidget {
                         onPressed: () => _showMappingDialog(context, ref, m),
                       ),
                       IconButton(
-                        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+                        icon: Icon(Icons.delete_outline,
+                            color: theme.colorScheme.error),
                         onPressed: () => _deleteMapping(context, ref, id, host),
                       ),
                     ],
@@ -550,7 +584,8 @@ class _DownloadClientOptionsTabState
                         ),
                         value: _enableCompletedDownloadHandling,
                         onChanged: (val) => setState(
-                            () => _enableCompletedDownloadHandling = val,),
+                          () => _enableCompletedDownloadHandling = val,
+                        ),
                       ),
                       SwitchListTile(
                         contentPadding: EdgeInsets.zero,

--- a/services/service_radarr/lib/src/home/settings/general_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/general_settings_screen.dart
@@ -147,7 +147,8 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('General configuration settings saved!')),
+          const SnackBar(
+              content: Text('General configuration settings saved!')),
         );
         Navigator.pop(context);
       }
@@ -165,7 +166,8 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final hostConfigAsync = ref.watch(radarrHostConfigProvider(widget.instance));
+    final hostConfigAsync =
+        ref.watch(radarrHostConfigProvider(widget.instance));
 
     return Scaffold(
       appBar: AppBar(
@@ -327,7 +329,8 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                                 );
                                 ScaffoldMessenger.of(context).showSnackBar(
                                   const SnackBar(
-                                    content: Text('API Key copied to clipboard!'),
+                                    content:
+                                        Text('API Key copied to clipboard!'),
                                   ),
                                 );
                               },

--- a/services/service_radarr/lib/src/home/settings/indexers_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/indexers_settings_screen.dart
@@ -68,9 +68,11 @@ class _IndexersTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectIndexerPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(radarrIndexerSchemaProvider(instance));
-    
+
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -111,7 +113,8 @@ class _IndexersTab extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showIndexerEditorDialog(context, ref, preset, isNew: true);
+                        _showIndexerEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -125,8 +128,11 @@ class _IndexersTab extends ConsumerWidget {
   }
 
   Future<void> _showIndexerEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> indexer,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> indexer, {
+    bool isNew = false,
+  }) async {
     final fields = (indexer['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -137,21 +143,24 @@ class _IndexersTab extends ConsumerWidget {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          title: Text(isNew ? 'Add ${indexer['name']}' : 'Edit ${indexer['name']}'),
+          title: Text(
+              isNew ? 'Add ${indexer['name']}' : 'Edit ${indexer['name']}'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(radarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(radarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(indexer);
                   payload['fields'] = updatedFields;
                   await api.testIndexer(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(radarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(radarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(indexer);
                     payload['fields'] = updatedFields;
 
@@ -166,7 +175,8 @@ class _IndexersTab extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text('Indexer ${isNew ? 'added' : 'updated'}!'),
+                          content:
+                              Text('Indexer ${isNew ? 'added' : 'updated'}!'),
                         ),
                       );
                     }
@@ -187,7 +197,11 @@ class _IndexersTab extends ConsumerWidget {
   }
 
   Future<void> _deleteIndexer(
-      BuildContext context, WidgetRef ref, int id, String name,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+    String name,
+  ) async {
     final confirmed = await confirmDelete(context, 'Indexer "$name"');
     if (!confirmed) return;
 
@@ -227,7 +241,8 @@ class _IndexersTab extends ConsumerWidget {
         error: (err, _) => Center(child: Text('Error: $err')),
         data: (indexers) {
           if (indexers.isEmpty) {
-            return const Center(child: Text('No indexers configured. Tap + to add one.'));
+            return const Center(
+                child: Text('No indexers configured. Tap + to add one.'));
           }
 
           return ListView.builder(
@@ -243,17 +258,20 @@ class _IndexersTab extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(name,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: Text('Protocol: ${proto.toUpperCase()}'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showIndexerEditorDialog(context, ref, idx),
+                        onPressed: () =>
+                            _showIndexerEditorDialog(context, ref, idx),
                       ),
                       IconButton(
-                        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+                        icon: Icon(Icons.delete_outline,
+                            color: theme.colorScheme.error),
                         onPressed: () => _deleteIndexer(context, ref, id, name),
                       ),
                     ],
@@ -274,9 +292,11 @@ class _ImportListsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectImportListPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(radarrImportListSchemaProvider(instance));
-    
+
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -314,7 +334,8 @@ class _ImportListsTab extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showImportListEditorDialog(context, ref, preset, isNew: true);
+                        _showImportListEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -328,8 +349,11 @@ class _ImportListsTab extends ConsumerWidget {
   }
 
   Future<void> _showImportListEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> list,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> list, {
+    bool isNew = false,
+  }) async {
     final fields = (list['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -350,14 +374,16 @@ class _ImportListsTab extends ConsumerWidget {
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(radarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(radarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(list);
                   payload['fields'] = updatedFields;
                   await api.testImportList(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(radarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(radarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(list);
                     payload['fields'] = updatedFields;
 
@@ -405,14 +431,16 @@ class _ImportListsTab extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                          content: Text('Import list ${isNew ? 'added' : 'updated'}!'),
+                          content: Text(
+                              'Import list ${isNew ? 'added' : 'updated'}!'),
                         ),
                       );
                     }
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to save import list: $e')),
+                        SnackBar(
+                            content: Text('Failed to save import list: $e')),
                       );
                     }
                   }
@@ -426,7 +454,11 @@ class _ImportListsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteImportList(
-      BuildContext context, WidgetRef ref, int id, String name,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+    String name,
+  ) async {
     final confirmed = await confirmDelete(context, 'Import List "$name"');
     if (!confirmed) return;
 
@@ -465,7 +497,8 @@ class _ImportListsTab extends ConsumerWidget {
         error: (err, _) => Center(child: Text('Error: $err')),
         data: (lists) {
           if (lists.isEmpty) {
-            return const Center(child: Text('No import lists configured. Tap + to add one.'));
+            return const Center(
+                child: Text('No import lists configured. Tap + to add one.'));
           }
 
           return ListView.builder(
@@ -480,17 +513,21 @@ class _ImportListsTab extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(name,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showImportListEditorDialog(context, ref, lst),
+                        onPressed: () =>
+                            _showImportListEditorDialog(context, ref, lst),
                       ),
                       IconButton(
-                        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
-                        onPressed: () => _deleteImportList(context, ref, id, name),
+                        icon: Icon(Icons.delete_outline,
+                            color: theme.colorScheme.error),
+                        onPressed: () =>
+                            _deleteImportList(context, ref, id, name),
                       ),
                     ],
                   ),
@@ -549,7 +586,8 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
     _minAgeController.text = (config['minimumAge'] as int? ?? 0).toString();
     _retentionController.text = (config['retention'] as int? ?? 0).toString();
     _maxSizeController.text = (config['maximumSize'] as int? ?? 0).toString();
-    _rssIntervalController.text = (config['rssSyncInterval'] as int? ?? 15).toString();
+    _rssIntervalController.text =
+        (config['rssSyncInterval'] as int? ?? 15).toString();
   }
 
   Future<void> _save() async {
@@ -560,9 +598,12 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
       final api = await ref.read(radarrApiProvider(widget.instance).future);
       final payload = Map<String, dynamic>.from(_rawConfig!);
       payload['minimumAge'] = int.tryParse(_minAgeController.text.trim()) ?? 0;
-      payload['retention'] = int.tryParse(_retentionController.text.trim()) ?? 0;
-      payload['maximumSize'] = int.tryParse(_maxSizeController.text.trim()) ?? 0;
-      payload['rssSyncInterval'] = int.tryParse(_rssIntervalController.text.trim()) ?? 15;
+      payload['retention'] =
+          int.tryParse(_retentionController.text.trim()) ?? 0;
+      payload['maximumSize'] =
+          int.tryParse(_maxSizeController.text.trim()) ?? 0;
+      payload['rssSyncInterval'] =
+          int.tryParse(_rssIntervalController.text.trim()) ?? 15;
 
       await api.updateIndexerConfig(payload);
       ref.invalidate(radarrIndexerConfigProvider(widget.instance));
@@ -633,7 +674,8 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
                         keyboardType: TextInputType.number,
                         decoration: const InputDecoration(
                           labelText: 'Retention (Days)',
-                          helperText: 'Usenet only: max retention age (0 = unlimited)',
+                          helperText:
+                              'Usenet only: max retention age (0 = unlimited)',
                           border: OutlineInputBorder(),
                         ),
                       ),

--- a/services/service_radarr/lib/src/home/settings/media_management_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/media_management_settings_screen.dart
@@ -93,7 +93,8 @@ class _MediaManagementSettingsScreenState
     _renameMovies = naming['renameMovies'] as bool? ?? false;
     _replaceIllegalCharacters =
         naming['replaceIllegalCharacters'] as bool? ?? false;
-    _colonReplacementFormat = naming['colonReplacementFormat'] as String? ?? 'smart';
+    _colonReplacementFormat =
+        naming['colonReplacementFormat'] as String? ?? 'smart';
 
     _standardMovieFormatController.text =
         (naming['standardMovieFormat'] as String?) ?? '';
@@ -110,7 +111,7 @@ class _MediaManagementSettingsScreenState
     _enableMediaInfo = mediaMgmt['enableMediaInfo'] as bool? ?? false;
     _minimumFreeSpaceController.text =
         (mediaMgmt['minimumFreeSpaceWhenImporting'] as int? ?? 0).toString();
-    
+
     _autoUnmonitorPreviouslyDownloadedMovies =
         mediaMgmt['autoUnmonitorPreviouslyDownloadedMovies'] as bool? ?? false;
     _skipFreeSpaceCheckWhenImporting =
@@ -202,7 +203,8 @@ class _MediaManagementSettingsScreenState
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final namingConfigAsync = ref.watch(radarrNamingConfigProvider(widget.instance));
+    final namingConfigAsync =
+        ref.watch(radarrNamingConfigProvider(widget.instance));
     final mediaMgmtConfigAsync =
         ref.watch(radarrMediaManagementConfigProvider(widget.instance));
 
@@ -228,11 +230,13 @@ class _MediaManagementSettingsScreenState
       ),
       body: namingConfigAsync.when(
         loading: () => const Center(child: ExpressiveProgressIndicator()),
-        error: (err, _) => Center(child: Text('Error loading naming settings: $err')),
+        error: (err, _) =>
+            Center(child: Text('Error loading naming settings: $err')),
         data: (naming) {
           return mediaMgmtConfigAsync.when(
             loading: () => const Center(child: ExpressiveProgressIndicator()),
-            error: (err, _) => Center(child: Text('Error loading media management: $err')),
+            error: (err, _) =>
+                Center(child: Text('Error loading media management: $err')),
             data: (mediaMgmt) {
               _initializeValues(naming, mediaMgmt);
 
@@ -246,7 +250,8 @@ class _MediaManagementSettingsScreenState
                       color: theme.colorScheme.surfaceContainerLow,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(16),
-                        side: BorderSide(color: theme.colorScheme.outlineVariant),
+                        side:
+                            BorderSide(color: theme.colorScheme.outlineVariant),
                       ),
                       child: Padding(
                         padding: const EdgeInsets.all(Insets.md),
@@ -263,7 +268,8 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Rename Movies'),
                               value: _renameMovies,
-                              onChanged: (val) => setState(() => _renameMovies = val),
+                              onChanged: (val) =>
+                                  setState(() => _renameMovies = val),
                             ),
                             if (_renameMovies) ...[
                               const SizedBox(height: Insets.md),
@@ -287,8 +293,8 @@ class _MediaManagementSettingsScreenState
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('Replace Illegal Characters'),
                                 value: _replaceIllegalCharacters,
-                                onChanged: (val) =>
-                                    setState(() => _replaceIllegalCharacters = val),
+                                onChanged: (val) => setState(
+                                    () => _replaceIllegalCharacters = val),
                               ),
                               if (_replaceIllegalCharacters) ...[
                                 const SizedBox(height: Insets.md),
@@ -317,12 +323,14 @@ class _MediaManagementSettingsScreenState
                                     ),
                                     DropdownMenuItem(
                                       value: 'smart',
-                                      child: Text('Smart (Replace with Dash or Space Dash)'),
+                                      child: Text(
+                                          'Smart (Replace with Dash or Space Dash)'),
                                     ),
                                   ],
                                   onChanged: (val) {
                                     if (val != null) {
-                                      setState(() => _colonReplacementFormat = val);
+                                      setState(
+                                          () => _colonReplacementFormat = val);
                                     }
                                   },
                                 ),
@@ -338,7 +346,8 @@ class _MediaManagementSettingsScreenState
                       color: theme.colorScheme.surfaceContainerLow,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(16),
-                        side: BorderSide(color: theme.colorScheme.outlineVariant),
+                        side:
+                            BorderSide(color: theme.colorScheme.outlineVariant),
                       ),
                       child: Padding(
                         padding: const EdgeInsets.all(Insets.md),
@@ -355,8 +364,8 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Create Empty Movie Folders'),
                               value: _createEmptyMovieFolders,
-                              onChanged: (val) =>
-                                  setState(() => _createEmptyMovieFolders = val),
+                              onChanged: (val) => setState(
+                                  () => _createEmptyMovieFolders = val),
                             ),
                             SwitchListTile(
                               contentPadding: EdgeInsets.zero,
@@ -367,7 +376,8 @@ class _MediaManagementSettingsScreenState
                             ),
                             SwitchListTile(
                               contentPadding: EdgeInsets.zero,
-                              title: const Text('Use Hardlinks instead of Copy'),
+                              title:
+                                  const Text('Use Hardlinks instead of Copy'),
                               value: _copyUsingHardlinks,
                               onChanged: (val) =>
                                   setState(() => _copyUsingHardlinks = val),
@@ -400,7 +410,8 @@ class _MediaManagementSettingsScreenState
                       color: theme.colorScheme.surfaceContainerLow,
                       shape: RoundedRectangleBorder(
                         borderRadius: BorderRadius.circular(16),
-                        side: BorderSide(color: theme.colorScheme.outlineVariant),
+                        side:
+                            BorderSide(color: theme.colorScheme.outlineVariant),
                       ),
                       child: Padding(
                         padding: const EdgeInsets.all(Insets.md),

--- a/services/service_radarr/lib/src/home/settings/metadata_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/metadata_settings_screen.dart
@@ -12,7 +12,10 @@ class MetadataSettingsScreen extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showMetadataEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> metadata,) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> metadata,
+  ) async {
     final fields = (metadata['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -31,22 +34,28 @@ class MetadataSettingsScreen extends ConsumerWidget {
                 fields: fields,
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(radarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(radarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(metadata);
                     payload['fields'] = updatedFields;
 
-                    await api.updateMetadataConfig(payload, payload['id'] as int);
+                    await api.updateMetadataConfig(
+                        payload, payload['id'] as int);
                     ref.invalidate(radarrMetadataConfigsProvider(instance));
                     if (context.mounted) {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Metadata "${metadata['name']}" updated!')),
+                        SnackBar(
+                            content: Text(
+                                'Metadata "${metadata['name']}" updated!')),
                       );
                     }
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to save metadata settings: $e')),
+                        SnackBar(
+                            content:
+                                Text('Failed to save metadata settings: $e')),
                       );
                     }
                   }
@@ -88,7 +97,8 @@ class MetadataSettingsScreen extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(name,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: Text('Status: ${enable ? "Enabled" : "Disabled"}'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -97,11 +107,14 @@ class MetadataSettingsScreen extends ConsumerWidget {
                         value: enable,
                         onChanged: (val) async {
                           try {
-                            final api = await ref.read(radarrApiProvider(instance).future);
+                            final api = await ref
+                                .read(radarrApiProvider(instance).future);
                             final payload = Map<String, dynamic>.from(c);
                             payload['enable'] = val;
-                            await api.updateMetadataConfig(payload, payload['id'] as int);
-                            ref.invalidate(radarrMetadataConfigsProvider(instance));
+                            await api.updateMetadataConfig(
+                                payload, payload['id'] as int);
+                            ref.invalidate(
+                                radarrMetadataConfigsProvider(instance));
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
@@ -113,7 +126,8 @@ class MetadataSettingsScreen extends ConsumerWidget {
                       ),
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showMetadataEditorDialog(context, ref, c),
+                        onPressed: () =>
+                            _showMetadataEditorDialog(context, ref, c),
                       ),
                     ],
                   ),

--- a/services/service_radarr/lib/src/home/settings/parse_title_dialog.dart
+++ b/services/service_radarr/lib/src/home/settings/parse_title_dialog.dart
@@ -11,10 +11,12 @@ class RadarrParseTitleDialog extends ConsumerStatefulWidget {
   final Instance instance;
 
   @override
-  ConsumerState<RadarrParseTitleDialog> createState() => _RadarrParseTitleDialogState();
+  ConsumerState<RadarrParseTitleDialog> createState() =>
+      _RadarrParseTitleDialogState();
 }
 
-class _RadarrParseTitleDialogState extends ConsumerState<RadarrParseTitleDialog> {
+class _RadarrParseTitleDialogState
+    extends ConsumerState<RadarrParseTitleDialog> {
   final _controller = TextEditingController();
   String _query = '';
 
@@ -27,7 +29,7 @@ class _RadarrParseTitleDialogState extends ConsumerState<RadarrParseTitleDialog>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    
+
     final parseAsync = _query.trim().isNotEmpty
         ? ref.watch(radarrParseResultProvider((widget.instance, _query.trim())))
         : null;
@@ -108,29 +110,41 @@ class _RadarrParseTitleDialogState extends ConsumerState<RadarrParseTitleDialog>
                   child: parseAsync.when(
                     data: (data) {
                       if (data == null) {
-                        return const Center(child: Text('Failed to parse title.'));
+                        return const Center(
+                            child: Text('Failed to parse title.'));
                       }
-                      final parsedInfo = data['parsedMovieInfo'] as Map<String, dynamic>?;
+                      final parsedInfo =
+                          data['parsedMovieInfo'] as Map<String, dynamic>?;
                       if (parsedInfo == null) {
-                        return const Center(child: Text('Could not extract movie details.'));
+                        return const Center(
+                            child: Text('Could not extract movie details.'));
                       }
 
-                      final String? movieTitle = parsedInfo['movieTitle'] as String?;
+                      final String? movieTitle =
+                          parsedInfo['movieTitle'] as String?;
                       final int? year = parsedInfo['year'] as int?;
-                      final String? releaseGroup = parsedInfo['releaseGroup'] as String?;
-                      
-                      final qualityMap = parsedInfo['quality'] as Map<String, dynamic>?;
-                      final qualityInner = qualityMap?['quality'] as Map<String, dynamic>?;
-                      final String? qualityName = qualityInner?['name'] as String?;
-                      
-                      final languages = parsedInfo['languages'] as List<dynamic>?;
+                      final String? releaseGroup =
+                          parsedInfo['releaseGroup'] as String?;
+
+                      final qualityMap =
+                          parsedInfo['quality'] as Map<String, dynamic>?;
+                      final qualityInner =
+                          qualityMap?['quality'] as Map<String, dynamic>?;
+                      final String? qualityName =
+                          qualityInner?['name'] as String?;
+
+                      final languages =
+                          parsedInfo['languages'] as List<dynamic>?;
                       final List<String> languageNames = languages
-                              ?.map((l) => (l as Map<String, dynamic>)['name'] as String)
+                              ?.map((l) =>
+                                  (l as Map<String, dynamic>)['name'] as String)
                               .toList() ??
                           [];
 
-                      final matchingMovie = data['movie'] as Map<String, dynamic>?;
-                      final matchingMovieTitle = matchingMovie?['title'] as String?;
+                      final matchingMovie =
+                          data['movie'] as Map<String, dynamic>?;
+                      final matchingMovieTitle =
+                          matchingMovie?['title'] as String?;
 
                       return SingleChildScrollView(
                         child: Column(
@@ -144,11 +158,20 @@ class _RadarrParseTitleDialogState extends ConsumerState<RadarrParseTitleDialog>
                               ),
                             ),
                             const SizedBox(height: Insets.sm),
-                            _buildInfoRow(theme, 'Movie Title', movieTitle ?? 'N/A'),
-                            _buildInfoRow(theme, 'Year', year?.toString() ?? 'N/A'),
-                            _buildInfoRow(theme, 'Quality', qualityName ?? 'N/A'),
-                            _buildInfoRow(theme, 'Release Group', releaseGroup ?? 'N/A'),
-                            _buildInfoRow(theme, 'Language', languageNames.isNotEmpty ? languageNames.join(', ') : 'N/A'),
+                            _buildInfoRow(
+                                theme, 'Movie Title', movieTitle ?? 'N/A'),
+                            _buildInfoRow(
+                                theme, 'Year', year?.toString() ?? 'N/A'),
+                            _buildInfoRow(
+                                theme, 'Quality', qualityName ?? 'N/A'),
+                            _buildInfoRow(
+                                theme, 'Release Group', releaseGroup ?? 'N/A'),
+                            _buildInfoRow(
+                                theme,
+                                'Language',
+                                languageNames.isNotEmpty
+                                    ? languageNames.join(', ')
+                                    : 'N/A'),
                             const SizedBox(height: Insets.md),
                             Text(
                               'Radarr Database Match',
@@ -192,7 +215,8 @@ class _RadarrParseTitleDialogState extends ConsumerState<RadarrParseTitleDialog>
     );
   }
 
-  Widget _buildInfoRow(ThemeData theme, String label, String value, {Color? valueColor}) {
+  Widget _buildInfoRow(ThemeData theme, String label, String value,
+      {Color? valueColor}) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4.0),
       child: Row(

--- a/services/service_radarr/lib/src/home/settings/profiles_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/profiles_settings_screen.dart
@@ -67,14 +67,19 @@ class _QualityProfilesTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showProfileDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? profile,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? profile,
+  ]) async {
     Map<String, dynamic>? schema;
     try {
-      schema = await ref.read(radarrQualityProfileSchemaProvider(instance).future);
+      schema =
+          await ref.read(radarrQualityProfileSchemaProvider(instance).future);
     } catch (_) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to load quality profile schema')),
+          const SnackBar(
+              content: Text('Failed to load quality profile schema')),
         );
       }
       return;
@@ -87,9 +92,11 @@ class _QualityProfilesTab extends ConsumerWidget {
       text: (profile?['name'] as String?) ?? '',
     );
 
-    final sourceItems = (profile?['items'] ?? schema!['items']) as List<dynamic>;
+    final sourceItems =
+        (profile?['items'] ?? schema!['items']) as List<dynamic>;
     final editableItems = sourceItems
-        .map((dynamic e) => Map<String, dynamic>.from(e as Map<String, dynamic>))
+        .map(
+            (dynamic e) => Map<String, dynamic>.from(e as Map<String, dynamic>))
         .toList();
 
     bool upgradeAllowed = profile?['upgradeAllowed'] as bool? ?? false;
@@ -114,7 +121,8 @@ class _QualityProfilesTab extends ConsumerWidget {
             }
 
             return AlertDialog(
-              title: Text(isEdit ? 'Edit Quality Profile' : 'Add Quality Profile'),
+              title:
+                  Text(isEdit ? 'Edit Quality Profile' : 'Add Quality Profile'),
               content: SizedBox(
                 width: double.maxFinite,
                 child: SingleChildScrollView(
@@ -134,12 +142,16 @@ class _QualityProfilesTab extends ConsumerWidget {
                         contentPadding: EdgeInsets.zero,
                         title: const Text('Upgrades Allowed'),
                         value: upgradeAllowed,
-                        onChanged: (val) => setDialogState(() => upgradeAllowed = val),
+                        onChanged: (val) =>
+                            setDialogState(() => upgradeAllowed = val),
                       ),
                       if (upgradeAllowed && cutoffOptions.isNotEmpty) ...[
                         const SizedBox(height: Insets.md),
                         DropdownButtonFormField<int>(
-                          initialValue: cutoffOptions.any((q) => q['id'] == cutoffId) ? cutoffId : null,
+                          initialValue:
+                              cutoffOptions.any((q) => q['id'] == cutoffId)
+                                  ? cutoffId
+                                  : null,
                           decoration: const InputDecoration(
                             labelText: 'Upgrade Cutoff',
                             border: OutlineInputBorder(),
@@ -216,7 +228,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                         : allowedIds.first;
 
                     try {
-                      final api = await ref.read(radarrApiProvider(instance).future);
+                      final api =
+                          await ref.read(radarrApiProvider(instance).future);
                       final payload = isEdit
                           ? Map<String, dynamic>.from(profile)
                           : Map<String, dynamic>.from(schema!);
@@ -227,7 +240,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                       payload['items'] = editableItems;
 
                       if (isEdit) {
-                        await api.updateQualityProfile(payload, payload['id'] as int);
+                        await api.updateQualityProfile(
+                            payload, payload['id'] as int);
                       } else {
                         // Remove id for creation
                         payload.remove('id');
@@ -286,7 +300,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(name,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   subtitle: Text(upgrade ? 'Upgrades Allowed' : 'No Upgrades'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
@@ -296,18 +311,23 @@ class _QualityProfilesTab extends ConsumerWidget {
                         onPressed: () => _showProfileDialog(context, ref, p),
                       ),
                       IconButton(
-                        icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+                        icon: Icon(Icons.delete_outline,
+                            color: theme.colorScheme.error),
                         onPressed: () async {
-                          final ok = await confirmDelete(context, 'Quality Profile "$name"');
+                          final ok = await confirmDelete(
+                              context, 'Quality Profile "$name"');
                           if (ok) {
                             try {
-                              final api = await ref.read(radarrApiProvider(instance).future);
+                              final api = await ref
+                                  .read(radarrApiProvider(instance).future);
                               await api.deleteQualityProfile(p['id'] as int);
-                              ref.invalidate(radarrQualityProfilesProvider(instance));
+                              ref.invalidate(
+                                  radarrQualityProfilesProvider(instance));
                             } catch (e) {
                               if (context.mounted) {
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(content: Text('Failed to delete: $e')),
+                                  SnackBar(
+                                      content: Text('Failed to delete: $e')),
                                 );
                               }
                             }
@@ -356,8 +376,10 @@ class _DelayProfilesTab extends ConsumerWidget {
               margin: const EdgeInsets.only(bottom: 12),
               color: theme.colorScheme.surfaceContainerLow,
               child: ListTile(
-                title: Text('Delay Profile (Usenet: ${usenet}m, Torrent: ${torrent}m)'),
-                subtitle: Text('Protocol preference: ${p['preferredProtocol'] ?? 'None'}'),
+                title: Text(
+                    'Delay Profile (Usenet: ${usenet}m, Torrent: ${torrent}m)'),
+                subtitle: Text(
+                    'Protocol preference: ${p['preferredProtocol'] ?? 'None'}'),
               ),
             );
           },
@@ -396,7 +418,8 @@ class _CustomFormatsTab extends ConsumerWidget {
               margin: const EdgeInsets.only(bottom: 12),
               color: theme.colorScheme.surfaceContainerLow,
               child: ListTile(
-                title: Text(name, style: const TextStyle(fontWeight: FontWeight.bold)),
+                title: Text(name,
+                    style: const TextStyle(fontWeight: FontWeight.bold)),
                 subtitle: Text(f['description'] as String? ?? ''),
               ),
             );

--- a/services/service_radarr/lib/src/home/settings/quality_definitions_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/quality_definitions_screen.dart
@@ -19,7 +19,8 @@ class QualityDefinitionsScreen extends ConsumerStatefulWidget {
       _QualityDefinitionsScreenState();
 }
 
-class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScreen> {
+class _QualityDefinitionsScreenState
+    extends ConsumerState<QualityDefinitionsScreen> {
   bool _initialized = false;
   bool _saving = false;
   late List<Map<String, dynamic>> _definitions;
@@ -38,7 +39,8 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
       ref.invalidate(radarrQualityDefinitionsProvider(widget.instance));
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Quality definitions updated successfully!')),
+          const SnackBar(
+              content: Text('Quality definitions updated successfully!')),
         );
         Navigator.pop(context);
       }
@@ -56,7 +58,8 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final definitionsAsync = ref.watch(radarrQualityDefinitionsProvider(widget.instance));
+    final definitionsAsync =
+        ref.watch(radarrQualityDefinitionsProvider(widget.instance));
 
     return Scaffold(
       appBar: AppBar(
@@ -91,10 +94,11 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
               final def = _definitions[index];
               final qualityMap = def['quality'] as Map<String, dynamic>?;
               final qName = (qualityMap?['name'] as String?) ?? 'Unknown';
-              
+
               final double minVal = (def['minSize'] as num?)?.toDouble() ?? 0.0;
               final double? maxVal = (def['maxSize'] as num?)?.toDouble();
-              final double prefVal = (def['preferredSize'] as num?)?.toDouble() ?? minVal;
+              final double prefVal =
+                  (def['preferredSize'] as num?)?.toDouble() ?? minVal;
 
               final bool isUnlimited = maxVal == null || maxVal == 0;
 
@@ -124,7 +128,6 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
                         ),
                       ),
                       const SizedBox(height: Insets.md),
-
                       Text(
                         'Min Size: ${minVal.toStringAsFixed(1)} GB',
                         style: theme.textTheme.bodySmall,
@@ -142,7 +145,6 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
                           });
                         },
                       ),
-
                       Text(
                         'Preferred Size: ${prefVal.toStringAsFixed(1)} GB',
                         style: theme.textTheme.bodySmall,
@@ -158,7 +160,6 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
                           });
                         },
                       ),
-
                       Row(
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [

--- a/services/service_radarr/lib/src/home/settings/tags_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/tags_settings_screen.dart
@@ -53,7 +53,8 @@ class TagsSettingsScreen extends ConsumerWidget {
     }
   }
 
-  Future<void> _deleteTag(BuildContext context, WidgetRef ref, int id, String label) async {
+  Future<void> _deleteTag(
+      BuildContext context, WidgetRef ref, int id, String label) async {
     final ok = await confirmDelete(context, 'Tag "$label"');
     if (ok) {
       try {
@@ -88,7 +89,8 @@ class TagsSettingsScreen extends ConsumerWidget {
         error: (err, _) => Center(child: Text('Error: $err')),
         data: (tags) {
           if (tags.isEmpty) {
-            return const Center(child: Text('No tags defined. Tap + to add one.'));
+            return const Center(
+                child: Text('No tags defined. Tap + to add one.'));
           }
 
           return ListView.builder(
@@ -103,9 +105,11 @@ class TagsSettingsScreen extends ConsumerWidget {
                 margin: const EdgeInsets.only(bottom: 12),
                 color: theme.colorScheme.surfaceContainerLow,
                 child: ListTile(
-                  title: Text(label, style: const TextStyle(fontWeight: FontWeight.bold)),
+                  title: Text(label,
+                      style: const TextStyle(fontWeight: FontWeight.bold)),
                   trailing: IconButton(
-                    icon: Icon(Icons.delete_outline, color: theme.colorScheme.error),
+                    icon: Icon(Icons.delete_outline,
+                        color: theme.colorScheme.error),
                     onPressed: () => _deleteTag(context, ref, id, label),
                   ),
                 ),

--- a/services/service_radarr/lib/src/home/settings/ui_settings_screen.dart
+++ b/services/service_radarr/lib/src/home/settings/ui_settings_screen.dart
@@ -23,7 +23,7 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
   int _firstDayOfWeek = 0;
   bool _showRelativeDates = true;
   bool _enableColorImpairedMode = false;
-  
+
   late final TextEditingController _shortDateFormatController;
   late final TextEditingController _longDateFormatController;
   late final TextEditingController _timeFormatController;
@@ -55,10 +55,13 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
 
     _firstDayOfWeek = config['firstDayOfWeek'] as int? ?? 0;
     _showRelativeDates = config['showRelativeDates'] as bool? ?? true;
-    _enableColorImpairedMode = config['enableColorImpairedMode'] as bool? ?? false;
+    _enableColorImpairedMode =
+        config['enableColorImpairedMode'] as bool? ?? false;
 
-    _shortDateFormatController.text = (config['shortDateFormat'] as String?) ?? 'MMM dd yyyy';
-    _longDateFormatController.text = (config['longDateFormat'] as String?) ?? 'dddd, MMMM dd yyyy';
+    _shortDateFormatController.text =
+        (config['shortDateFormat'] as String?) ?? 'MMM dd yyyy';
+    _longDateFormatController.text =
+        (config['longDateFormat'] as String?) ?? 'dddd, MMMM dd yyyy';
     _timeFormatController.text = (config['timeFormat'] as String?) ?? 'h:mmtt';
   }
 
@@ -228,7 +231,8 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                           contentPadding: EdgeInsets.zero,
                           title: const Text('Show Relative Dates'),
                           value: _showRelativeDates,
-                          onChanged: (val) => setState(() => _showRelativeDates = val),
+                          onChanged: (val) =>
+                              setState(() => _showRelativeDates = val),
                         ),
                       ],
                     ),

--- a/services/service_radarr/lib/src/home/settings/widgets/dynamic_schema_form.dart
+++ b/services/service_radarr/lib/src/home/settings/widgets/dynamic_schema_form.dart
@@ -37,8 +37,7 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       final value = field['value'];
 
       if (type == 'checkbox' || type == 'select') continue;
-      final text =
-          value is List ? value.join(',') : value?.toString() ?? '';
+      final text = value is List ? value.join(',') : value?.toString() ?? '';
       _controllers[name] = TextEditingController(text: text);
       _initialTexts[name] = text;
     }
@@ -124,7 +123,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final hasAdvanced = _localFields.any((f) => f['advanced'] as bool? ?? false);
+    final hasAdvanced =
+        _localFields.any((f) => f['advanced'] as bool? ?? false);
 
     final visibleFields = _localFields.where((f) {
       final hiddenMode = f['hidden'];
@@ -186,7 +186,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
               ),
               child: Row(
                 children: [
-                  Icon(Icons.check_circle_outline, color: theme.colorScheme.onPrimaryContainer),
+                  Icon(Icons.check_circle_outline,
+                      color: theme.colorScheme.onPrimaryContainer),
                   const SizedBox(width: Insets.sm),
                   Text(
                     'Connection Test Successful!',
@@ -266,9 +267,9 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       final selectOptions = ((field['selectOptions'] as List<dynamic>?) ?? [])
           .cast<Map<String, dynamic>>();
       final value = field['value'];
-      
+
       final isMulti = selectOptions.isNotEmpty && value is List;
-      
+
       if (isMulti) {
         final List<dynamic> listValue = List<dynamic>.from(value);
         return Padding(
@@ -278,13 +279,15 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
             children: [
               Text(
                 label,
-                style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(fontWeight: FontWeight.bold),
               ),
               if (helpText != null) ...[
                 const SizedBox(height: 2),
                 Text(
                   helpText,
-                  style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
                 ),
               ],
               const SizedBox(height: Insets.sm),
@@ -319,8 +322,10 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
 
       dynamic matchedValue;
       final valStr = (value as Object?)?.toString();
-      if (selectOptions.any((opt) => (opt['value'] as Object).toString() == valStr)) {
-        matchedValue = selectOptions.firstWhere((opt) => (opt['value'] as Object).toString() == valStr)['value'];
+      if (selectOptions
+          .any((opt) => (opt['value'] as Object).toString() == valStr)) {
+        matchedValue = selectOptions.firstWhere(
+            (opt) => (opt['value'] as Object).toString() == valStr)['value'];
       } else if (selectOptions.isNotEmpty) {
         matchedValue = selectOptions.first['value'];
       }
@@ -336,8 +341,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
             border: const OutlineInputBorder(),
           ),
           items: selectOptions.map((opt) {
-            final optName = (opt['name'] as String?) ??
-                (opt['value'] as Object).toString();
+            final optName =
+                (opt['name'] as String?) ?? (opt['value'] as Object).toString();
             return DropdownMenuItem<dynamic>(
               value: opt['value'],
               child: Text(optName),
@@ -358,7 +363,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       child: TextFormField(
         controller: _controllers[name],
         obscureText: isPassword,
-        keyboardType: type == 'number' ? TextInputType.number : TextInputType.text,
+        keyboardType:
+            type == 'number' ? TextInputType.number : TextInputType.text,
         decoration: InputDecoration(
           labelText: label,
           helperText: helpText,

--- a/services/service_radarr/lib/src/home/settings_tab.dart
+++ b/services/service_radarr/lib/src/home/settings_tab.dart
@@ -41,83 +41,92 @@ class SettingsTab extends StatelessWidget {
           _buildSettingsCard(
             context: context,
             title: 'Media Management',
-            subtitle: 'Rename movies, configure empty folders, copy links & permission details.',
+            subtitle:
+                'Rename movies, configure empty folders, copy links & permission details.',
             icon: Icons.folder_open_outlined,
             screen: MediaManagementSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Profiles',
-            subtitle: 'Manage quality profiles, delay profiles, and custom formats.',
+            subtitle:
+                'Manage quality profiles, delay profiles, and custom formats.',
             icon: Icons.high_quality_outlined,
             screen: ProfilesSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Quality Definitions',
-            subtitle: 'Configure minimum, maximum, and preferred size limits per quality type.',
+            subtitle:
+                'Configure minimum, maximum, and preferred size limits per quality type.',
             icon: Icons.aspect_ratio_outlined,
             screen: QualityDefinitionsScreen(instance: instance),
           ),
           const SizedBox(height: Insets.md),
-
           _buildCategoryHeader(context, 'Network & Integration'),
           _buildSettingsCard(
             context: context,
             title: 'Indexers & Trackers',
-            subtitle: 'RSS feeds, automatic search, indexers list, and import lists configurations.',
+            subtitle:
+                'RSS feeds, automatic search, indexers list, and import lists configurations.',
             icon: Icons.rss_feed_outlined,
             screen: IndexersSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Download Clients',
-            subtitle: 'Clients list, connections, download tracking, and path override mappings.',
+            subtitle:
+                'Clients list, connections, download tracking, and path override mappings.',
             icon: Icons.download_for_offline_outlined,
             screen: DownloadClientsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Connect',
-            subtitle: 'Discord, Telegram, Email, Plex notifications and trigger events.',
+            subtitle:
+                'Discord, Telegram, Email, Plex notifications and trigger events.',
             icon: Icons.connect_without_contact,
             screen: ConnectSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Metadata Consumers',
-            subtitle: 'Configure metadata files creation for Kodi, Emby, Roksbox, and WDTV.',
+            subtitle:
+                'Configure metadata files creation for Kodi, Emby, Roksbox, and WDTV.',
             icon: Icons.settings_applications_outlined,
             screen: MetadataSettingsScreen(instance: instance),
           ),
           const SizedBox(height: Insets.md),
-
           _buildCategoryHeader(context, 'Application System'),
           _buildSettingsCard(
             context: context,
             title: 'General',
-            subtitle: 'Set server listening port, SSL certifications, API Keys, and logs.',
+            subtitle:
+                'Set server listening port, SSL certifications, API Keys, and logs.',
             icon: Icons.dns_outlined,
             screen: GeneralSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'UI Settings',
-            subtitle: 'Date formatting, first day of week selection, and color options.',
+            subtitle:
+                'Date formatting, first day of week selection, and color options.',
             icon: Icons.palette_outlined,
             screen: UiSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Tags',
-            subtitle: 'Manage label identifiers for categories, movies, and profiles.',
+            subtitle:
+                'Manage label identifiers for categories, movies, and profiles.',
             icon: Icons.label_outline,
             screen: TagsSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Connection Settings',
-            subtitle: 'Edit connection URL, API Key, and label for this Radarr instance in Atrium.',
+            subtitle:
+                'Edit connection URL, API Key, and label for this Radarr instance in Atrium.',
             icon: Icons.key_outlined,
             onTap: () {
               context.pushNamed(
@@ -129,17 +138,18 @@ class SettingsTab extends StatelessWidget {
             },
           ),
           const SizedBox(height: Insets.md),
-
           _buildCategoryHeader(context, 'Diagnostics & Troubleshooting'),
           _buildSettingsCard(
             context: context,
             title: 'Parse Title',
-            subtitle: 'Extract metadata and check matching movie database results for any release name.',
+            subtitle:
+                'Extract metadata and check matching movie database results for any release name.',
             icon: Icons.troubleshoot_outlined,
             onTap: () {
               showDialog<void>(
                 context: context,
-                builder: (context) => RadarrParseTitleDialog(instance: instance),
+                builder: (context) =>
+                    RadarrParseTitleDialog(instance: instance),
               ).ignore();
             },
           ),
@@ -182,11 +192,12 @@ class SettingsTab extends StatelessWidget {
       ),
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: onTap ?? () {
-          if (screen != null) {
-            pushScreen<void>(context, screen);
-          }
-        },
+        onTap: onTap ??
+            () {
+              if (screen != null) {
+                pushScreen<void>(context, screen);
+              }
+            },
         child: Padding(
           padding: const EdgeInsets.all(Insets.md),
           child: Row(

--- a/services/service_radarr/lib/src/home/system_tab.dart
+++ b/services/service_radarr/lib/src/home/system_tab.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../radarr_api.dart';
 import '../radarr_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class SystemTab extends ConsumerStatefulWidget {
   const SystemTab({required this.instance, super.key});
@@ -242,10 +243,8 @@ class _StatusTab extends ConsumerWidget {
               );
             },
           ),
-
           statusAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
             error: (Object err, _) => _sectionError('Status', err),
             data: (Map<String, dynamic> s) {
               final String version = s['version'] as String? ?? 'Unknown';
@@ -253,7 +252,8 @@ class _StatusTab extends ConsumerWidget {
               final String osName = s['osName'] as String? ?? 'Unknown';
               final String osVersion = s['osVersion'] as String? ?? '';
               final String runtimeName = s['runtimeName'] as String? ?? '';
-              final String runtimeVersion = s['runtimeVersion'] as String? ?? '';
+              final String runtimeVersion =
+                  s['runtimeVersion'] as String? ?? '';
               final bool isDocker = s['isDocker'] as bool? ?? false;
               final String packageAuthor = s['packageAuthor'] as String? ?? '';
               final String dbType = s['databaseType'] as String? ?? '';
@@ -272,8 +272,7 @@ class _StatusTab extends ConsumerWidget {
                   uptimeText =
                       '${uptime.inDays}d ${uptime.inHours % 24}h ${uptime.inMinutes % 60}m';
                 } else if (uptime.inHours > 0) {
-                  uptimeText =
-                      '${uptime.inHours}h ${uptime.inMinutes % 60}m';
+                  uptimeText = '${uptime.inHours}h ${uptime.inMinutes % 60}m';
                 } else {
                   uptimeText = '${uptime.inMinutes}m';
                 }
@@ -354,7 +353,6 @@ class _StatusTab extends ConsumerWidget {
               );
             },
           ),
-
           diskAsync.when(
             loading: () => const SizedBox.shrink(),
             error: (Object err, _) => _sectionError('Disk Space', err),
@@ -365,8 +363,7 @@ class _StatusTab extends ConsumerWidget {
                 children: <Widget>[
                   _sectionHeader(theme, 'Disk Space'),
                   ...disks.map(
-                    (Map<String, dynamic> d) =>
-                        _DiskSpaceCard(disk: d),
+                    (Map<String, dynamic> d) => _DiskSpaceCard(disk: d),
                   ),
                 ],
               );
@@ -526,8 +523,7 @@ class _DiskSpaceCard extends StatelessWidget {
     final int freeSpace = disk['freeSpace'] as int? ?? 0;
     final int totalSpace = disk['totalSpace'] as int? ?? 1;
     final int usedSpace = totalSpace - freeSpace;
-    final double usedPercent =
-        totalSpace > 0 ? usedSpace / totalSpace : 0.0;
+    final double usedPercent = totalSpace > 0 ? usedSpace / totalSpace : 0.0;
 
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -571,17 +567,13 @@ class _DiskSpaceCard extends StatelessWidget {
             const SizedBox(height: Insets.sm),
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
-                value: usedPercent,
-                minHeight: 8,
-                backgroundColor:
-                    theme.colorScheme.surfaceContainerHighest,
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  usedPercent > 0.9
+              child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
+                  value: usedPercent,
+                  trackColor: theme.colorScheme.surfaceContainerHighest,
+                  activeColor: usedPercent > 0.9
                       ? theme.colorScheme.error
-                      : theme.colorScheme.primary,
-                ),
-              ),
+                      : theme.colorScheme.primary),
             ),
             const SizedBox(height: Insets.xs),
             Text(
@@ -619,8 +611,7 @@ class _TasksTab extends ConsumerWidget {
     String taskName,
   ) async {
     try {
-      final RadarrApi api =
-          await ref.read(radarrApiProvider(instance).future);
+      final RadarrApi api = await ref.read(radarrApiProvider(instance).future);
       await api.runCommand(<String, dynamic>{'name': taskName});
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -649,10 +640,8 @@ class _TasksTab extends ConsumerWidget {
         await ref.read(radarrTasksProvider(instance).future);
       },
       child: tasksAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> tasks) {
           if (tasks.isEmpty) {
             return const Center(child: Text('No scheduled tasks.'));
@@ -663,24 +652,16 @@ class _TasksTab extends ConsumerWidget {
             itemCount: tasks.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> task = tasks[index];
-              final String name =
-                  task['name'] as String? ?? 'Task';
-              final String taskName =
-                  task['taskName'] as String? ?? '';
-              final int interval =
-                  task['interval'] as int? ?? 0;
-              final String lastExecStr =
-                  task['lastExecution'] as String? ?? '';
-              final String nextExecStr =
-                  task['nextExecution'] as String? ?? '';
-              final String lastDuration =
-                  task['lastDuration'] as String? ?? '';
+              final String name = task['name'] as String? ?? 'Task';
+              final String taskName = task['taskName'] as String? ?? '';
+              final int interval = task['interval'] as int? ?? 0;
+              final String lastExecStr = task['lastExecution'] as String? ?? '';
+              final String nextExecStr = task['nextExecution'] as String? ?? '';
+              final String lastDuration = task['lastDuration'] as String? ?? '';
 
               final String intervalText = _formatInterval(interval);
-              final String lastExecText =
-                  _formatRelativeTime(lastExecStr);
-              final String nextExecText =
-                  _formatRelativeTime(nextExecStr);
+              final String lastExecText = _formatRelativeTime(lastExecStr);
+              final String nextExecText = _formatRelativeTime(nextExecStr);
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -723,8 +704,7 @@ class _TasksTab extends ConsumerWidget {
                   trailing: IconButton(
                     icon: const Icon(Icons.play_arrow_outlined),
                     tooltip: 'Run now',
-                    onPressed: () =>
-                        _runTask(context, ref, taskName),
+                    onPressed: () => _runTask(context, ref, taskName),
                   ),
                 ),
               );
@@ -796,10 +776,8 @@ class _UpdatesTab extends ConsumerWidget {
         await ref.read(radarrUpdatesProvider(instance).future);
       },
       child: updatesAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> updates) {
           if (updates.isEmpty) {
             return const Center(
@@ -833,21 +811,18 @@ class _UpdateCard extends StatelessWidget {
     final String branch = update['branch'] as String? ?? '';
     final bool installed = update['installed'] as bool? ?? false;
     final bool latest = update['latest'] as bool? ?? false;
-    final String releaseDateStr =
-        update['releaseDate'] as String? ?? '';
+    final String releaseDateStr = update['releaseDate'] as String? ?? '';
     final Map<String, dynamic>? changes =
         update['changes'] as Map<String, dynamic>?;
 
-    final List<String> newItems =
-        (changes?['new'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
-    final List<String> fixedItems =
-        (changes?['fixed'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
+    final List<String> newItems = (changes?['new'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
+    final List<String> fixedItems = (changes?['fixed'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
 
     String releaseDateText = '';
     if (releaseDateStr.isNotEmpty) {
@@ -861,9 +836,8 @@ class _UpdateCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.md),
       elevation: 0,
-      color: installed
-          ? theme.colorScheme.primaryContainer.withAlpha(50)
-          : null,
+      color:
+          installed ? theme.colorScheme.primaryContainer.withAlpha(50) : null,
       shape: RoundedRectangleBorder(
         side: BorderSide(
           color: installed
@@ -895,23 +869,19 @@ class _UpdateCard extends StatelessWidget {
                       color: theme.colorScheme.onPrimaryContainer,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
                 if (latest && !installed)
                   Chip(
                     label: const Text('Latest'),
-                    backgroundColor:
-                        theme.colorScheme.tertiary.withAlpha(30),
-                    labelStyle:
-                        theme.textTheme.labelSmall?.copyWith(
+                    backgroundColor: theme.colorScheme.tertiary.withAlpha(30),
+                    labelStyle: theme.textTheme.labelSmall?.copyWith(
                       color: theme.colorScheme.tertiary,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
@@ -1029,12 +999,14 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final logsAsync = ref.watch(
-      radarrLogsProvider((
-        widget.instance,
-        page: _currentPage,
-        pageSize: _pageSize,
-        level: _levelFilter,
-      ),),
+      radarrLogsProvider(
+        (
+          widget.instance,
+          page: _currentPage,
+          pageSize: _pageSize,
+          level: _levelFilter,
+        ),
+      ),
     );
 
     return Column(
@@ -1085,18 +1057,14 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
             ],
           ),
         ),
-
         Expanded(
           child: logsAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
-            error: (Object err, _) =>
-                Center(child: Text('Error: $err')),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
+            error: (Object err, _) => Center(child: Text('Error: $err')),
             data: (Map<String, dynamic> data) {
               final List<dynamic> records =
                   data['records'] as List<dynamic>? ?? <dynamic>[];
-              final int totalRecords =
-                  data['totalRecords'] as int? ?? 0;
+              final int totalRecords = data['totalRecords'] as int? ?? 0;
               final int totalPages =
                   (totalRecords / _pageSize).ceil().clamp(1, 9999);
 
@@ -1109,19 +1077,22 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                   Expanded(
                     child: M3RefreshIndicator(
                       onRefresh: () async {
-                        ref.invalidate(radarrLogsProvider((
-                          widget.instance,
-                          page: _currentPage,
-                          pageSize: _pageSize,
-                          level: _levelFilter,
-                        ),),);
+                        ref.invalidate(
+                          radarrLogsProvider(
+                            (
+                              widget.instance,
+                              page: _currentPage,
+                              pageSize: _pageSize,
+                              level: _levelFilter,
+                            ),
+                          ),
+                        );
                       },
                       child: ListView.builder(
                         padding:
                             const EdgeInsets.symmetric(horizontal: Insets.md),
                         itemCount: records.length,
-                        itemBuilder:
-                            (BuildContext context, int index) {
+                        itemBuilder: (BuildContext context, int index) {
                           final Map<String, dynamic> log =
                               records[index] as Map<String, dynamic>;
                           return _LogEntryTile(log: log);
@@ -1129,7 +1100,6 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                       ),
                     ),
                   ),
-
                   Padding(
                     padding: const EdgeInsets.all(Insets.sm),
                     child: Row(
@@ -1138,8 +1108,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_left),
                           onPressed: _currentPage > 1
-                              ? () =>
-                                  setState(() => _currentPage--)
+                              ? () => setState(() => _currentPage--)
                               : null,
                         ),
                         Text(
@@ -1149,8 +1118,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_right),
                           onPressed: _currentPage < totalPages
-                              ? () =>
-                                  setState(() => _currentPage++)
+                              ? () => setState(() => _currentPage++)
                               : null,
                         ),
                       ],
@@ -1282,8 +1250,7 @@ class _LogEntryTile extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 4),
                         child: Text(
                           exception,
-                          style:
-                              theme.textTheme.bodySmall?.copyWith(
+                          style: theme.textTheme.bodySmall?.copyWith(
                             color: theme.colorScheme.error,
                             fontFamily: 'monospace',
                             fontSize: 11,
@@ -1371,10 +1338,8 @@ class _BackupsTab extends ConsumerWidget {
         await ref.read(radarrBackupsProvider(instance).future);
       },
       child: backupsAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> backups) {
           if (backups.isEmpty) {
             return const Center(child: Text('No backups found.'));
@@ -1385,14 +1350,11 @@ class _BackupsTab extends ConsumerWidget {
             itemCount: backups.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> backup = backups[index];
-              final String name =
-                  backup['name'] as String? ?? 'Backup';
-              final String type =
-                  backup['type'] as String? ?? 'unknown';
+              final String name = backup['name'] as String? ?? 'Backup';
+              final String type = backup['type'] as String? ?? 'unknown';
               final int size = backup['size'] as int? ?? 0;
               final int id = backup['id'] as int? ?? 0;
-              final String timeStr =
-                  backup['time'] as String? ?? '';
+              final String timeStr = backup['time'] as String? ?? '';
 
               String dateText = '';
               if (timeStr.isNotEmpty) {
@@ -1427,8 +1389,7 @@ class _BackupsTab extends ConsumerWidget {
                 ),
                 child: ListTile(
                   leading: CircleAvatar(
-                    backgroundColor:
-                        theme.colorScheme.surfaceContainerHighest,
+                    backgroundColor: theme.colorScheme.surfaceContainerHighest,
                     child: Icon(
                       typeIcon,
                       color: theme.colorScheme.onSurfaceVariant,
@@ -1453,8 +1414,7 @@ class _BackupsTab extends ConsumerWidget {
                       Icons.delete_outline,
                       color: theme.colorScheme.error,
                     ),
-                    onPressed: () =>
-                        _deleteBackup(context, ref, id, name),
+                    onPressed: () => _deleteBackup(context, ref, id, name),
                   ),
                 ),
               );

--- a/services/service_radarr/lib/src/home/wanted_tab.dart
+++ b/services/service_radarr/lib/src/home/wanted_tab.dart
@@ -93,7 +93,9 @@ class _WantedTabState extends ConsumerState<WantedTab>
       });
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Search started for ${ids.length} selected movies.')),
+          SnackBar(
+              content:
+                  Text('Search started for ${ids.length} selected movies.')),
         );
       }
     } catch (e) {
@@ -145,7 +147,8 @@ class _WantedTabState extends ConsumerState<WantedTab>
     final Set<int> selectedMovieIds =
         ref.watch(radarrWantedSelectionProvider(widget.instance));
     final bool hasSelection = selectedMovieIds.isNotEmpty;
-    final bool isGrouped = ref.watch(radarrWantedGroupedProvider(widget.instance));
+    final bool isGrouped =
+        ref.watch(radarrWantedGroupedProvider(widget.instance));
 
     ref.listen<String>(radarrWantedSearchQueryProvider(widget.instance),
         (String? previous, String next) {
@@ -163,7 +166,8 @@ class _WantedTabState extends ConsumerState<WantedTab>
       child: Scaffold(
         backgroundColor: theme.colorScheme.surface,
         body: NestedScrollView(
-          headerSliverBuilder: (BuildContext innerContext, bool innerBoxIsScrolled) {
+          headerSliverBuilder:
+              (BuildContext innerContext, bool innerBoxIsScrolled) {
             return <Widget>[
               SliverAppBar(
                 floating: true,
@@ -256,12 +260,18 @@ class _WantedTabState extends ConsumerState<WantedTab>
                     : <Widget>[
                         IconButton(
                           icon: Icon(
-                            isGrouped ? Icons.format_list_bulleted : Icons.group_work_outlined,
+                            isGrouped
+                                ? Icons.format_list_bulleted
+                                : Icons.group_work_outlined,
                           ),
-                          tooltip: isGrouped ? 'Switch to plain list' : 'Switch to grouped view',
+                          tooltip: isGrouped
+                              ? 'Switch to plain list'
+                              : 'Switch to grouped view',
                           onPressed: () {
                             ref
-                                .read(radarrWantedGroupedProvider(widget.instance).notifier)
+                                .read(
+                                    radarrWantedGroupedProvider(widget.instance)
+                                        .notifier)
                                 .update((state) => !state);
                           },
                         ),
@@ -535,9 +545,11 @@ class _WantedMovieCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(16),
         onTap: () {
           if (hasSelection) {
-            final notifier = ref.read(radarrWantedSelectionProvider(instance).notifier);
+            final notifier =
+                ref.read(radarrWantedSelectionProvider(instance).notifier);
             if (isSelected) {
-              notifier.state = selectedIds(ref).where((id) => id != movie.id).toSet();
+              notifier.state =
+                  selectedIds(ref).where((id) => id != movie.id).toSet();
             } else {
               notifier.state = {...selectedIds(ref), movie.id};
             }
@@ -552,9 +564,11 @@ class _WantedMovieCard extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          final notifier = ref.read(radarrWantedSelectionProvider(instance).notifier);
+          final notifier =
+              ref.read(radarrWantedSelectionProvider(instance).notifier);
           if (isSelected) {
-            notifier.state = selectedIds(ref).where((id) => id != movie.id).toSet();
+            notifier.state =
+                selectedIds(ref).where((id) => id != movie.id).toSet();
           } else {
             notifier.state = {...selectedIds(ref), movie.id};
           }
@@ -733,7 +747,8 @@ class _GroupedWantedCardState extends ConsumerState<_GroupedWantedCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(10),

--- a/services/service_radarr/lib/src/movie_detail_screen.dart
+++ b/services/service_radarr/lib/src/movie_detail_screen.dart
@@ -37,7 +37,8 @@ class MovieDetailScreen extends ConsumerWidget {
           body: ErrorView(
             title: 'Failed to load movie details',
             message: error.toString(),
-            onRetry: () => ref.invalidate(radarrMovieByIdProvider((instance, movieId))),
+            onRetry: () =>
+                ref.invalidate(radarrMovieByIdProvider((instance, movieId))),
           ),
         ),
       ),
@@ -117,7 +118,8 @@ class _MovieDetailBodyState extends ConsumerState<_MovieDetailBody> {
                   color: Colors.black.withValues(alpha: 0.35),
                 ),
                 child: IconButton(
-                  icon: const Icon(Icons.arrow_back, size: 20, color: Colors.white),
+                  icon: const Icon(Icons.arrow_back,
+                      size: 20, color: Colors.white),
                   onPressed: () => Navigator.maybePop(context),
                   padding: EdgeInsets.zero,
                 ),
@@ -426,12 +428,8 @@ class _StatusPill extends StatelessWidget {
     final ColorScheme cs = theme.colorScheme;
 
     final bool hasFile = movie.hasFile;
-    final Color background = hasFile
-        ? cs.primaryContainer
-        : cs.errorContainer;
-    final Color tint = hasFile
-        ? cs.onPrimaryContainer
-        : cs.onErrorContainer;
+    final Color background = hasFile ? cs.primaryContainer : cs.errorContainer;
+    final Color tint = hasFile ? cs.onPrimaryContainer : cs.onErrorContainer;
     final String label = hasFile ? 'Downloaded' : 'Missing';
     final IconData icon = hasFile ? Icons.check : Icons.warning_amber_rounded;
 
@@ -526,7 +524,9 @@ class _FileSection extends StatelessWidget {
               context,
               'Status',
               movie.hasFile ? 'File downloaded' : 'File missing',
-              icon: movie.hasFile ? Icons.check_circle_outline : Icons.error_outline,
+              icon: movie.hasFile
+                  ? Icons.check_circle_outline
+                  : Icons.error_outline,
               iconColor: movie.hasFile ? cs.primary : cs.error,
             ),
             if (movie.hasFile && movie.sizeOnDisk > 0) ...[
@@ -610,14 +610,17 @@ class _ReleaseDatesSection extends StatelessWidget {
     }
     DateTime? physicalReleaseDate;
     if (movie.physicalRelease != null && movie.physicalRelease!.isNotEmpty) {
-      physicalReleaseDate = DateTime.tryParse(movie.physicalRelease!)?.toLocal();
+      physicalReleaseDate =
+          DateTime.tryParse(movie.physicalRelease!)?.toLocal();
     }
     DateTime? digitalReleaseDate;
     if (movie.digitalRelease != null && movie.digitalRelease!.isNotEmpty) {
       digitalReleaseDate = DateTime.tryParse(movie.digitalRelease!)?.toLocal();
     }
 
-    if (inCinemasDate == null && physicalReleaseDate == null && digitalReleaseDate == null) {
+    if (inCinemasDate == null &&
+        physicalReleaseDate == null &&
+        digitalReleaseDate == null) {
       return const SizedBox.shrink();
     }
 
@@ -639,14 +642,21 @@ class _ReleaseDatesSection extends StatelessWidget {
             ),
             const SizedBox(height: Insets.md),
             if (inCinemasDate != null)
-              _buildReleaseRow(context, 'In Cinemas', formatter.format(inCinemasDate), Icons.local_play_outlined),
+              _buildReleaseRow(context, 'In Cinemas',
+                  formatter.format(inCinemasDate), Icons.local_play_outlined),
             if (digitalReleaseDate != null) ...[
               if (inCinemasDate != null) const Divider(height: 24),
-              _buildReleaseRow(context, 'Digital Release', formatter.format(digitalReleaseDate), Icons.language_outlined),
+              _buildReleaseRow(
+                  context,
+                  'Digital Release',
+                  formatter.format(digitalReleaseDate),
+                  Icons.language_outlined),
             ],
             if (physicalReleaseDate != null) ...[
-              if (inCinemasDate != null || digitalReleaseDate != null) const Divider(height: 24),
-              _buildReleaseRow(context, 'Physical Release', formatter.format(physicalReleaseDate), Icons.album_outlined),
+              if (inCinemasDate != null || digitalReleaseDate != null)
+                const Divider(height: 24),
+              _buildReleaseRow(context, 'Physical Release',
+                  formatter.format(physicalReleaseDate), Icons.album_outlined),
             ],
           ],
         ),
@@ -654,7 +664,8 @@ class _ReleaseDatesSection extends StatelessWidget {
     );
   }
 
-  Widget _buildReleaseRow(BuildContext context, String label, String value, IconData icon) {
+  Widget _buildReleaseRow(
+      BuildContext context, String label, String value, IconData icon) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
 
@@ -707,8 +718,8 @@ class _ActionsRow extends ConsumerWidget {
           child: movie.monitored
               ? FilledButton.tonalIcon(
                   style: FilledButton.styleFrom(
-                    backgroundColor:
-                        theme.colorScheme.primaryContainer.withValues(alpha: 0.8),
+                    backgroundColor: theme.colorScheme.primaryContainer
+                        .withValues(alpha: 0.8),
                     foregroundColor: theme.colorScheme.onPrimaryContainer,
                     padding: const EdgeInsets.symmetric(vertical: 12),
                     shape: RoundedRectangleBorder(

--- a/services/service_radarr/lib/src/radarr_api.dart
+++ b/services/service_radarr/lib/src/radarr_api.dart
@@ -109,7 +109,8 @@ class RadarrApi {
     }
   }
 
-  Future<void> bulkDeleteMovies(List<int> ids, {bool deleteFiles = false}) async {
+  Future<void> bulkDeleteMovies(List<int> ids,
+      {bool deleteFiles = false}) async {
     try {
       await _dio.delete<dynamic>(
         '$_base/movie/editor',
@@ -203,7 +204,8 @@ class RadarrApi {
       if (records is List<dynamic>) {
         return records
             .map(
-              (dynamic e) => RadarrQueueItem.fromJson(e as Map<String, dynamic>),
+              (dynamic e) =>
+                  RadarrQueueItem.fromJson(e as Map<String, dynamic>),
             )
             .toList();
       }
@@ -588,7 +590,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createQualityProfile(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/qualityprofile',
@@ -716,7 +719,8 @@ class RadarrApi {
   // connection test (offline client, unreachable indexer) does not 400 the
   // save.
   Future<Map<String, dynamic>> createIndexer(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/indexer',
@@ -803,7 +807,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createDownloadClient(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/downloadclient',
@@ -817,7 +822,9 @@ class RadarrApi {
   }
 
   Future<void> updateDownloadClient(
-      Map<String, dynamic> payload, int id,) async {
+    Map<String, dynamic> payload,
+    int id,
+  ) async {
     try {
       await _dio.put<dynamic>(
         '$_base/downloadclient/$id',
@@ -891,7 +898,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createNotification(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/notification',
@@ -934,8 +942,7 @@ class RadarrApi {
 
   Future<List<Map<String, dynamic>>> getMetadataConfigs() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('$_base/metadata');
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/metadata');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();
@@ -956,7 +963,8 @@ class RadarrApi {
     }
   }
 
-  Future<void> updateMetadataConfig(Map<String, dynamic> payload, int id) async {
+  Future<void> updateMetadataConfig(
+      Map<String, dynamic> payload, int id) async {
     try {
       await _dio.put<dynamic>(
         '$_base/metadata/$id',
@@ -993,7 +1001,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createCustomFormat(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/customformat',
@@ -1037,7 +1046,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createDelayProfile(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/delayprofile',
@@ -1114,7 +1124,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createImportList(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/importlist',
@@ -1252,7 +1263,8 @@ class RadarrApi {
   }
 
   Future<Map<String, dynamic>> createRemotePathMapping(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/remotepathmapping',
@@ -1265,7 +1277,9 @@ class RadarrApi {
   }
 
   Future<void> updateRemotePathMapping(
-      Map<String, dynamic> payload, int id,) async {
+    Map<String, dynamic> payload,
+    int id,
+  ) async {
     try {
       await _dio.put<dynamic>(
         '$_base/remotepathmapping/$id',
@@ -1334,7 +1348,8 @@ class RadarrApi {
 
   Future<List<Map<String, dynamic>>> getDiskSpace() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/diskspace');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/diskspace');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();
@@ -1392,8 +1407,7 @@ class RadarrApi {
 
   Future<List<Map<String, dynamic>>> getLogFiles() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('$_base/log/file');
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/log/file');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();

--- a/services/service_radarr/lib/src/radarr_home.dart
+++ b/services/service_radarr/lib/src/radarr_home.dart
@@ -88,18 +88,21 @@ class RadarrHome extends ConsumerWidget {
     ];
 
     return Scaffold(
-      drawerEdgeDragWidth: drawer != null ? MediaQuery.sizeOf(context).width * 0.15 : null,
+      drawerEdgeDragWidth:
+          drawer != null ? MediaQuery.sizeOf(context).width * 0.15 : null,
       drawer: drawer,
       body: NotificationListener<UserScrollNotification>(
         onNotification: (UserScrollNotification notification) {
           if (notification.metrics.axis == Axis.vertical) {
             final ScrollDirection direction = notification.direction;
             if (direction == ScrollDirection.reverse) {
-              ref.read(radarrBottomNavVisibleProvider(instance).notifier).state =
-                  false;
+              ref
+                  .read(radarrBottomNavVisibleProvider(instance).notifier)
+                  .state = false;
             } else if (direction == ScrollDirection.forward) {
-              ref.read(radarrBottomNavVisibleProvider(instance).notifier).state =
-                  true;
+              ref
+                  .read(radarrBottomNavVisibleProvider(instance).notifier)
+                  .state = true;
             }
           }
           return false;

--- a/services/service_radarr/lib/src/radarr_providers.dart
+++ b/services/service_radarr/lib/src/radarr_providers.dart
@@ -345,7 +345,8 @@ final radarrCalendarProvider =
 
   // Calculate local month boundaries
   final DateTime start = DateTime(month.year, month.month);
-  final DateTime end = DateTime(month.year, month.month + 1).subtract(const Duration(seconds: 1));
+  final DateTime end = DateTime(month.year, month.month + 1)
+      .subtract(const Duration(seconds: 1));
 
   return api.getCalendar(start: start, end: end);
 });
@@ -367,7 +368,8 @@ final radarrWantedFilteredMissingProvider = Provider.autoDispose
     }
     final String lowercaseQuery = query.toLowerCase();
     return page.records
-        .where((RadarrMovie m) => m.title.toLowerCase().contains(lowercaseQuery))
+        .where(
+            (RadarrMovie m) => m.title.toLowerCase().contains(lowercaseQuery))
         .toList();
   });
 });
@@ -385,7 +387,8 @@ final radarrWantedFilteredCutoffProvider = Provider.autoDispose
     }
     final String lowercaseQuery = query.toLowerCase();
     return page.records
-        .where((RadarrMovie m) => m.title.toLowerCase().contains(lowercaseQuery))
+        .where(
+            (RadarrMovie m) => m.title.toLowerCase().contains(lowercaseQuery))
         .toList();
   });
 });
@@ -447,8 +450,8 @@ final radarrUiConfigProvider =
 });
 
 /// Quality definitions provider.
-final radarrQualityDefinitionsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrQualityDefinitionsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -457,8 +460,8 @@ final radarrQualityDefinitionsProvider = FutureProvider.autoDispose
 });
 
 /// Indexers configuration provider.
-final radarrIndexersProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrIndexersProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -467,8 +470,8 @@ final radarrIndexersProvider = FutureProvider.autoDispose
 });
 
 /// Download Clients configuration provider.
-final radarrDownloadClientsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrDownloadClientsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -487,8 +490,8 @@ final radarrDownloadClientConfigProvider =
 });
 
 /// Indexer schemas provider.
-final radarrIndexerSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrIndexerSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -497,8 +500,8 @@ final radarrIndexerSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Import lists provider.
-final radarrImportListsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrImportListsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -527,8 +530,8 @@ final radarrIndexerConfigProvider =
 });
 
 /// Import list schemas provider.
-final radarrImportListSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrImportListSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -537,8 +540,8 @@ final radarrImportListSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Download client schemas provider.
-final radarrDownloadClientSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrDownloadClientSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -547,8 +550,8 @@ final radarrDownloadClientSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Remote path mappings provider.
-final radarrRemotePathMappingsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrRemotePathMappingsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -557,8 +560,8 @@ final radarrRemotePathMappingsProvider = FutureProvider.autoDispose
 });
 
 /// Notifications provider.
-final radarrNotificationsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrNotificationsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -567,8 +570,8 @@ final radarrNotificationsProvider = FutureProvider.autoDispose
 });
 
 /// Notification schemas provider.
-final radarrNotificationSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrNotificationSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -577,8 +580,8 @@ final radarrNotificationSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Metadata configurations provider.
-final radarrMetadataConfigsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrMetadataConfigsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -587,8 +590,8 @@ final radarrMetadataConfigsProvider = FutureProvider.autoDispose
 });
 
 /// Metadata schemas provider.
-final radarrMetadataSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrMetadataSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -597,8 +600,8 @@ final radarrMetadataSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Delay profiles provider.
-final radarrDelayProfilesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrDelayProfilesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -607,8 +610,8 @@ final radarrDelayProfilesProvider = FutureProvider.autoDispose
 });
 
 /// Custom formats provider.
-final radarrCustomFormatsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrCustomFormatsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -617,8 +620,8 @@ final radarrCustomFormatsProvider = FutureProvider.autoDispose
 });
 
 /// Custom format schemas provider.
-final radarrCustomFormatSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrCustomFormatSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -631,8 +634,8 @@ final radarrCustomFormatSchemaProvider = FutureProvider.autoDispose
 // ==========================================
 
 /// System status (version, OS, uptime, etc.).
-final radarrSystemStatusProvider = FutureProvider.autoDispose
-    .family<Map<String, dynamic>, Instance>((
+final radarrSystemStatusProvider =
+    FutureProvider.autoDispose.family<Map<String, dynamic>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -641,8 +644,8 @@ final radarrSystemStatusProvider = FutureProvider.autoDispose
 });
 
 /// Health check warnings/errors.
-final radarrHealthProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrHealthProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -651,8 +654,8 @@ final radarrHealthProvider = FutureProvider.autoDispose
 });
 
 /// Disk space for all root paths.
-final radarrDiskSpaceProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrDiskSpaceProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -661,8 +664,8 @@ final radarrDiskSpaceProvider = FutureProvider.autoDispose
 });
 
 /// Scheduled tasks list.
-final radarrTasksProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrTasksProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -671,8 +674,8 @@ final radarrTasksProvider = FutureProvider.autoDispose
 });
 
 /// Available software updates.
-final radarrUpdatesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrUpdatesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -681,9 +684,8 @@ final radarrUpdatesProvider = FutureProvider.autoDispose
 });
 
 /// Paginated logs. Key is (instance, page, pageSize, level).
-final radarrLogsProvider = FutureProvider.autoDispose
-    .family<Map<String, dynamic>,
-        (Instance, {int page, int pageSize, String? level})>((
+final radarrLogsProvider = FutureProvider.autoDispose.family<
+    Map<String, dynamic>, (Instance, {int page, int pageSize, String? level})>((
   Ref ref,
   (Instance, {int page, int pageSize, String? level}) key,
 ) async {
@@ -699,8 +701,8 @@ final radarrLogsProvider = FutureProvider.autoDispose
 });
 
 /// Log files list.
-final radarrLogFilesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrLogFilesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -709,8 +711,8 @@ final radarrLogFilesProvider = FutureProvider.autoDispose
 });
 
 /// Backups list.
-final radarrBackupsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final radarrBackupsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -745,6 +747,3 @@ final radarrParseResultProvider = FutureProvider.autoDispose
   final RadarrApi api = await ref.watch(radarrApiProvider(instance).future);
   return api.parseTitle(title);
 });
-
-
-

--- a/services/service_radarr/lib/src/radarr_release_search_screen.dart
+++ b/services/service_radarr/lib/src/radarr_release_search_screen.dart
@@ -143,7 +143,8 @@ class _RadarrReleaseSearchScreenState
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Release grabbed successfully!')),
         );
-        ref.invalidate(radarrMovieByIdProvider((widget.instance, widget.movie.id)));
+        ref.invalidate(
+            radarrMovieByIdProvider((widget.instance, widget.movie.id)));
         ref.invalidate(radarrQueueProvider(widget.instance));
         Navigator.pop(context);
       }
@@ -581,8 +582,8 @@ class _RadarrReleaseSearchScreenState
                               ? const SizedBox(
                                   width: 24,
                                   height: 24,
-                                  child:
-                                      ExpressiveProgressIndicator(strokeWidth: 2),
+                                  child: ExpressiveProgressIndicator(
+                                      strokeWidth: 2),
                                 )
                               : IconButton(
                                   icon: Icon(

--- a/services/service_radarr/lib/src/radarr_settings_form_screen.dart
+++ b/services/service_radarr/lib/src/radarr_settings_form_screen.dart
@@ -155,7 +155,6 @@ class _RadarrSettingsFormScreenState
                             ),
                           ),
                           const SizedBox(height: Insets.md),
-
                           TextFormField(
                             controller: _pathController,
                             decoration: const InputDecoration(
@@ -165,13 +164,12 @@ class _RadarrSettingsFormScreenState
                             ),
                             validator: (value) {
                               if (value == null || value.trim().isEmpty) {
-                                  return 'Path cannot be empty';
+                                return 'Path cannot be empty';
                               }
                               return null;
                             },
                           ),
                           const SizedBox(height: Insets.md),
-
                           SwitchListTile(
                             title: const Text('Monitored'),
                             subtitle: const Text(
@@ -184,7 +182,6 @@ class _RadarrSettingsFormScreenState
                             },
                           ),
                           const SizedBox(height: Insets.md),
-
                           profilesAsync.when(
                             loading: () => const Center(
                               child: ExpressiveProgressIndicator(),
@@ -224,7 +221,6 @@ class _RadarrSettingsFormScreenState
                             },
                           ),
                           const SizedBox(height: Insets.md),
-
                           DropdownButtonFormField<String>(
                             initialValue: _minimumAvailability,
                             decoration: const InputDecoration(
@@ -257,7 +253,6 @@ class _RadarrSettingsFormScreenState
                             },
                           ),
                           const SizedBox(height: Insets.md),
-
                           tagsAsync.when(
                             loading: () => const Center(
                               child: ExpressiveProgressIndicator(),
@@ -273,8 +268,7 @@ class _RadarrSettingsFormScreenState
                                 children: [
                                   Text(
                                     'Tags',
-                                    style: theme.textTheme.titleSmall
-                                        ?.copyWith(
+                                    style: theme.textTheme.titleSmall?.copyWith(
                                       fontWeight: FontWeight.bold,
                                     ),
                                   ),

--- a/services/service_radarr/pubspec.yaml
+++ b/services/service_radarr/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   cached_network_image: ^3.4.1
   collection: ^1.18.0
   core_models:

--- a/services/service_sabnzbd/lib/src/models/sab_history.dart
+++ b/services/service_sabnzbd/lib/src/models/sab_history.dart
@@ -31,13 +31,16 @@ abstract class SabHistorySlot with _$SabHistorySlot {
   const factory SabHistorySlot({
     @JsonKey(name: 'nzo_id') @Default('') String nzoId,
     @Default('') String name,
+
     /// Completed, Failed, Extracting, Verifying, Repairing, etc.
     @Default('') String status,
     @Default('') String category,
+
     /// Human size string, e.g. "1.2 GB".
     @Default('') String size,
     @Default(0) int bytes,
     @JsonKey(name: 'fail_message') @Default('') String failMessage,
+
     /// Unix epoch seconds when the item finished.
     @Default(0) int completed,
   }) = _SabHistorySlot;

--- a/services/service_sabnzbd/lib/src/models/sab_queue.dart
+++ b/services/service_sabnzbd/lib/src/models/sab_queue.dart
@@ -19,14 +19,17 @@ abstract class SabQueueResponse with _$SabQueueResponse {
 abstract class SabQueue with _$SabQueue {
   const factory SabQueue({
     @Default('') String status,
+
     /// Human speed string, e.g. "1.2 M".
     @Default('') String speed,
     @Default('') String sizeleft,
     @Default('') String timeleft,
     @Default('') String mbleft,
     @Default('') String mb,
+
     /// Active global speed limit as a percentage string, e.g. "100".
     @Default('') String speedlimit,
+
     /// Free / total disk space at the download location, in GB strings.
     @Default('') String diskspace1,
     @Default('') String diskspacetotal1,

--- a/services/service_sabnzbd/lib/src/sabnzbd_home.dart
+++ b/services/service_sabnzbd/lib/src/sabnzbd_home.dart
@@ -8,6 +8,7 @@ import 'models/sab_queue.dart';
 import 'models/sab_stats.dart';
 import 'sabnzbd_api.dart';
 import 'sabnzbd_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// SABnzbd's per-instance UI: Queue / History / Server tabs.
 class SabnzbdHome extends StatelessWidget {
@@ -144,8 +145,8 @@ class _QueueSummary extends ConsumerWidget {
                   children: <Widget>[
                     Text(
                       speed,
-                      style: theme.textTheme.titleLarge
-                          ?.copyWith(fontWeight: FontWeight.w700, color: accent),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700, color: accent),
                     ),
                     Text(
                       _isPaused
@@ -182,7 +183,8 @@ class _QueueSummary extends ConsumerWidget {
             children: <Widget>[
               _StatPill(
                 icon: Icons.speed,
-                label: 'Limit ${queue.speedlimit.isEmpty ? "100" : queue.speedlimit}%',
+                label:
+                    'Limit ${queue.speedlimit.isEmpty ? "100" : queue.speedlimit}%',
                 color: cs.tertiary,
               ),
               if (queue.diskspace1.isNotEmpty) ...<Widget>[
@@ -244,11 +246,11 @@ class _SlotCard extends ConsumerWidget {
             const SizedBox(height: Insets.sm),
             ClipRRect(
               borderRadius: BorderRadius.circular(8),
-              child: LinearProgressIndicator(
+              child: LinearProgressIndicatorM3E(
+                shape: ProgressM3EShape.flat,
                 value: pct.clamp(0, 1),
-                minHeight: 6,
-                color: color,
-                backgroundColor: cs.surfaceContainerHighest,
+                activeColor: color,
+                trackColor: cs.surfaceContainerHighest,
               ),
             ),
             const SizedBox(height: Insets.sm),
@@ -265,7 +267,8 @@ class _SlotCard extends ConsumerWidget {
                     <String>[
                       slot.status,
                       if (slot.mb.isNotEmpty) _mbToHuman(slot.mb),
-                      if (slot.timeleft.isNotEmpty && slot.timeleft != '0:00:00')
+                      if (slot.timeleft.isNotEmpty &&
+                          slot.timeleft != '0:00:00')
                         slot.timeleft,
                     ].join(' • '),
                     maxLines: 1,
@@ -316,7 +319,8 @@ class _HistoryTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<SabHistory> history = ref.watch(sabHistoryProvider(instance));
+    final AsyncValue<SabHistory> history =
+        ref.watch(sabHistoryProvider(instance));
     return M3RefreshIndicator(
       onRefresh: () async => ref.invalidate(sabHistoryProvider(instance)),
       child: AsyncValueView<SabHistory>(
@@ -463,8 +467,7 @@ class _ServerTab extends ConsumerWidget {
     final AsyncValue<SabServerStats> stats =
         ref.watch(sabServerStatsProvider(instance));
     final SabQueue? queue = ref.watch(sabQueueProvider(instance)).value;
-    final String version =
-        ref.watch(sabVersionProvider(instance)).value ?? '';
+    final String version = ref.watch(sabVersionProvider(instance)).value ?? '';
     final int currentLimit = int.tryParse(queue?.speedlimit ?? '') ?? 100;
 
     return M3RefreshIndicator(
@@ -481,10 +484,18 @@ class _ServerTab extends ConsumerWidget {
             child: stats.when(
               data: (SabServerStats s) => Row(
                 children: <Widget>[
-                  Expanded(child: _StatTile(label: 'Today', value: _fmtBytes(s.day))),
-                  Expanded(child: _StatTile(label: 'Week', value: _fmtBytes(s.week))),
-                  Expanded(child: _StatTile(label: 'Month', value: _fmtBytes(s.month))),
-                  Expanded(child: _StatTile(label: 'Total', value: _fmtBytes(s.total))),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Today', value: _fmtBytes(s.day))),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Week', value: _fmtBytes(s.week))),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Month', value: _fmtBytes(s.month))),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Total', value: _fmtBytes(s.total))),
                 ],
               ),
               loading: () => const Padding(
@@ -535,7 +546,8 @@ class _ServerTab extends ConsumerWidget {
 }
 
 class _SpeedLimitControl extends ConsumerStatefulWidget {
-  const _SpeedLimitControl({required this.instance, required this.initialPercent});
+  const _SpeedLimitControl(
+      {required this.instance, required this.initialPercent});
 
   final Instance instance;
   final int initialPercent;
@@ -585,7 +597,8 @@ class _SpeedLimitControlState extends ConsumerState<_SpeedLimitControl> {
 // Shared -------------------------------------------------------------------
 
 class _StatPill extends StatelessWidget {
-  const _StatPill({required this.icon, required this.label, required this.color});
+  const _StatPill(
+      {required this.icon, required this.label, required this.color});
 
   final IconData icon;
   final String label;
@@ -638,8 +651,8 @@ class _SectionCard extends StatelessWidget {
         children: <Widget>[
           Text(
             title,
-            style:
-                theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            style: theme.textTheme.titleMedium
+                ?.copyWith(fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: Insets.sm),
           child,
@@ -749,8 +762,9 @@ String _fmtBytes(int bytes) {
     value /= 1024;
     unit++;
   }
-  final String text =
-      value >= 100 || unit == 0 ? value.toStringAsFixed(0) : value.toStringAsFixed(1);
+  final String text = value >= 100 || unit == 0
+      ? value.toStringAsFixed(0)
+      : value.toStringAsFixed(1);
   return '$text ${units[unit]}';
 }
 

--- a/services/service_sabnzbd/lib/src/sabnzbd_providers.dart
+++ b/services/service_sabnzbd/lib/src/sabnzbd_providers.dart
@@ -16,53 +16,50 @@ const Duration sabHistoryPollInterval = Duration(seconds: 10);
 /// A [SabnzbdApi] for an instance, over the shared `instanceDioProvider`.
 ///
 /// Deliberately NOT autoDispose: the underlying Dio is shared and cheap to keep.
-final sabnzbdApiProvider =
-    FutureProvider.family<SabnzbdApi, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      return SabnzbdApi(dio);
-    });
+final sabnzbdApiProvider = FutureProvider.family<SabnzbdApi, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  return SabnzbdApi(dio);
+});
 
 /// The current download queue. Polls fast while watched.
-final sabQueueProvider =
-    FutureProvider.autoDispose.family<SabQueue, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(sabQueuePollInterval);
-      final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
-      return api.getQueue();
-    });
+final sabQueueProvider = FutureProvider.autoDispose.family<SabQueue, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(sabQueuePollInterval);
+  final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
+  return api.getQueue();
+});
 
 /// Completed / failed download history. Polls slowly while watched.
 final sabHistoryProvider =
     FutureProvider.autoDispose.family<SabHistory, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(sabHistoryPollInterval);
-      final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
-      return api.getHistory();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(sabHistoryPollInterval);
+  final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
+  return api.getHistory();
+});
 
 /// Bytes-downloaded stats (day/week/month/total). Fetched on demand.
 final sabServerStatsProvider =
     FutureProvider.autoDispose.family<SabServerStats, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
-      return api.getServerStats();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
+  return api.getServerStats();
+});
 
 /// SABnzbd version string. Fetched on demand.
-final sabVersionProvider =
-    FutureProvider.autoDispose.family<String, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
-      return api.getVersion();
-    });
+final sabVersionProvider = FutureProvider.autoDispose.family<String, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final SabnzbdApi api = await ref.watch(sabnzbdApiProvider(instance).future);
+  return api.getVersion();
+});

--- a/services/service_sabnzbd/pubspec.yaml
+++ b/services/service_sabnzbd/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   collection: ^1.18.0
   core_models:
   core_networking:

--- a/services/service_seerr/lib/src/models/seerr_discover.dart
+++ b/services/service_seerr/lib/src/models/seerr_discover.dart
@@ -39,13 +39,17 @@ abstract class SeerrDiscoverResult with _$SeerrDiscoverResult {
     SeerrMedia? mediaInfo,
     // Detail-only fields (populated by GET /{movie|tv}/{id}).
     String? backdropPath,
+
     /// TMDB status, e.g. "Released", "Ended", "Returning Series".
     String? status,
+
     /// Movie runtime in minutes.
     int? runtime,
+
     /// TV total episode count.
     int? numberOfEpisodes,
     @Default(<SeerrGenre>[]) List<SeerrGenre> genres,
+
     /// Inline cast credits (returned by GET /{movie|tv}/{id}).
     @JsonKey(name: 'credits') SeerrCredits? credits,
   }) = _SeerrDiscoverResult;

--- a/services/service_seerr/lib/src/models/seerr_request.dart
+++ b/services/service_seerr/lib/src/models/seerr_request.dart
@@ -22,6 +22,7 @@ abstract class SeerrRequest with _$SeerrRequest {
   const factory SeerrRequest({
     required int id,
     @Default(1) int status,
+
     /// 'movie' or 'tv'.
     @Default('') String type,
     SeerrMedia? media,

--- a/services/service_seerr/lib/src/seerr_api.dart
+++ b/services/service_seerr/lib/src/seerr_api.dart
@@ -71,7 +71,8 @@ class SeerrApi {
 
   Future<SeerrCounts> getRequestCounts() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/request/count');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/request/count');
       return SeerrCounts.fromJson(resp.data as Map<String, dynamic>);
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
@@ -93,7 +94,8 @@ class SeerrApi {
         'is4k': is4k,
         if (serverId != null) 'serverId': serverId,
         if (profileId != null) 'profileId': profileId,
-        if (rootFolder != null && rootFolder.isNotEmpty) 'rootFolder': rootFolder,
+        if (rootFolder != null && rootFolder.isNotEmpty)
+          'rootFolder': rootFolder,
       };
       if (mediaType.toLowerCase() == 'tv') {
         data['seasons'] = 'all';
@@ -181,8 +183,7 @@ class SeerrApi {
           'filter': filter,
         },
       );
-      return SeerrIssuePage.fromJson(resp.data as Map<String, dynamic>)
-          .results;
+      return SeerrIssuePage.fromJson(resp.data as Map<String, dynamic>).results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -236,9 +237,11 @@ class SeerrApi {
 
   // --- Seerr / Discover Endpoints ---
 
-  Future<SeerrDiscoverResult> getMediaDetails(String mediaType, int tmdbId) async {
+  Future<SeerrDiscoverResult> getMediaDetails(
+      String mediaType, int tmdbId) async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/$mediaType/$tmdbId');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/$mediaType/$tmdbId');
       final Map<String, dynamic> data = resp.data as Map<String, dynamic>;
       // The endpoints return full details but include mediaInfo. mediaType is not always set by default.
       data['mediaType'] ??= mediaType;
@@ -253,7 +256,8 @@ class SeerrApi {
       final Response<dynamic> resp = await _dio.get<dynamic>(
         '$_base/search?query=${Uri.encodeComponent(query)}',
       );
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -261,8 +265,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> discoverMovies() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/movies');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/movies');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -270,9 +276,12 @@ class SeerrApi {
 
   Future<List<SeerrGenre>> getMovieGenres() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/genres/movie');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/genres/movie');
       final List<dynamic> list = resp.data as List<dynamic>;
-      return list.map((dynamic e) => SeerrGenre.fromJson(e as Map<String, dynamic>)).toList();
+      return list
+          .map((dynamic e) => SeerrGenre.fromJson(e as Map<String, dynamic>))
+          .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -280,8 +289,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> getMoviesByGenre(int genreId) async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/movies/genre/$genreId');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/movies/genre/$genreId');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -289,8 +300,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> getUpcomingMovies() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/movies/upcoming');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/movies/upcoming');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -298,8 +311,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> discoverTvShows() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/tv');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/tv');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -307,9 +322,12 @@ class SeerrApi {
 
   Future<List<SeerrGenre>> getTvGenres() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/genres/tv');
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/genres/tv');
       final List<dynamic> list = resp.data as List<dynamic>;
-      return list.map((dynamic e) => SeerrGenre.fromJson(e as Map<String, dynamic>)).toList();
+      return list
+          .map((dynamic e) => SeerrGenre.fromJson(e as Map<String, dynamic>))
+          .toList();
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -317,8 +335,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> getTvShowsByGenre(int genreId) async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/tv/genre/$genreId');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/tv/genre/$genreId');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -326,8 +346,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> getUpcomingTvShows() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/tv/upcoming');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/tv/upcoming');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }
@@ -335,8 +357,10 @@ class SeerrApi {
 
   Future<List<SeerrDiscoverResult>> getTrending() async {
     try {
-      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/discover/trending');
-      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>).results;
+      final Response<dynamic> resp =
+          await _dio.get<dynamic>('$_base/discover/trending');
+      return SeerrDiscoverPage.fromJson(resp.data as Map<String, dynamic>)
+          .results;
     } on DioException catch (e) {
       throw NetworkException.fromDio(e);
     }

--- a/services/service_seerr/lib/src/seerr_genre_screen.dart
+++ b/services/service_seerr/lib/src/seerr_genre_screen.dart
@@ -23,7 +23,8 @@ class SeerrGenreScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<List<SeerrDiscoverResult>> items = ref.watch(
-      seerrItemsByGenreProvider((instance: instance, genreId: genre.id, isMovie: isMovie)),
+      seerrItemsByGenreProvider(
+          (instance: instance, genreId: genre.id, isMovie: isMovie)),
     );
 
     return Scaffold(
@@ -32,7 +33,8 @@ class SeerrGenreScreen extends ConsumerWidget {
       ),
       body: AsyncValueView<List<SeerrDiscoverResult>>(
         value: items,
-        onRetry: () => ref.invalidate(seerrItemsByGenreProvider((instance: instance, genreId: genre.id, isMovie: isMovie))),
+        onRetry: () => ref.invalidate(seerrItemsByGenreProvider(
+            (instance: instance, genreId: genre.id, isMovie: isMovie))),
         data: (List<SeerrDiscoverResult> list) {
           if (list.isEmpty) {
             return const EmptyView(
@@ -107,14 +109,18 @@ class _SeerrGenrePosterCard extends StatelessWidget {
             item.displayTitle,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(fontWeight: FontWeight.bold),
           ),
           if (item.displayDate != null)
             Text(
               item.displayDate!,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
         ],
       ),

--- a/services/service_seerr/lib/src/seerr_home.dart
+++ b/services/service_seerr/lib/src/seerr_home.dart
@@ -160,12 +160,15 @@ class _RequestTileState extends ConsumerState<_RequestTile> {
       );
     }
 
-    final AsyncValue<SeerrDiscoverResult> detailsAsync =
-        ref.watch(seerrMediaDetailsProvider((
-      instance: widget.instance,
-      mediaType: mediaType,
-      tmdbId: tmdbId,
-    ),),);
+    final AsyncValue<SeerrDiscoverResult> detailsAsync = ref.watch(
+      seerrMediaDetailsProvider(
+        (
+          instance: widget.instance,
+          mediaType: mediaType,
+          tmdbId: tmdbId,
+        ),
+      ),
+    );
 
     return detailsAsync.when(
       data: (SeerrDiscoverResult item) {

--- a/services/service_seerr/lib/src/seerr_item_detail.dart
+++ b/services/service_seerr/lib/src/seerr_item_detail.dart
@@ -207,7 +207,8 @@ class _SeerrItemDetailScreenState extends ConsumerState<SeerrItemDetailScreen> {
           ),
           SliverToBoxAdapter(
             child: Padding(
-              padding: const EdgeInsets.fromLTRB(Insets.lg, Insets.lg, Insets.lg, 0),
+              padding:
+                  const EdgeInsets.fromLTRB(Insets.lg, Insets.lg, Insets.lg, 0),
               child: _ActionRow(
                 instance: widget.instance,
                 item: full,
@@ -218,8 +219,8 @@ class _SeerrItemDetailScreenState extends ConsumerState<SeerrItemDetailScreen> {
           if (genreNames.isNotEmpty)
             SliverToBoxAdapter(
               child: Padding(
-                padding:
-                    const EdgeInsets.fromLTRB(Insets.lg, Insets.lg, Insets.lg, 0),
+                padding: const EdgeInsets.fromLTRB(
+                    Insets.lg, Insets.lg, Insets.lg, 0),
                 child: Wrap(
                   spacing: 6.0,
                   runSpacing: 6.0,
@@ -249,8 +250,8 @@ class _SeerrItemDetailScreenState extends ConsumerState<SeerrItemDetailScreen> {
           if (full.overview != null && full.overview!.isNotEmpty)
             SliverToBoxAdapter(
               child: Padding(
-                padding:
-                    const EdgeInsets.fromLTRB(Insets.lg, Insets.lg, Insets.lg, 0),
+                padding: const EdgeInsets.fromLTRB(
+                    Insets.lg, Insets.lg, Insets.lg, 0),
                 child: OverviewBox(overview: full.overview!),
               ),
             ),
@@ -639,8 +640,7 @@ class _PosterCard extends StatelessWidget {
                         ? CachedNetworkImage(
                             imageUrl: _tmdbImage(item.posterPath!, 'w342'),
                             fit: BoxFit.cover,
-                            errorWidget: (_, __, ___) =>
-                                _posterFallback(theme),
+                            errorWidget: (_, __, ___) => _posterFallback(theme),
                           )
                         : _posterFallback(theme),
                     Positioned(
@@ -996,10 +996,12 @@ class _RequestOptionsSheetState extends ConsumerState<_RequestOptionsSheet> {
               border: OutlineInputBorder(),
             ),
             items: pool
-                .map((SeerrServer s) => DropdownMenuItem<int>(
-                      value: s.id,
-                      child: Text(s.name.isEmpty ? 'Server ${s.id}' : s.name),
-                    ),)
+                .map(
+                  (SeerrServer s) => DropdownMenuItem<int>(
+                    value: s.id,
+                    child: Text(s.name.isEmpty ? 'Server ${s.id}' : s.name),
+                  ),
+                )
                 .toList(),
             onChanged: (int? v) => setState(() {
               _serverId = v;
@@ -1076,10 +1078,12 @@ class _RequestOptionsSheetState extends ConsumerState<_RequestOptionsSheet> {
               border: OutlineInputBorder(),
             ),
             items: profiles
-                .map((SeerrProfile p) => DropdownMenuItem<int>(
-                      value: p.id,
-                      child: Text(p.name),
-                    ),)
+                .map(
+                  (SeerrProfile p) => DropdownMenuItem<int>(
+                    value: p.id,
+                    child: Text(p.name),
+                  ),
+                )
                 .toList(),
             onChanged: (int? v) => setState(() => _profileId = v),
           ),
@@ -1094,10 +1098,12 @@ class _RequestOptionsSheetState extends ConsumerState<_RequestOptionsSheet> {
               border: OutlineInputBorder(),
             ),
             items: roots
-                .map((SeerrRootFolder r) => DropdownMenuItem<String>(
-                      value: r.path,
-                      child: Text(r.path, overflow: TextOverflow.ellipsis),
-                    ),)
+                .map(
+                  (SeerrRootFolder r) => DropdownMenuItem<String>(
+                    value: r.path,
+                    child: Text(r.path, overflow: TextOverflow.ellipsis),
+                  ),
+                )
                 .toList(),
             onChanged: (String? v) => setState(() => _rootFolder = v),
           ),

--- a/services/service_seerr/lib/src/seerr_media_card.dart
+++ b/services/service_seerr/lib/src/seerr_media_card.dart
@@ -310,8 +310,7 @@ class SeerrRequestCard extends StatelessWidget {
                         height: 114,
                         child: item.posterPath != null
                             ? CachedNetworkImage(
-                                imageUrl:
-                                    _tmdbImage(item.posterPath!, 'w342'),
+                                imageUrl: _tmdbImage(item.posterPath!, 'w342'),
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) =>
                                     _posterFallback(cs),
@@ -328,8 +327,7 @@ class SeerrRequestCard extends StatelessWidget {
               ],
             ),
           ),
-          if (trailing != null)
-            Positioned(top: 4, right: 4, child: trailing!),
+          if (trailing != null) Positioned(top: 4, right: 4, child: trailing!),
         ],
       ),
     );

--- a/services/service_seerr/lib/src/seerr_providers.dart
+++ b/services/service_seerr/lib/src/seerr_providers.dart
@@ -12,142 +12,143 @@ import 'models/seerr_service.dart';
 import 'seerr_api.dart';
 
 /// An [SeerrApi] for an instance, over the shared `instanceDioProvider`.
-final seerrApiProvider =
-    FutureProvider.family<SeerrApi, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      return SeerrApi(dio);
-    });
+final seerrApiProvider = FutureProvider.family<SeerrApi, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  return SeerrApi(dio);
+});
 
 final seerrRequestCountsProvider =
     FutureProvider.family<SeerrCounts, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(instance).future);
-      return api.getRequestCounts();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getRequestCounts();
+});
 
 final seerrRequestsProvider =
     FutureProvider.autoDispose.family<List<SeerrRequest>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(instance).future);
-      
-      final link = ref.keepAlive();
-      final timer = Timer(const Duration(seconds: 10), () {
-        link.close();
-        ref.invalidateSelf();
-      });
-      ref.onDispose(timer.cancel);
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
 
-      return api.getAllRequests();
-    });
+  final link = ref.keepAlive();
+  final timer = Timer(const Duration(seconds: 10), () {
+    link.close();
+    ref.invalidateSelf();
+  });
+  ref.onDispose(timer.cancel);
+
+  return api.getAllRequests();
+});
 
 final seerrTrendingProvider =
     FutureProvider.family<List<SeerrDiscoverResult>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.getTrending();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getTrending();
+});
 
 final seerrUpcomingMoviesProvider =
     FutureProvider.family<List<SeerrDiscoverResult>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.getUpcomingMovies();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getUpcomingMovies();
+});
 
 final seerrUpcomingTvProvider =
     FutureProvider.family<List<SeerrDiscoverResult>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.getUpcomingTvShows();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getUpcomingTvShows();
+});
 
 final seerrDiscoverMoviesProvider =
     FutureProvider.family<List<SeerrDiscoverResult>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.discoverMovies();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.discoverMovies();
+});
 
 final seerrDiscoverTvProvider =
     FutureProvider.family<List<SeerrDiscoverResult>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.discoverTvShows();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.discoverTvShows();
+});
 
 final seerrMovieGenresProvider =
     FutureProvider.family<List<SeerrGenre>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.getMovieGenres();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getMovieGenres();
+});
 
 final seerrTvGenresProvider =
     FutureProvider.family<List<SeerrGenre>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.getTvGenres();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getTvGenres();
+});
 
 typedef SeerrSearchArgs = ({Instance instance, String query});
 
-final seerrSearchProvider =
-    FutureProvider.autoDispose.family<List<SeerrDiscoverResult>, SeerrSearchArgs>((
-      Ref ref,
-      SeerrSearchArgs args,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
-      return api.search(args.query);
-    });
+final seerrSearchProvider = FutureProvider.autoDispose
+    .family<List<SeerrDiscoverResult>, SeerrSearchArgs>((
+  Ref ref,
+  SeerrSearchArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.search(args.query);
+});
 
 typedef SeerrGenreArgs = ({Instance instance, int genreId, bool isMovie});
 
 final seerrItemsByGenreProvider =
     FutureProvider.family<List<SeerrDiscoverResult>, SeerrGenreArgs>((
-      Ref ref,
-      SeerrGenreArgs args,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
-      if (args.isMovie) {
-        return api.getMoviesByGenre(args.genreId);
-      } else {
-        return api.getTvShowsByGenre(args.genreId);
-      }
-    });
+  Ref ref,
+  SeerrGenreArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  if (args.isMovie) {
+    return api.getMoviesByGenre(args.genreId);
+  } else {
+    return api.getTvShowsByGenre(args.genreId);
+  }
+});
 
-typedef SeerrMediaDetailsArgs = ({Instance instance, String mediaType, int tmdbId});
+typedef SeerrMediaDetailsArgs = ({
+  Instance instance,
+  String mediaType,
+  int tmdbId
+});
 
 final seerrMediaDetailsProvider =
     FutureProvider.family<SeerrDiscoverResult, SeerrMediaDetailsArgs>((
-      Ref ref,
-      SeerrMediaDetailsArgs args,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
-      return api.getMediaDetails(args.mediaType, args.tmdbId);
-    });
+  Ref ref,
+  SeerrMediaDetailsArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.getMediaDetails(args.mediaType, args.tmdbId);
+});
 
 typedef SeerrServersArgs = ({Instance instance, String mediaType});
 
@@ -155,27 +156,28 @@ typedef SeerrServersArgs = ({Instance instance, String mediaType});
 /// options sheet.
 final seerrServersProvider =
     FutureProvider.autoDispose.family<List<SeerrServer>, SeerrServersArgs>((
-      Ref ref,
-      SeerrServersArgs args,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(args.instance).future);
-      return api.getServers(args.mediaType);
-    });
+  Ref ref,
+  SeerrServersArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.getServers(args.mediaType);
+});
 
-typedef SeerrServerDetailsArgs =
-    ({Instance instance, String mediaType, int serverId});
+typedef SeerrServerDetailsArgs = ({
+  Instance instance,
+  String mediaType,
+  int serverId
+});
 
 /// Quality profiles + root folders for a chosen server.
 final seerrServerDetailsProvider = FutureProvider.autoDispose
     .family<SeerrServerDetails, SeerrServerDetailsArgs>((
-      Ref ref,
-      SeerrServerDetailsArgs args,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(args.instance).future);
-      return api.getServerDetails(args.mediaType, args.serverId);
-    });
+  Ref ref,
+  SeerrServerDetailsArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.getServerDetails(args.mediaType, args.serverId);
+});
 
 typedef SeerrIssuesArgs = ({Instance instance, String filter});
 
@@ -183,60 +185,56 @@ typedef SeerrIssuesArgs = ({Instance instance, String filter});
 /// watched.
 final seerrIssuesProvider =
     FutureProvider.autoDispose.family<List<SeerrIssue>, SeerrIssuesArgs>((
-      Ref ref,
-      SeerrIssuesArgs args,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(args.instance).future);
+  Ref ref,
+  SeerrIssuesArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
 
-      final link = ref.keepAlive();
-      final timer = Timer(const Duration(seconds: 10), () {
-        link.close();
-        ref.invalidateSelf();
-      });
-      ref.onDispose(timer.cancel);
+  final link = ref.keepAlive();
+  final timer = Timer(const Duration(seconds: 10), () {
+    link.close();
+    ref.invalidateSelf();
+  });
+  ref.onDispose(timer.cancel);
 
-      return api.getIssues(filter: args.filter);
-    });
+  return api.getIssues(filter: args.filter);
+});
 
 typedef SeerrIssueDetailArgs = ({Instance instance, int id});
 
 /// One issue with its comment thread.
 final seerrIssueDetailProvider =
     FutureProvider.autoDispose.family<SeerrIssue, SeerrIssueDetailArgs>((
-      Ref ref,
-      SeerrIssueDetailArgs args,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(args.instance).future);
-      return api.getIssue(args.id);
-    });
+  Ref ref,
+  SeerrIssueDetailArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.getIssue(args.id);
+});
 
 final seerrRecommendationsProvider = FutureProvider.autoDispose
     .family<List<SeerrDiscoverResult>, SeerrMediaDetailsArgs>((
-      Ref ref,
-      SeerrMediaDetailsArgs args,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(args.instance).future);
-      return api.getRecommendations(args.mediaType, args.tmdbId);
-    });
+  Ref ref,
+  SeerrMediaDetailsArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.getRecommendations(args.mediaType, args.tmdbId);
+});
 
 final seerrSimilarProvider = FutureProvider.autoDispose
     .family<List<SeerrDiscoverResult>, SeerrMediaDetailsArgs>((
-      Ref ref,
-      SeerrMediaDetailsArgs args,
-    ) async {
-      final SeerrApi api =
-          await ref.watch(seerrApiProvider(args.instance).future);
-      return api.getSimilar(args.mediaType, args.tmdbId);
-    });
+  Ref ref,
+  SeerrMediaDetailsArgs args,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(args.instance).future);
+  return api.getSimilar(args.mediaType, args.tmdbId);
+});
 
 final seerrWatchlistProvider =
     FutureProvider.autoDispose.family<List<SeerrDiscoverResult>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
-      return api.getWatchlist();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final SeerrApi api = await ref.watch(seerrApiProvider(instance).future);
+  return api.getWatchlist();
+});

--- a/services/service_seerr/lib/src/seerr_report_issue_sheet.dart
+++ b/services/service_seerr/lib/src/seerr_report_issue_sheet.dart
@@ -52,8 +52,7 @@ class SeerrReportIssueSheet extends ConsumerStatefulWidget {
       _SeerrReportIssueSheetState();
 }
 
-class _SeerrReportIssueSheetState
-    extends ConsumerState<SeerrReportIssueSheet> {
+class _SeerrReportIssueSheetState extends ConsumerState<SeerrReportIssueSheet> {
   static const List<(int, String)> _types = <(int, String)>[
     (1, 'Video'),
     (2, 'Audio'),

--- a/services/service_seerr/lib/src/seerr_search.dart
+++ b/services/service_seerr/lib/src/seerr_search.dart
@@ -71,7 +71,8 @@ class _SearchResults extends ConsumerWidget {
 
     return AsyncValueView<List<SeerrDiscoverResult>>(
       value: results,
-      onRetry: () => ref.invalidate(seerrSearchProvider((instance: instance, query: query.trim()))),
+      onRetry: () => ref.invalidate(
+          seerrSearchProvider((instance: instance, query: query.trim()))),
       data: (List<SeerrDiscoverResult> list) {
         if (list.isEmpty) {
           return const EmptyView(
@@ -145,14 +146,18 @@ class _SeerrSearchPosterCard extends StatelessWidget {
             item.displayTitle,
             maxLines: 2,
             overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.bodySmall?.copyWith(fontWeight: FontWeight.bold),
+            style: Theme.of(context)
+                .textTheme
+                .bodySmall
+                ?.copyWith(fontWeight: FontWeight.bold),
           ),
           if (item.displayDate != null)
             Text(
               item.displayDate!,
               maxLines: 1,
               overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(color: Theme.of(context).colorScheme.onSurfaceVariant),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).colorScheme.onSurfaceVariant),
             ),
         ],
       ),

--- a/services/service_seerr/pubspec.yaml
+++ b/services/service_seerr/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   cached_network_image: ^3.4.1
   collection: ^1.18.0
   core_models:

--- a/services/service_sonarr/lib/src/home/activity_tab.dart
+++ b/services/service_sonarr/lib/src/home/activity_tab.dart
@@ -9,6 +9,7 @@ import '../models/sonarr_history_item.dart';
 import '../models/sonarr_queue_item.dart';
 import '../models/sonarr_series.dart';
 import '../sonarr_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class ActivityTab extends ConsumerStatefulWidget {
   const ActivityTab({
@@ -44,8 +45,11 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
     _tabController = TabController(length: 3, vsync: this);
     _tabController.addListener(() {
       if (_tabController.indexIsChanging) {
-        ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state = {};
-        ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+        ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state =
+            {};
+        ref
+            .read(sonarrBlocklistSelectionProvider(widget.instance).notifier)
+            .state = {};
         setState(() {});
       }
     });
@@ -91,8 +95,10 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final grouped = ref.watch(sonarrActivityGroupedProvider(widget.instance));
-    final queueSelection = ref.watch(sonarrQueueSelectionProvider(widget.instance));
-    final blocklistSelection = ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
+    final queueSelection =
+        ref.watch(sonarrQueueSelectionProvider(widget.instance));
+    final blocklistSelection =
+        ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
     final activeSelection = _tabController.index == 0
         ? queueSelection
         : _tabController.index == 2
@@ -121,13 +127,20 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
               selectedIds: activeSelection,
               isQueue: _tabController.index == 0,
               onClear: () {
-                ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                ref
+                    .read(
+                        sonarrQueueSelectionProvider(widget.instance).notifier)
+                    .state = {};
+                ref
+                    .read(sonarrBlocklistSelectionProvider(widget.instance)
+                        .notifier)
+                    .state = {};
               },
             )
           : null,
       body: NestedScrollView(
-        headerSliverBuilder: (BuildContext innerContext, bool innerBoxIsScrolled) {
+        headerSliverBuilder:
+            (BuildContext innerContext, bool innerBoxIsScrolled) {
           return <Widget>[
             SliverAppBar(
               floating: true,
@@ -143,8 +156,15 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                   ? IconButton(
                       icon: const Icon(Icons.close),
                       onPressed: () {
-                        ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                        ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                        ref
+                            .read(sonarrQueueSelectionProvider(widget.instance)
+                                .notifier)
+                            .state = {};
+                        ref
+                            .read(sonarrBlocklistSelectionProvider(
+                                    widget.instance)
+                                .notifier)
+                            .state = {};
                       },
                     )
                   : IconButton(
@@ -162,55 +182,59 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                       ),
                     )
                   : SearchBar(
-                focusNode: _searchFocusNode,
-                controller: _searchController,
-                hintText: 'Search activity...',
-                onTapOutside: (event) {
-                  if (_searchFocusNode.hasFocus) {
-                    _searchFocusNode.unfocus();
-                  }
-                },
-                elevation: const WidgetStatePropertyAll<double>(0),
-                backgroundColor: WidgetStatePropertyAll<Color>(
-                  theme.colorScheme.surfaceContainerHigh,
-                ),
-                trailing: <Widget>[
-                  if (_searchController.text.isNotEmpty)
-                    IconButton(
-                      icon: const Icon(Icons.clear),
-                      onPressed: () {
-                        setState(() {
-                          _searchController.clear();
-                        });
+                      focusNode: _searchFocusNode,
+                      controller: _searchController,
+                      hintText: 'Search activity...',
+                      onTapOutside: (event) {
+                        if (_searchFocusNode.hasFocus) {
+                          _searchFocusNode.unfocus();
+                        }
+                      },
+                      elevation: const WidgetStatePropertyAll<double>(0),
+                      backgroundColor: WidgetStatePropertyAll<Color>(
+                        theme.colorScheme.surfaceContainerHigh,
+                      ),
+                      trailing: <Widget>[
+                        if (_searchController.text.isNotEmpty)
+                          IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              setState(() {
+                                _searchController.clear();
+                              });
+                              ref
+                                  .read(
+                                    sonarrActivitySearchQueryProvider(
+                                      widget.instance,
+                                    ).notifier,
+                                  )
+                                  .state = '';
+                              _updateSearchActiveState();
+                            },
+                          ),
+                      ],
+                      onChanged: (String value) {
+                        setState(() {});
                         ref
                             .read(
-                              sonarrActivitySearchQueryProvider(
-                                widget.instance,
-                              ).notifier,
+                              sonarrActivitySearchQueryProvider(widget.instance)
+                                  .notifier,
                             )
-                            .state = '';
+                            .state = value;
                         _updateSearchActiveState();
                       },
                     ),
-                ],
-                onChanged: (String value) {
-                  setState(() {});
-                  ref
-                      .read(
-                        sonarrActivitySearchQueryProvider(widget.instance)
-                            .notifier,
-                      )
-                      .state = value;
-                  _updateSearchActiveState();
-                },
-              ),
               actions: <Widget>[
                 if (!isSelecting) ...[
                   IconButton(
                     icon: Icon(
-                      grouped ? Icons.format_list_bulleted : Icons.group_work_outlined,
+                      grouped
+                          ? Icons.format_list_bulleted
+                          : Icons.group_work_outlined,
                     ),
-                    tooltip: grouped ? 'Switch to plain list' : 'Switch to grouped view',
+                    tooltip: grouped
+                        ? 'Switch to plain list'
+                        : 'Switch to grouped view',
                     onPressed: () {
                       ref
                           .read(
@@ -265,14 +289,17 @@ class _QueueView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final queueAsync = ref.watch(sonarrQueueProvider(instance));
-    final searchQuery = ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return queueAsync.when(
       data: (List<SonarrQueueItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.title?.toLowerCase().contains(searchQuery) ?? false;
-          final seriesMatch = item.series?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.title?.toLowerCase().contains(searchQuery) ?? false;
+          final seriesMatch =
+              item.series?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || seriesMatch;
         }).toList();
 
@@ -305,7 +332,9 @@ class _QueueView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  searchQuery.isEmpty ? 'Queue is empty' : 'No items match search',
+                  searchQuery.isEmpty
+                      ? 'Queue is empty'
+                      : 'No items match search',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -353,7 +382,8 @@ class _QueueView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 FilledButton.tonal(
-                  onPressed: () => ref.invalidate(sonarrQueueProvider(instance)),
+                  onPressed: () =>
+                      ref.invalidate(sonarrQueueProvider(instance)),
                   child: const Text('Retry'),
                 ),
               ],
@@ -385,9 +415,11 @@ class _QueueItemCard extends ConsumerWidget {
     final isSelected = groupIds.every(selection.contains);
 
     void toggleSelection() {
-      final notifier = ref.read(sonarrQueueSelectionProvider(instance).notifier);
+      final notifier =
+          ref.read(sonarrQueueSelectionProvider(instance).notifier);
       if (isSelected) {
-        notifier.state = selection.where((id) => !groupIds.contains(id)).toSet();
+        notifier.state =
+            selection.where((id) => !groupIds.contains(id)).toSet();
       } else {
         notifier.state = {...selection, ...groupIds};
       }
@@ -401,23 +433,29 @@ class _QueueItemCard extends ConsumerWidget {
       totalSizeLeft += i.sizeleft ?? 0.0;
     }
 
-    final bool allSizesIdentical = group.every((i) => i.size == item.size && i.sizeleft == item.sizeleft);
-    final double displaySize = allSizesIdentical ? (item.size ?? 0.0) : totalSize;
-    final double displaySizeLeft = allSizesIdentical ? (item.sizeleft ?? 0.0) : totalSizeLeft;
-    final double progress = displaySize > 0 ? (displaySize - displaySizeLeft) / displaySize : 0.0;
+    final bool allSizesIdentical =
+        group.every((i) => i.size == item.size && i.sizeleft == item.sizeleft);
+    final double displaySize =
+        allSizesIdentical ? (item.size ?? 0.0) : totalSize;
+    final double displaySizeLeft =
+        allSizesIdentical ? (item.sizeleft ?? 0.0) : totalSizeLeft;
+    final double progress =
+        displaySize > 0 ? (displaySize - displaySizeLeft) / displaySize : 0.0;
 
     // Construct episodes display list (e.g. S01E01, S01E02)
     final List<String> episodeTexts = [];
     for (final i in group) {
       if (i.episode != null) {
-        final String seasonStr = i.seasonNumber != null ? 'S${i.seasonNumber.toString().padLeft(2, '0')}' : '';
-        final String epStr = 'E${i.episode!.episodeNumber.toString().padLeft(2, '0')}';
+        final String seasonStr = i.seasonNumber != null
+            ? 'S${i.seasonNumber.toString().padLeft(2, '0')}'
+            : '';
+        final String epStr =
+            'E${i.episode!.episodeNumber.toString().padLeft(2, '0')}';
         episodeTexts.add('$seasonStr$epStr');
       }
     }
-    final String episodesDisplay = episodeTexts.isNotEmpty
-        ? 'Episodes: ${episodeTexts.join(', ')}'
-        : '';
+    final String episodesDisplay =
+        episodeTexts.isNotEmpty ? 'Episodes: ${episodeTexts.join(', ')}' : '';
 
     String? posterUrl;
     if (item.series?.images != null && api != null) {
@@ -463,30 +501,33 @@ class _QueueItemCard extends ConsumerWidget {
                     fit: StackFit.expand,
                     children: [
                       posterUrl != null
-                        ? CachedNetworkImage(
-                            imageUrl: posterUrl,
-                            fit: BoxFit.cover,
-                            placeholder: (context, url) => Container(
-                              color: theme.colorScheme.surfaceContainerHighest,
-                            ),
-                            errorWidget: (context, url, err) => Container(
+                          ? CachedNetworkImage(
+                              imageUrl: posterUrl,
+                              fit: BoxFit.cover,
+                              placeholder: (context, url) => Container(
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                              ),
+                              errorWidget: (context, url, err) => Container(
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                                child: Icon(
+                                  Icons.live_tv,
+                                  color: theme.colorScheme.outline,
+                                ),
+                              ),
+                            )
+                          : Container(
                               color: theme.colorScheme.surfaceContainerHighest,
                               child: Icon(
                                 Icons.live_tv,
                                 color: theme.colorScheme.outline,
                               ),
                             ),
-                          )
-                        : Container(
-                            color: theme.colorScheme.surfaceContainerHighest,
-                            child: Icon(
-                              Icons.live_tv,
-                              color: theme.colorScheme.outline,
-                            ),
-                          ),
                       if (isSelected)
                         Container(
-                          color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                          color:
+                              theme.colorScheme.primary.withValues(alpha: 0.25),
                           child: Center(
                             child: Container(
                               padding: const EdgeInsets.all(4),
@@ -549,10 +590,12 @@ class _QueueItemCard extends ConsumerWidget {
                         Expanded(
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress,
-                              backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                              color: item.status == 'warning'
+                              trackColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                              activeColor: item.status == 'warning'
                                   ? theme.colorScheme.error
                                   : theme.colorScheme.primary,
                             ),
@@ -578,7 +621,8 @@ class _QueueItemCard extends ConsumerWidget {
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
                         ),
-                        if (item.timeleft != null && item.timeleft != '00:00:00')
+                        if (item.timeleft != null &&
+                            item.timeleft != '00:00:00')
                           Text(
                             'ETA: ${item.timeleft}',
                             style: theme.textTheme.bodySmall?.copyWith(
@@ -667,20 +711,21 @@ class _QueueItemCard extends ConsumerWidget {
     final List<String> episodeTexts = [];
     for (final i in group) {
       if (i.episode != null) {
-        final String seasonStr = i.seasonNumber != null ? 'S${i.seasonNumber}' : '';
+        final String seasonStr =
+            i.seasonNumber != null ? 'S${i.seasonNumber}' : '';
         final String epStr = 'E${i.episode!.episodeNumber}';
         episodeTexts.add('$seasonStr$epStr');
       }
     }
-    final String episodesDisplay = episodeTexts.isNotEmpty
-        ? episodeTexts.join(', ')
-        : 'None';
+    final String episodesDisplay =
+        episodeTexts.isNotEmpty ? episodeTexts.join(', ') : 'None';
 
     showDialog<void>(
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
           title: Text(
             'Queue Item Details',
             style: theme.textTheme.titleLarge?.copyWith(
@@ -693,15 +738,24 @@ class _QueueItemCard extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
                 _DetailRow(label: 'Title', value: item.title ?? 'No title'),
-                _DetailRow(label: 'Series', value: item.series?.title ?? 'Unknown Series'),
+                _DetailRow(
+                    label: 'Series',
+                    value: item.series?.title ?? 'Unknown Series'),
                 _DetailRow(label: 'Episodes', value: episodesDisplay),
                 _DetailRow(label: 'Status', value: item.status ?? 'Unknown'),
-                _DetailRow(label: 'Tracked State', value: item.trackedDownloadState ?? 'None'),
-                _DetailRow(label: 'Download Client', value: item.downloadClient ?? 'Unknown'),
-                _DetailRow(label: 'Download ID', value: item.downloadId ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Tracked State',
+                    value: item.trackedDownloadState ?? 'None'),
+                _DetailRow(
+                    label: 'Download Client',
+                    value: item.downloadClient ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Download ID', value: item.downloadId ?? 'Unknown'),
                 _DetailRow(label: 'Indexer', value: item.indexer ?? 'Unknown'),
-                _DetailRow(label: 'Output Path', value: item.outputPath ?? 'Unknown'),
-                if (item.errorMessage != null && item.errorMessage!.isNotEmpty) ...[
+                _DetailRow(
+                    label: 'Output Path', value: item.outputPath ?? 'Unknown'),
+                if (item.errorMessage != null &&
+                    item.errorMessage!.isNotEmpty) ...[
                   const SizedBox(height: 12),
                   Text(
                     'Error Message:',
@@ -715,9 +769,11 @@ class _QueueItemCard extends ConsumerWidget {
                     width: double.maxFinite,
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: theme.colorScheme.errorContainer.withValues(alpha: 0.3),
+                      color: theme.colorScheme.errorContainer
+                          .withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(8),
-                      border: Border.all(color: theme.colorScheme.errorContainer),
+                      border:
+                          Border.all(color: theme.colorScheme.errorContainer),
                     ),
                     child: Text(
                       item.errorMessage!,
@@ -756,7 +812,8 @@ class _QueueItemCard extends ConsumerWidget {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return AlertDialog(
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(28)),
               title: Text(
                 'Remove from Queue',
                 style: theme.textTheme.titleLarge?.copyWith(
@@ -787,7 +844,8 @@ class _QueueItemCard extends ConsumerWidget {
                   ),
                   CheckboxListTile(
                     title: const Text('Blocklist this release'),
-                    subtitle: const Text('Prevents Sonarr from grabbing this file again'),
+                    subtitle: const Text(
+                        'Prevents Sonarr from grabbing this file again'),
                     value: blocklist,
                     controlAffinity: ListTileControlAffinity.leading,
                     contentPadding: EdgeInsets.zero,
@@ -812,7 +870,8 @@ class _QueueItemCard extends ConsumerWidget {
                   onPressed: () async {
                     Navigator.of(context).pop();
                     try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
+                      final api =
+                          await ref.read(sonarrApiProvider(instance).future);
                       // Delete all items in the grouped torrent.
                       for (final i in group) {
                         await api.deleteQueueItem(
@@ -861,16 +920,20 @@ class _HistoryView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final historyAsync = ref.watch(sonarrHistoryProvider(instance));
-    final searchQuery = ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
     final grouped = ref.watch(sonarrActivityGroupedProvider(instance));
 
     return historyAsync.when(
       data: (List<SonarrHistoryItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final seriesMatch = item.series?.title.toLowerCase().contains(searchQuery) ?? false;
-          final episodeMatch = item.episode?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final seriesMatch =
+              item.series?.title.toLowerCase().contains(searchQuery) ?? false;
+          final episodeMatch =
+              item.episode?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || seriesMatch || episodeMatch;
         }).toList();
 
@@ -886,7 +949,9 @@ class _HistoryView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  searchQuery.isEmpty ? 'No history records' : 'No history matches search',
+                  searchQuery.isEmpty
+                      ? 'No history records'
+                      : 'No history matches search',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -929,7 +994,8 @@ class _HistoryView extends ConsumerWidget {
             },
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
-              itemCount: seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
+              itemCount:
+                  seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
               itemBuilder: (BuildContext context, int index) {
                 if (index < seriesList.length) {
                   final series = seriesList[index];
@@ -990,7 +1056,8 @@ class _HistoryView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 FilledButton.tonal(
-                  onPressed: () => ref.invalidate(sonarrHistoryProvider(instance)),
+                  onPressed: () =>
+                      ref.invalidate(sonarrHistoryProvider(instance)),
                   child: const Text('Retry'),
                 ),
               ],
@@ -1014,7 +1081,8 @@ class _GroupedHistoryCard extends ConsumerStatefulWidget {
   final List<SonarrHistoryItem> items;
 
   @override
-  ConsumerState<_GroupedHistoryCard> createState() => _GroupedHistoryCardState();
+  ConsumerState<_GroupedHistoryCard> createState() =>
+      _GroupedHistoryCardState();
 }
 
 class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
@@ -1028,7 +1096,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
     String? posterUrl;
     if (widget.series?.images != null && api != null) {
       try {
-        final img = widget.series!.images.firstWhere((i) => i.coverType == 'poster');
+        final img =
+            widget.series!.images.firstWhere((i) => i.coverType == 'poster');
         posterUrl = api.posterUrl(img);
       } catch (_) {}
     }
@@ -1073,10 +1142,12 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                               ),
                               errorWidget: (context, url, err) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                                 child: Icon(
                                   Icons.live_tv,
                                   size: 18,
@@ -1119,7 +1190,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1184,7 +1256,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                         ),
                         IconButton(
                           icon: const Icon(Icons.info_outline, size: 20),
-                          onPressed: () => _showHistoryDetails(context, ref, widget.instance, item),
+                          onPressed: () => _showHistoryDetails(
+                              context, ref, widget.instance, item),
                         ),
                       ],
                     ),
@@ -1272,16 +1345,20 @@ class _BlocklistView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final blocklistAsync = ref.watch(sonarrBlocklistProvider(instance));
-    final searchQuery = ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
     final grouped = ref.watch(sonarrActivityGroupedProvider(instance));
 
     return blocklistAsync.when(
       data: (List<SonarrBlocklistItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final seriesMatch = item.series?.title.toLowerCase().contains(searchQuery) ?? false;
-          final messageMatch = item.message?.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final seriesMatch =
+              item.series?.title.toLowerCase().contains(searchQuery) ?? false;
+          final messageMatch =
+              item.message?.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || seriesMatch || messageMatch;
         }).toList();
 
@@ -1297,7 +1374,9 @@ class _BlocklistView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  searchQuery.isEmpty ? 'No blocklisted items' : 'No blocklist matches search',
+                  searchQuery.isEmpty
+                      ? 'No blocklisted items'
+                      : 'No blocklist matches search',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -1340,7 +1419,8 @@ class _BlocklistView extends ConsumerWidget {
             },
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
-              itemCount: seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
+              itemCount:
+                  seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
               itemBuilder: (BuildContext context, int index) {
                 if (index < seriesList.length) {
                   final series = seriesList[index];
@@ -1401,7 +1481,8 @@ class _BlocklistView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 FilledButton.tonal(
-                  onPressed: () => ref.invalidate(sonarrBlocklistProvider(instance)),
+                  onPressed: () =>
+                      ref.invalidate(sonarrBlocklistProvider(instance)),
                   child: const Text('Retry'),
                 ),
               ],
@@ -1425,7 +1506,8 @@ class _GroupedBlocklistCard extends ConsumerStatefulWidget {
   final List<SonarrBlocklistItem> items;
 
   @override
-  ConsumerState<_GroupedBlocklistCard> createState() => _GroupedBlocklistCardState();
+  ConsumerState<_GroupedBlocklistCard> createState() =>
+      _GroupedBlocklistCardState();
 }
 
 class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
@@ -1435,15 +1517,18 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final api = ref.watch(sonarrApiProvider(widget.instance)).value;
-    final selection = ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
+    final selection =
+        ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
     final isSelecting = selection.isNotEmpty;
     final groupIds = widget.items.map((i) => i.id).toList();
     final isGroupSelected = groupIds.every(selection.contains);
 
     void toggleGroupSelection() {
-      final notifier = ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier);
+      final notifier =
+          ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier);
       if (isGroupSelected) {
-        notifier.state = selection.where((id) => !groupIds.contains(id)).toSet();
+        notifier.state =
+            selection.where((id) => !groupIds.contains(id)).toSet();
       } else {
         notifier.state = {...selection, ...groupIds};
       }
@@ -1452,7 +1537,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
     String? posterUrl;
     if (widget.series?.images != null && api != null) {
       try {
-        final img = widget.series!.images.firstWhere((i) => i.coverType == 'poster');
+        final img =
+            widget.series!.images.firstWhere((i) => i.coverType == 'poster');
         posterUrl = api.posterUrl(img);
       } catch (_) {}
     }
@@ -1505,10 +1591,12 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   placeholder: (context, url) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
                                   ),
                                   errorWidget: (context, url, err) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
                                     child: Icon(
                                       Icons.live_tv,
                                       size: 18,
@@ -1517,7 +1605,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   ),
                                 )
                               : Container(
-                                  color: theme.colorScheme.surfaceContainerHighest,
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
                                   child: Icon(
                                     Icons.live_tv,
                                     size: 18,
@@ -1526,7 +1615,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                 ),
                           if (isGroupSelected)
                             Container(
-                              color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                              color: theme.colorScheme.primary
+                                  .withValues(alpha: 0.25),
                               child: Center(
                                 child: Container(
                                   padding: const EdgeInsets.all(3),
@@ -1571,7 +1661,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.errorContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1606,9 +1697,12 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   final isItemSelected = selection.contains(item.id);
 
                   void toggleItemSelection() {
-                    final notifier = ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier);
+                    final notifier = ref.read(
+                        sonarrBlocklistSelectionProvider(widget.instance)
+                            .notifier);
                     if (isItemSelected) {
-                      notifier.state = selection.where((id) => id != item.id).toSet();
+                      notifier.state =
+                          selection.where((id) => id != item.id).toSet();
                     } else {
                       notifier.state = {...selection, item.id};
                     }
@@ -1647,12 +1741,14 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,
                                 ),
-                                if (item.message != null && item.message!.isNotEmpty)
+                                if (item.message != null &&
+                                    item.message!.isNotEmpty)
                                   Padding(
                                     padding: const EdgeInsets.only(top: 2),
                                     child: Text(
                                       item.message!,
-                                      style: theme.textTheme.bodySmall?.copyWith(
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
                                         color: theme.colorScheme.error,
                                         fontSize: 11,
                                       ),
@@ -1671,12 +1767,15 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                         ),
                                         margin: const EdgeInsets.only(right: 6),
                                         decoration: BoxDecoration(
-                                          color: theme.colorScheme.surfaceContainerHighest,
-                                          borderRadius: BorderRadius.circular(4),
+                                          color: theme.colorScheme
+                                              .surfaceContainerHighest,
+                                          borderRadius:
+                                              BorderRadius.circular(4),
                                         ),
                                         child: Text(
                                           item.indexer!,
-                                          style: theme.textTheme.bodySmall?.copyWith(
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
                                             fontSize: 9,
                                             fontWeight: FontWeight.w500,
                                           ),
@@ -1684,7 +1783,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                       ),
                                     Text(
                                       _formatDateTime(item.date),
-                                      style: theme.textTheme.bodySmall?.copyWith(
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
                                         color: theme.colorScheme.outline,
                                         fontSize: 10,
                                       ),
@@ -1700,7 +1800,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                 Icons.delete_outline,
                                 color: theme.colorScheme.error,
                               ),
-                              onPressed: () => _confirmDeleteBlocklistItem(context, ref, widget.instance, item),
+                              onPressed: () => _confirmDeleteBlocklistItem(
+                                  context, ref, widget.instance, item),
                             ),
                         ],
                       ),
@@ -1733,7 +1834,8 @@ class _PlainBlocklistCard extends ConsumerWidget {
     final isSelected = selection.contains(item.id);
 
     void toggleSelection() {
-      final notifier = ref.read(sonarrBlocklistSelectionProvider(instance).notifier);
+      final notifier =
+          ref.read(sonarrBlocklistSelectionProvider(instance).notifier);
       if (isSelected) {
         notifier.state = selection.where((id) => id != item.id).toSet();
       } else {
@@ -1810,7 +1912,8 @@ class _PlainBlocklistCard extends ConsumerWidget {
                   Icons.delete_outline,
                   color: theme.colorScheme.error,
                 ),
-                onPressed: () => _confirmDeleteBlocklistItem(context, ref, instance, item),
+                onPressed: () =>
+                    _confirmDeleteBlocklistItem(context, ref, instance, item),
               ),
       ),
     );
@@ -1925,7 +2028,8 @@ void _showHistoryDetails(
             children: <Widget>[
               _DetailRow(label: 'Event Type', value: eventType.toUpperCase()),
               _DetailRow(label: 'Date', value: _formatDateTime(item.date)),
-              _DetailRow(label: 'Source Title', value: item.sourceTitle ?? 'None'),
+              _DetailRow(
+                  label: 'Source Title', value: item.sourceTitle ?? 'None'),
               if (item.downloadId != null)
                 _DetailRow(label: 'Download ID', value: item.downloadId!),
               if (item.data != null && item.data!.isNotEmpty) ...[
@@ -1964,11 +2068,13 @@ void _showHistoryDetails(
         actions: <Widget>[
           if (eventType.toLowerCase() == 'grabbed')
             TextButton(
-              style: TextButton.styleFrom(foregroundColor: theme.colorScheme.error),
+              style: TextButton.styleFrom(
+                  foregroundColor: theme.colorScheme.error),
               onPressed: () async {
                 Navigator.of(context).pop();
                 try {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   await api.failHistoryItem(item.id);
                   ref.invalidate(sonarrHistoryProvider(instance));
                   if (context.mounted) {
@@ -2041,7 +2147,8 @@ void _confirmDeleteBlocklistItem(
                 ref.invalidate(sonarrBlocklistProvider(instance));
                 if (context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Item removed from blocklist.')),
+                    const SnackBar(
+                        content: Text('Item removed from blocklist.')),
                   );
                 }
               } catch (e) {
@@ -2081,6 +2188,7 @@ String _formatDateTime(String? isoDate) {
     return isoDate;
   }
 }
+
 class _ActivityBulkActionsBar extends StatelessWidget {
   const _ActivityBulkActionsBar({
     required this.instance,
@@ -2193,7 +2301,8 @@ class _QueueBulkGrabDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return AlertDialog(
       title: Text('Force Grab ${selectedIds.length} Releases?'),
-      content: const Text('Are you sure you want to force download the selected releases from the queue?'),
+      content: const Text(
+          'Are you sure you want to force download the selected releases from the queue?'),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
@@ -2234,7 +2343,8 @@ class _QueueBulkGrabDialog extends ConsumerWidget {
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Forced grab successfully triggered')),
+              const SnackBar(
+                  content: Text('Forced grab successfully triggered')),
             );
           },
           child: const Text('Force Grab'),
@@ -2256,10 +2366,12 @@ class _QueueBulkDeleteDialog extends ConsumerStatefulWidget {
   final VoidCallback onClear;
 
   @override
-  ConsumerState<_QueueBulkDeleteDialog> createState() => _QueueBulkDeleteDialogState();
+  ConsumerState<_QueueBulkDeleteDialog> createState() =>
+      _QueueBulkDeleteDialogState();
 }
 
-class _QueueBulkDeleteDialogState extends ConsumerState<_QueueBulkDeleteDialog> {
+class _QueueBulkDeleteDialogState
+    extends ConsumerState<_QueueBulkDeleteDialog> {
   bool _blocklist = false;
 
   @override
@@ -2270,7 +2382,8 @@ class _QueueBulkDeleteDialogState extends ConsumerState<_QueueBulkDeleteDialog> 
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('Are you sure you want to remove these items from download client queue?'),
+          const Text(
+              'Are you sure you want to remove these items from download client queue?'),
           const SizedBox(height: 16),
           CheckboxListTile(
             title: const Text('Add items to blocklist'),
@@ -2306,7 +2419,8 @@ class _QueueBulkDeleteDialogState extends ConsumerState<_QueueBulkDeleteDialog> 
             try {
               final api =
                   await ref.read(sonarrApiProvider(widget.instance).future);
-              await api.bulkDeleteQueue(widget.selectedIds.toList(), blocklist: _blocklist);
+              await api.bulkDeleteQueue(widget.selectedIds.toList(),
+                  blocklist: _blocklist);
             } catch (e) {
               error = e;
             } finally {
@@ -2350,7 +2464,8 @@ class _BlocklistBulkDeleteDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return AlertDialog(
       title: Text('Remove ${selectedIds.length} items from Blocklist?'),
-      content: const Text('Are you sure you want to remove these items from blocklist? Sonarr will be able to search and grab these releases again.'),
+      content: const Text(
+          'Are you sure you want to remove these items from blocklist? Sonarr will be able to search and grab these releases again.'),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
@@ -2395,7 +2510,8 @@ class _BlocklistBulkDeleteDialog extends ConsumerWidget {
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Successfully removed items from blocklist')),
+              const SnackBar(
+                  content: Text('Successfully removed items from blocklist')),
             );
           },
           child: const Text('Remove'),
@@ -2404,4 +2520,3 @@ class _BlocklistBulkDeleteDialog extends ConsumerWidget {
     );
   }
 }
-

--- a/services/service_sonarr/lib/src/home/manual_import_dialog.dart
+++ b/services/service_sonarr/lib/src/home/manual_import_dialog.dart
@@ -17,13 +17,15 @@ void showManualImportFlow(
   WidgetRef ref,
   Instance instance,
 ) {
-  unawaited(showDialog<void>(
-    context: context,
-    barrierDismissible: false,
-    builder: (BuildContext context) => _ManualImportSetupDialog(
-      instance: instance,
+  unawaited(
+    showDialog<void>(
+      context: context,
+      barrierDismissible: false,
+      builder: (BuildContext context) => _ManualImportSetupDialog(
+        instance: instance,
+      ),
     ),
-  ),);
+  );
 }
 
 class _ManualImportSetupDialog extends ConsumerStatefulWidget {
@@ -68,9 +70,8 @@ class __ManualImportSetupDialogState
       setState(() {
         _pathController.text = selectedPath;
       });
-      ref
-          .read(sonarrManualImportPathProvider(widget.instance).notifier)
-          .state = selectedPath;
+      ref.read(sonarrManualImportPathProvider(widget.instance).notifier).state =
+          selectedPath;
     }
   }
 
@@ -87,62 +88,67 @@ class __ManualImportSetupDialogState
 
     // Show loading overlay
     final NavigatorState nav = Navigator.of(context, rootNavigator: true);
-    unawaited(showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext dialogContext) => PopScope<Object?>(
-        canPop: false,
-        child: Center(
-          child: Card(
-            margin: const EdgeInsets.symmetric(horizontal: 32),
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                children: <Widget>[
-                  const ExpressiveProgressIndicator(),
-                  const SizedBox(height: 16),
-                  const Text('Scanning folder contents...'),
-                  const SizedBox(height: 24),
-                  Row(
-                    mainAxisAlignment: MainAxisAlignment.end,
-                    children: <Widget>[
-                      TextButton(
-                        onPressed: () async {
-                          final bool? confirm = await showDialog<bool>(
-                            context: dialogContext,
-                            builder: (BuildContext confirmContext) => AlertDialog(
-                              title: const Text('Cancel Scan?'),
-                              content: const Text(
-                                'Are you sure you want to stop scanning this folder?',
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext dialogContext) => PopScope<Object?>(
+          canPop: false,
+          child: Center(
+            child: Card(
+              margin: const EdgeInsets.symmetric(horizontal: 32),
+              child: Padding(
+                padding: const EdgeInsets.all(24.0),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: <Widget>[
+                    const ExpressiveProgressIndicator(),
+                    const SizedBox(height: 16),
+                    const Text('Scanning folder contents...'),
+                    const SizedBox(height: 24),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.end,
+                      children: <Widget>[
+                        TextButton(
+                          onPressed: () async {
+                            final bool? confirm = await showDialog<bool>(
+                              context: dialogContext,
+                              builder: (BuildContext confirmContext) =>
+                                  AlertDialog(
+                                title: const Text('Cancel Scan?'),
+                                content: const Text(
+                                  'Are you sure you want to stop scanning this folder?',
+                                ),
+                                actions: <Widget>[
+                                  TextButton(
+                                    onPressed: () =>
+                                        Navigator.pop(confirmContext, false),
+                                    child: const Text('No'),
+                                  ),
+                                  TextButton(
+                                    onPressed: () =>
+                                        Navigator.pop(confirmContext, true),
+                                    child: const Text('Yes, Cancel'),
+                                  ),
+                                ],
                               ),
-                              actions: <Widget>[
-                                TextButton(
-                                  onPressed: () => Navigator.pop(confirmContext, false),
-                                  child: const Text('No'),
-                                ),
-                                TextButton(
-                                  onPressed: () => Navigator.pop(confirmContext, true),
-                                  child: const Text('Yes, Cancel'),
-                                ),
-                              ],
-                            ),
-                          );
-                          if (confirm == true) {
-                            cancelToken.cancel('user_cancelled');
-                          }
-                        },
-                        child: const Text('Cancel'),
-                      ),
-                    ],
-                  ),
-                ],
+                            );
+                            if (confirm == true) {
+                              cancelToken.cancel('user_cancelled');
+                            }
+                          },
+                          child: const Text('Cancel'),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
               ),
             ),
           ),
         ),
       ),
-    ),);
+    );
 
     Object? error;
     List<dynamic> scanResults = const <dynamic>[];
@@ -186,21 +192,24 @@ class __ManualImportSetupDialogState
 
     // Close setup dialog and open mapping screen
     Navigator.pop(context);
-    unawaited(nav.push<void>(
-      MaterialPageRoute<void>(
-        builder: (BuildContext context) => _ManualImportMappingScreen(
-          instance: widget.instance,
-          initialFiles: scanResults,
-          folderPath: folder,
+    unawaited(
+      nav.push<void>(
+        MaterialPageRoute<void>(
+          builder: (BuildContext context) => _ManualImportMappingScreen(
+            instance: widget.instance,
+            initialFiles: scanResults,
+            folderPath: folder,
+          ),
         ),
       ),
-    ),);
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final String mode = ref.watch(sonarrManualImportModeProvider(widget.instance));
+    final String mode =
+        ref.watch(sonarrManualImportModeProvider(widget.instance));
     final bool filterExisting =
         ref.watch(sonarrManualImportFilterProvider(widget.instance));
 
@@ -236,7 +245,8 @@ class __ManualImportSetupDialogState
                     ),
                     onChanged: (String val) {
                       ref
-                          .read(sonarrManualImportPathProvider(widget.instance).notifier)
+                          .read(sonarrManualImportPathProvider(widget.instance)
+                              .notifier)
                           .state = val;
                     },
                   ),
@@ -269,7 +279,8 @@ class __ManualImportSetupDialogState
               onChanged: (String? val) {
                 if (val != null) {
                   ref
-                      .read(sonarrManualImportModeProvider(widget.instance).notifier)
+                      .read(sonarrManualImportModeProvider(widget.instance)
+                          .notifier)
                       .state = val;
                 }
               },
@@ -282,7 +293,8 @@ class __ManualImportSetupDialogState
               value: filterExisting,
               onChanged: (bool val) {
                 ref
-                    .read(sonarrManualImportFilterProvider(widget.instance).notifier)
+                    .read(sonarrManualImportFilterProvider(widget.instance)
+                        .notifier)
                     .state = val;
               },
             ),
@@ -431,7 +443,8 @@ class __DirectoryBrowserDialogState
                     if (segments.isNotEmpty && !isWindows)
                       Text('/', style: theme.textTheme.bodyMedium),
                     for (int i = 0; i < segments.length; i++) ...<Widget>[
-                      if (i > 0) Text(separator, style: theme.textTheme.bodyMedium),
+                      if (i > 0)
+                        Text(separator, style: theme.textTheme.bodyMedium),
                       TextButton(
                         style: TextButton.styleFrom(
                           minimumSize: Size.zero,
@@ -442,7 +455,8 @@ class __DirectoryBrowserDialogState
                           tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                         ),
                         onPressed: () {
-                          final List<String> subSegments = segments.sublist(0, i + 1);
+                          final List<String> subSegments =
+                              segments.sublist(0, i + 1);
                           final String target = isWindows
                               ? subSegments.join('\\')
                               : '/${subSegments.join('/')}';
@@ -505,7 +519,8 @@ class __DirectoryBrowserDialogState
                       : _directories.isEmpty
                           ? const Center(child: Text('No directories found.'))
                           : ListView.builder(
-                              itemCount: _directories.length + (segments.isNotEmpty ? 1 : 0),
+                              itemCount: _directories.length +
+                                  (segments.isNotEmpty ? 1 : 0),
                               itemBuilder: (BuildContext context, int index) {
                                 if (segments.isNotEmpty && index == 0) {
                                   return ListTile(
@@ -515,15 +530,20 @@ class __DirectoryBrowserDialogState
                                   );
                                 }
 
-                                final int dataIndex = segments.isNotEmpty ? index - 1 : index;
-                                final dir = _directories[dataIndex] as Map<String, dynamic>;
-                                final String name = (dir['name'] as String?) ?? 'Unknown';
-                                final String fullPath = (dir['path'] as String?) ?? '';
+                                final int dataIndex =
+                                    segments.isNotEmpty ? index - 1 : index;
+                                final dir = _directories[dataIndex]
+                                    as Map<String, dynamic>;
+                                final String name =
+                                    (dir['name'] as String?) ?? 'Unknown';
+                                final String fullPath =
+                                    (dir['path'] as String?) ?? '';
 
                                 return ListTile(
                                   leading: const Icon(Icons.folder),
                                   title: Text(name),
-                                  trailing: const Icon(Icons.chevron_right, size: 16),
+                                  trailing:
+                                      const Icon(Icons.chevron_right, size: 16),
                                   onTap: () {
                                     _navigateTo(fullPath);
                                   },
@@ -540,7 +560,8 @@ class __DirectoryBrowserDialogState
           child: const Text('Cancel'),
         ),
         FilledButton(
-          onPressed: _loading ? null : () => Navigator.pop(context, _currentPath),
+          onPressed:
+              _loading ? null : () => Navigator.pop(context, _currentPath),
           child: const Text('Select Folder'),
         ),
       ],
@@ -612,7 +633,8 @@ class __ManualImportMappingScreenState
     super.initState();
     // Copy the items locally so they are mutable, filtering out non-video files
     final List<Map<String, dynamic>> rawFiles = List<Map<String, dynamic>>.from(
-      widget.initialFiles.map((dynamic f) => Map<String, dynamic>.from(f as Map)),
+      widget.initialFiles
+          .map((dynamic f) => Map<String, dynamic>.from(f as Map)),
     );
     _files = rawFiles.where(_isVideoFile).toList();
 
@@ -709,14 +731,16 @@ class __ManualImportMappingScreenState
 
     // Show loading spinner
     final NavigatorState nav = Navigator.of(context, rootNavigator: true);
-    unawaited(showDialog<void>(
-      context: context,
-      barrierDismissible: false,
-      builder: (BuildContext context) => const PopScope<Object?>(
-        canPop: false,
-        child: Center(child: ExpressiveProgressIndicator()),
+    unawaited(
+      showDialog<void>(
+        context: context,
+        barrierDismissible: false,
+        builder: (BuildContext context) => const PopScope<Object?>(
+          canPop: false,
+          child: Center(child: ExpressiveProgressIndicator()),
+        ),
       ),
-    ),);
+    );
 
     Object? error;
     List<SonarrEpisode> allEpisodes = const <SonarrEpisode>[];
@@ -738,9 +762,8 @@ class __ManualImportMappingScreenState
       return;
     }
 
-    final List<SonarrEpisode> seasonEpisodes = allEpisodes
-        .where((e) => e.seasonNumber == seasonNumber)
-        .toList();
+    final List<SonarrEpisode> seasonEpisodes =
+        allEpisodes.where((e) => e.seasonNumber == seasonNumber).toList();
 
     if (seasonEpisodes.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -777,20 +800,18 @@ class __ManualImportMappingScreenState
   }
 
   Future<void> _executeImport() async {
-    final List<Map<String, dynamic>> importList = _files
-        .cast<Map<String, dynamic>>()
-        .where((f) {
-          final String? path = f['path'] as String?;
-          final dynamic series = f['series'];
-          final List<dynamic>? episodes = f['episodes'] as List<dynamic>?;
+    final List<Map<String, dynamic>> importList =
+        _files.cast<Map<String, dynamic>>().where((f) {
+      final String? path = f['path'] as String?;
+      final dynamic series = f['series'];
+      final List<dynamic>? episodes = f['episodes'] as List<dynamic>?;
 
-          return path != null &&
-              _selectedPaths.contains(path) &&
-              series != null &&
-              episodes != null &&
-              episodes.isNotEmpty;
-        })
-        .toList();
+      return path != null &&
+          _selectedPaths.contains(path) &&
+          series != null &&
+          episodes != null &&
+          episodes.isNotEmpty;
+    }).toList();
 
     if (importList.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -835,7 +856,9 @@ class __ManualImportMappingScreenState
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Import command triggered for ${importList.length} files.')),
+          SnackBar(
+              content: Text(
+                  'Import command triggered for ${importList.length} files.')),
         );
         Navigator.pop(context); // Close the mapping screen
       }
@@ -930,12 +953,15 @@ class __ManualImportMappingScreenState
                     itemBuilder: (BuildContext context, int index) {
                       final f = _files[index] as Map<String, dynamic>;
                       final String pathStr = (f['path'] as String?) ?? '';
-                      final String relativePath = (f['relativePath'] as String?) ?? pathStr;
+                      final String relativePath =
+                          (f['relativePath'] as String?) ?? pathStr;
                       final int bytes = (f['size'] as int?) ?? 0;
                       final series = f['series'] as Map<String, dynamic>?;
                       final int? season = f['seasonNumber'] as int?;
-                      final List<dynamic>? episodes = f['episodes'] as List<dynamic>?;
-                      final List<dynamic>? rejections = f['rejections'] as List<dynamic>?;
+                      final List<dynamic>? episodes =
+                          f['episodes'] as List<dynamic>?;
+                      final List<dynamic>? rejections =
+                          f['rejections'] as List<dynamic>?;
                       final bool isSelected = _selectedPaths.contains(pathStr);
 
                       // Parse quality
@@ -957,7 +983,8 @@ class __ManualImportMappingScreenState
                           side: BorderSide(
                             color: isSelected
                                 ? theme.colorScheme.primary
-                                : theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+                                : theme.colorScheme.outlineVariant
+                                    .withValues(alpha: 0.5),
                             width: isSelected ? 2.0 : 1.0,
                           ),
                           borderRadius: BorderRadius.circular(12),
@@ -984,11 +1011,13 @@ class __ManualImportMappingScreenState
                                   ),
                                   Expanded(
                                     child: Column(
-                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      crossAxisAlignment:
+                                          CrossAxisAlignment.start,
                                       children: <Widget>[
                                         Text(
                                           relativePath,
-                                          style: theme.textTheme.bodyMedium?.copyWith(
+                                          style: theme.textTheme.bodyMedium
+                                              ?.copyWith(
                                             fontWeight: FontWeight.bold,
                                           ),
                                           maxLines: 2,
@@ -997,8 +1026,10 @@ class __ManualImportMappingScreenState
                                         const SizedBox(height: 2),
                                         Text(
                                           '${_formatSize(bytes)} • $qName',
-                                          style: theme.textTheme.bodySmall?.copyWith(
-                                            color: theme.colorScheme.onSurfaceVariant,
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                            color: theme
+                                                .colorScheme.onSurfaceVariant,
                                           ),
                                         ),
                                       ],
@@ -1008,15 +1039,18 @@ class __ManualImportMappingScreenState
                               ),
                               const Divider(height: 16),
                               // Rejection notes if any
-                              if (rejections != null && rejections.isNotEmpty) ...<Widget>[
+                              if (rejections != null &&
+                                  rejections.isNotEmpty) ...<Widget>[
                                 Container(
                                   padding: const EdgeInsets.all(8),
                                   margin: const EdgeInsets.only(bottom: 12),
                                   decoration: BoxDecoration(
-                                    color: theme.colorScheme.errorContainer.withValues(alpha: 0.2),
+                                    color: theme.colorScheme.errorContainer
+                                        .withValues(alpha: 0.2),
                                     borderRadius: BorderRadius.circular(8),
                                     border: Border.all(
-                                      color: theme.colorScheme.error.withValues(alpha: 0.4),
+                                      color: theme.colorScheme.error
+                                          .withValues(alpha: 0.4),
                                     ),
                                   ),
                                   child: Row(
@@ -1033,8 +1067,10 @@ class __ManualImportMappingScreenState
                                               .cast<Map<String, dynamic>>()
                                               .map((r) => r['reason'] as String)
                                               .join(', '),
-                                          style: theme.textTheme.bodySmall?.copyWith(
-                                            color: theme.colorScheme.onErrorContainer,
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
+                                            color: theme
+                                                .colorScheme.onErrorContainer,
                                           ),
                                         ),
                                       ),
@@ -1056,29 +1092,39 @@ class __ManualImportMappingScreenState
                                           : 'Select Series',
                                     ),
                                     backgroundColor: series == null
-                                        ? theme.colorScheme.errorContainer.withValues(alpha: 0.3)
+                                        ? theme.colorScheme.errorContainer
+                                            .withValues(alpha: 0.3)
                                         : null,
-                                    onPressed: () => _selectSeriesForFile(index),
+                                    onPressed: () =>
+                                        _selectSeriesForFile(index),
                                   ),
                                   // Season number dropdown
                                   if (series != null)
                                     ActionChip(
-                                      avatar: const Icon(Icons.calendar_view_day, size: 14),
+                                      avatar: const Icon(
+                                          Icons.calendar_view_day,
+                                          size: 14),
                                       label: Text(
-                                        season != null ? 'Season $season' : 'Season ?',
+                                        season != null
+                                            ? 'Season $season'
+                                            : 'Season ?',
                                       ),
                                       onPressed: () async {
-                                        final int? nextSeason = await showDialog<int>(
+                                        final int? nextSeason =
+                                            await showDialog<int>(
                                           context: context,
-                                          builder: (BuildContext context) => _SeasonPickerDialog(
-                                            seasonNumbers: _seasonNumbersFor(series),
+                                          builder: (BuildContext context) =>
+                                              _SeasonPickerDialog(
+                                            seasonNumbers:
+                                                _seasonNumbersFor(series),
                                             initialSeason: season ?? 1,
                                           ),
                                         );
                                         if (nextSeason != null) {
                                           setState(() {
                                             f['seasonNumber'] = nextSeason;
-                                            f['episodes'] = <dynamic>[]; // Reset mapped ep
+                                            f['episodes'] =
+                                                <dynamic>[]; // Reset mapped ep
                                           });
                                         }
                                       },
@@ -1086,16 +1132,20 @@ class __ManualImportMappingScreenState
                                   // Episodes list
                                   if (series != null)
                                     ActionChip(
-                                      avatar: const Icon(Icons.numbers, size: 14),
+                                      avatar:
+                                          const Icon(Icons.numbers, size: 14),
                                       label: Text(
                                         episodes != null && episodes.isNotEmpty
                                             ? 'Episode ${episodes.cast<Map<String, dynamic>>().map((e) => e['episodeNumber'].toString()).join(', ')}'
                                             : 'Select Episode(s)',
                                       ),
-                                      backgroundColor: episodes == null || episodes.isEmpty
-                                          ? theme.colorScheme.errorContainer.withValues(alpha: 0.3)
-                                          : null,
-                                      onPressed: () => _selectEpisodesForFile(index),
+                                      backgroundColor:
+                                          episodes == null || episodes.isEmpty
+                                              ? theme.colorScheme.errorContainer
+                                                  .withValues(alpha: 0.3)
+                                              : null,
+                                      onPressed: () =>
+                                          _selectEpisodesForFile(index),
                                     ),
                                 ],
                               ),
@@ -1113,7 +1163,8 @@ class __ManualImportMappingScreenState
               color: theme.colorScheme.surfaceContainer,
               border: Border(
                 top: BorderSide(
-                  color: theme.colorScheme.outlineVariant.withValues(alpha: 0.3),
+                  color:
+                      theme.colorScheme.outlineVariant.withValues(alpha: 0.3),
                 ),
               ),
             ),
@@ -1204,7 +1255,8 @@ class _SeriesPickerDialogState extends State<_SeriesPickerDialog> {
                   final SonarrSeries s = _filtered[index];
                   return ListTile(
                     title: Text(s.title),
-                    subtitle: Text('${s.network ?? 'Unknown'} • ${s.year ?? ''}'),
+                    subtitle:
+                        Text('${s.network ?? 'Unknown'} • ${s.year ?? ''}'),
                     onTap: () {
                       Navigator.pop(context, s);
                     },

--- a/services/service_sonarr/lib/src/home/series_tab.dart
+++ b/services/service_sonarr/lib/src/home/series_tab.dart
@@ -128,14 +128,18 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
               instance: widget.instance,
               selectedIds: selection,
               onClear: () {
-                ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier).state = {};
+                ref
+                    .read(
+                        sonarrSeriesSelectionProvider(widget.instance).notifier)
+                    .state = {};
               },
             )
           : null,
-      floatingActionButton: !isSelecting && ref.watch(
-                sonarrActiveTabBarIndexProvider(widget.instance),
-              ) ==
-              0
+      floatingActionButton: !isSelecting &&
+              ref.watch(
+                    sonarrActiveTabBarIndexProvider(widget.instance),
+                  ) ==
+                  0
           ? Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.end,
@@ -165,7 +169,8 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                     Navigator.of(context, rootNavigator: true).push(
                       FadePageRoute<void>(
                         builder: (BuildContext context) =>
-                            SonarrAddSeriesSearchScreen(instance: widget.instance),
+                            SonarrAddSeriesSearchScreen(
+                                instance: widget.instance),
                       ),
                     );
                   },
@@ -180,8 +185,7 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
         behavior: HitTestBehavior.translucent,
         child: AsyncValueView<List<SonarrSeries>>(
           value: filtered,
-          onRetry: () =>
-              ref.invalidate(sonarrSeriesProvider(widget.instance)),
+          onRetry: () => ref.invalidate(sonarrSeriesProvider(widget.instance)),
           data: (List<SonarrSeries> list) {
             return M3RefreshIndicator(
               onRefresh: () async {
@@ -205,7 +209,11 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                         ? IconButton(
                             icon: const Icon(Icons.close),
                             onPressed: () {
-                              ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier).state = {};
+                              ref
+                                  .read(sonarrSeriesSelectionProvider(
+                                          widget.instance)
+                                      .notifier)
+                                  .state = {};
                             },
                           )
                         : IconButton(
@@ -273,7 +281,9 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                               tooltip: 'Select all',
                               onPressed: () {
                                 ref
-                                    .read(sonarrSeriesSelectionProvider(widget.instance).notifier)
+                                    .read(sonarrSeriesSelectionProvider(
+                                            widget.instance)
+                                        .notifier)
                                     .state = list.map((s) => s.id).toSet();
                               },
                             )
@@ -283,7 +293,9 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                               tooltip: 'Deselect all',
                               onPressed: () {
                                 ref
-                                    .read(sonarrSeriesSelectionProvider(widget.instance).notifier)
+                                    .read(sonarrSeriesSelectionProvider(
+                                            widget.instance)
+                                        .notifier)
                                     .state = {};
                               },
                             ),
@@ -354,18 +366,28 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                                   : api?.posterUrl(poster, width: 500),
                               selected: isSelected,
                               onLongPress: () {
-                                final notifier = ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier);
+                                final notifier = ref.read(
+                                    sonarrSeriesSelectionProvider(
+                                            widget.instance)
+                                        .notifier);
                                 if (isSelected) {
-                                  notifier.state = selection.where((id) => id != s.id).toSet();
+                                  notifier.state = selection
+                                      .where((id) => id != s.id)
+                                      .toSet();
                                 } else {
                                   notifier.state = {...selection, s.id};
                                 }
                               },
                               onTap: () {
                                 if (isSelecting) {
-                                  final notifier = ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier);
+                                  final notifier = ref.read(
+                                      sonarrSeriesSelectionProvider(
+                                              widget.instance)
+                                          .notifier);
                                   if (isSelected) {
-                                    notifier.state = selection.where((id) => id != s.id).toSet();
+                                    notifier.state = selection
+                                        .where((id) => id != s.id)
+                                        .toSet();
                                   } else {
                                     notifier.state = {...selection, s.id};
                                   }
@@ -401,17 +423,21 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                           (BuildContext context, int index) {
                             final SonarrSeries s = list[index];
                             return Padding(
-                              padding:
-                                  const EdgeInsets.only(bottom: Insets.md),
+                              padding: const EdgeInsets.only(bottom: Insets.md),
                               child: _SeriesBannerCard(
                                 instance: widget.instance,
                                 series: s,
                                 selected: selection.contains(s.id),
                                 onLongPress: () {
                                   final isSelected = selection.contains(s.id);
-                                  final notifier = ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier);
+                                  final notifier = ref.read(
+                                      sonarrSeriesSelectionProvider(
+                                              widget.instance)
+                                          .notifier);
                                   if (isSelected) {
-                                    notifier.state = selection.where((id) => id != s.id).toSet();
+                                    notifier.state = selection
+                                        .where((id) => id != s.id)
+                                        .toSet();
                                   } else {
                                     notifier.state = {...selection, s.id};
                                   }
@@ -419,9 +445,14 @@ class _SeriesTabState extends ConsumerState<SeriesTab>
                                 onTap: () {
                                   final isSelected = selection.contains(s.id);
                                   if (isSelecting) {
-                                    final notifier = ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier);
+                                    final notifier = ref.read(
+                                        sonarrSeriesSelectionProvider(
+                                                widget.instance)
+                                            .notifier);
                                     if (isSelected) {
-                                      notifier.state = selection.where((id) => id != s.id).toSet();
+                                      notifier.state = selection
+                                          .where((id) => id != s.id)
+                                          .toSet();
                                     } else {
                                       notifier.state = {...selection, s.id};
                                     }
@@ -498,7 +529,8 @@ class _SeriesCard extends StatelessWidget {
                   if (selected)
                     Positioned.fill(
                       child: Container(
-                        color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                        color:
+                            theme.colorScheme.primary.withValues(alpha: 0.25),
                         child: Center(
                           child: Container(
                             padding: const EdgeInsets.all(6),
@@ -844,6 +876,7 @@ class FadePageRoute<T> extends PageRouteBuilder<T> {
           reverseTransitionDuration: const Duration(milliseconds: 250),
         );
 }
+
 class _BulkActionsBar extends StatelessWidget {
   const _BulkActionsBar({
     required this.instance,
@@ -938,7 +971,8 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
 
   @override
   Widget build(BuildContext context) {
-    final profilesAsync = ref.watch(sonarrQualityProfilesProvider(widget.instance));
+    final profilesAsync =
+        ref.watch(sonarrQualityProfilesProvider(widget.instance));
     final foldersAsync = ref.watch(sonarrRootFoldersProvider(widget.instance));
 
     return AlertDialog(
@@ -986,10 +1020,12 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
                 ),
                 items: [
                   const DropdownMenuItem(child: Text('Keep current')),
-                  ...profiles.map((p) => DropdownMenuItem(
-                        value: p['id'] as int,
-                        child: Text(p['name'] as String),
-                      ),),
+                  ...profiles.map(
+                    (p) => DropdownMenuItem(
+                      value: p['id'] as int,
+                      child: Text(p['name'] as String),
+                    ),
+                  ),
                 ],
                 onChanged: (val) => setState(() => _qualityProfileId = val),
               ),
@@ -1009,10 +1045,12 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
                 ),
                 items: [
                   const DropdownMenuItem(child: Text('Keep current')),
-                  ...folders.map((f) => DropdownMenuItem(
-                        value: f['path'] as String,
-                        child: Text(f['path'] as String),
-                      ),),
+                  ...folders.map(
+                    (f) => DropdownMenuItem(
+                      value: f['path'] as String,
+                      child: Text(f['path'] as String),
+                    ),
+                  ),
                 ],
                 onChanged: (val) => setState(() => _rootFolderPath = val),
               ),
@@ -1037,19 +1075,22 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
             final payload = <String, dynamic>{
               'seriesIds': widget.selectedIds.toList(),
               if (_monitored != null) 'monitored': _monitored,
-              if (_qualityProfileId != null) 'qualityProfileId': _qualityProfileId,
+              if (_qualityProfileId != null)
+                'qualityProfileId': _qualityProfileId,
               if (_seriesType != null) 'seriesType': _seriesType,
               if (_rootFolderPath != null) 'rootFolderPath': _rootFolderPath,
             };
 
-            unawaited(showDialog<void>(
-              context: context,
-              barrierDismissible: false,
-              builder: (ctx) => const PopScope<Object?>(
-                canPop: false,
-                child: Center(child: ExpressiveProgressIndicator()),
+            unawaited(
+              showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (ctx) => const PopScope<Object?>(
+                  canPop: false,
+                  child: Center(child: ExpressiveProgressIndicator()),
+                ),
               ),
-            ),);
+            );
 
             Object? error;
             try {
@@ -1070,7 +1111,9 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
               return;
             }
             ref.invalidate(sonarrSeriesProvider(widget.instance));
-            ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier).state = {};
+            ref
+                .read(sonarrSeriesSelectionProvider(widget.instance).notifier)
+                .state = {};
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
@@ -1108,7 +1151,8 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('Are you sure you want to delete these series? This action cannot be undone.'),
+          const Text(
+              'Are you sure you want to delete these series? This action cannot be undone.'),
           const SizedBox(height: 16),
           CheckboxListTile(
             title: const Text('Delete all files from disk'),
@@ -1131,20 +1175,23 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
           onPressed: () async {
             final NavigatorState nav =
                 Navigator.of(context, rootNavigator: true);
-            unawaited(showDialog<void>(
-              context: context,
-              barrierDismissible: false,
-              builder: (ctx) => const PopScope<Object?>(
-                canPop: false,
-                child: Center(child: ExpressiveProgressIndicator()),
+            unawaited(
+              showDialog<void>(
+                context: context,
+                barrierDismissible: false,
+                builder: (ctx) => const PopScope<Object?>(
+                  canPop: false,
+                  child: Center(child: ExpressiveProgressIndicator()),
+                ),
               ),
-            ),);
+            );
 
             Object? error;
             try {
               final api =
                   await ref.read(sonarrApiProvider(widget.instance).future);
-              await api.bulkDeleteSeries(widget.selectedIds.toList(), deleteFiles: _deleteFiles);
+              await api.bulkDeleteSeries(widget.selectedIds.toList(),
+                  deleteFiles: _deleteFiles);
             } catch (e) {
               error = e;
             } finally {
@@ -1159,7 +1206,9 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
               return;
             }
             ref.invalidate(sonarrSeriesProvider(widget.instance));
-            ref.read(sonarrSeriesSelectionProvider(widget.instance).notifier).state = {};
+            ref
+                .read(sonarrSeriesSelectionProvider(widget.instance).notifier)
+                .state = {};
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
@@ -1183,7 +1232,8 @@ class _SortFilterBottomSheet extends ConsumerWidget {
     final theme = Theme.of(context);
 
     final sortField = ref.watch(sonarrSeriesSortFieldProvider(instance));
-    final sortAscending = ref.watch(sonarrSeriesSortAscendingProvider(instance));
+    final sortAscending =
+        ref.watch(sonarrSeriesSortAscendingProvider(instance));
     final filter = ref.watch(sonarrSeriesFilterProvider(instance));
 
     return SafeArea(
@@ -1258,7 +1308,8 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                     onSelected: (val) {
                       if (val) {
                         ref
-                            .read(sonarrSeriesSortFieldProvider(instance).notifier)
+                            .read(sonarrSeriesSortFieldProvider(instance)
+                                .notifier)
                             .state = field;
                       }
                     },
@@ -1289,7 +1340,8 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                 selected: {sortAscending},
                 onSelectionChanged: (val) {
                   ref
-                      .read(sonarrSeriesSortAscendingProvider(instance).notifier)
+                      .read(
+                          sonarrSeriesSortAscendingProvider(instance).notifier)
                       .state = val.first;
                 },
               ),
@@ -1313,4 +1365,3 @@ String _formatSize(int bytes) {
   }
   return '${dBytes.toStringAsFixed(1)} ${suffixes[i]}';
 }
-

--- a/services/service_sonarr/lib/src/home/settings/connect_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/connect_settings_screen.dart
@@ -16,7 +16,9 @@ class ConnectSettingsScreen extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectNotificationPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(sonarrNotificationSchemaProvider(instance));
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
@@ -60,7 +62,11 @@ class ConnectSettingsScreen extends ConsumerWidget {
                       onTap: () {
                         Navigator.pop(context);
                         _showNotificationEditorDialog(
-                            context, ref, preset, isNew: true,);
+                          context,
+                          ref,
+                          preset,
+                          isNew: true,
+                        );
                       },
                     );
                   },
@@ -74,8 +80,11 @@ class ConnectSettingsScreen extends ConsumerWidget {
   }
 
   Future<void> _showNotificationEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> notification,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> notification, {
+    bool isNew = false,
+  }) async {
     final fields = (notification['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -100,9 +109,11 @@ class ConnectSettingsScreen extends ConsumerWidget {
         return StatefulBuilder(
           builder: (context, setDialogState) {
             return AlertDialog(
-              title: Text(isNew
-                  ? 'Add ${notification['name']}'
-                  : 'Edit ${notification['name']}',),
+              title: Text(
+                isNew
+                    ? 'Add ${notification['name']}'
+                    : 'Edit ${notification['name']}',
+              ),
               content: SizedBox(
                 width: double.maxFinite,
                 child: SingleChildScrollView(
@@ -122,7 +133,8 @@ class ConnectSettingsScreen extends ConsumerWidget {
                         elevation: 0,
                         shape: RoundedRectangleBorder(
                           side: BorderSide(
-                              color: Theme.of(context).colorScheme.outlineVariant,),
+                            color: Theme.of(context).colorScheme.outlineVariant,
+                          ),
                           borderRadius: Radii.card,
                         ),
                         child: Padding(
@@ -148,50 +160,54 @@ class ConnectSettingsScreen extends ConsumerWidget {
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Download'),
                                 value: onDownload,
-                                onChanged: (val) =>
-                                    setDialogState(() => onDownload = val ?? false),
+                                onChanged: (val) => setDialogState(
+                                    () => onDownload = val ?? false),
                               ),
                               CheckboxListTile(
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Upgrade'),
                                 value: onUpgrade,
-                                onChanged: (val) =>
-                                    setDialogState(() => onUpgrade = val ?? false),
+                                onChanged: (val) => setDialogState(
+                                    () => onUpgrade = val ?? false),
                               ),
                               CheckboxListTile(
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Rename'),
                                 value: onRename,
-                                onChanged: (val) =>
-                                    setDialogState(() => onRename = val ?? false),
+                                onChanged: (val) => setDialogState(
+                                    () => onRename = val ?? false),
                               ),
                               CheckboxListTile(
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Series Add'),
                                 value: onSeriesAdd,
                                 onChanged: (val) => setDialogState(
-                                    () => onSeriesAdd = val ?? false,),
+                                  () => onSeriesAdd = val ?? false,
+                                ),
                               ),
                               CheckboxListTile(
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Series Delete'),
                                 value: onSeriesDelete,
                                 onChanged: (val) => setDialogState(
-                                    () => onSeriesDelete = val ?? false,),
+                                  () => onSeriesDelete = val ?? false,
+                                ),
                               ),
                               CheckboxListTile(
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Episode File Delete'),
                                 value: onEpisodeFileDelete,
                                 onChanged: (val) => setDialogState(
-                                    () => onEpisodeFileDelete = val ?? false,),
+                                  () => onEpisodeFileDelete = val ?? false,
+                                ),
                               ),
                               CheckboxListTile(
                                 contentPadding: EdgeInsets.zero,
                                 title: const Text('On Health Issue'),
                                 value: onHealthIssue,
                                 onChanged: (val) => setDialogState(
-                                    () => onHealthIssue = val ?? false,),
+                                  () => onHealthIssue = val ?? false,
+                                ),
                               ),
                             ],
                           ),
@@ -242,21 +258,26 @@ class ConnectSettingsScreen extends ConsumerWidget {
                               await api.updateNotification(payload);
                             }
 
-                            ref.invalidate(sonarrNotificationsProvider(instance));
+                            ref.invalidate(
+                                sonarrNotificationsProvider(instance));
                             if (context.mounted) {
                               Navigator.pop(context);
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
-                                    content: Text(
-                                        'Notification ${isNew ? 'added' : 'updated'}!',),),
+                                  content: Text(
+                                    'Notification ${isNew ? 'added' : 'updated'}!',
+                                  ),
+                                ),
                               );
                             }
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
-                                    content: Text(
-                                        'Failed to save notification: $e',),),
+                                  content: Text(
+                                    'Failed to save notification: $e',
+                                  ),
+                                ),
                               );
                             }
                           }
@@ -274,7 +295,10 @@ class ConnectSettingsScreen extends ConsumerWidget {
   }
 
   Future<void> _deleteNotification(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     if (!await confirmDelete(context, 'this notification')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -315,7 +339,8 @@ class ConnectSettingsScreen extends ConsumerWidget {
         data: (notifications) {
           if (notifications.isEmpty) {
             return const Center(
-                child: Text('No notification connections configured.'),);
+              child: Text('No notification connections configured.'),
+            );
           }
 
           return ListView.builder(
@@ -329,14 +354,16 @@ class ConnectSettingsScreen extends ConsumerWidget {
                   (notification['implementationName'] as String?) ?? '';
 
               final List<String> activeEvents = [];
-              if (notification['onGrab'] as bool? ?? false) activeEvents.add('Grab');
+              if (notification['onGrab'] as bool? ?? false)
+                activeEvents.add('Grab');
               if (notification['onDownload'] as bool? ?? false) {
                 activeEvents.add('Download');
               }
               if (notification['onUpgrade'] as bool? ?? false) {
                 activeEvents.add('Upgrade');
               }
-              if (notification['onRename'] as bool? ?? false) activeEvents.add('Rename');
+              if (notification['onRename'] as bool? ?? false)
+                activeEvents.add('Rename');
               if (notification['onSeriesAdd'] as bool? ?? false) {
                 activeEvents.add('Series Add');
               }
@@ -359,14 +386,18 @@ class ConnectSettingsScreen extends ConsumerWidget {
                     ),
                   ),
                   subtitle: Text(
-                      '$implementation\nEvents: ${activeEvents.isEmpty ? 'None' : activeEvents.join(', ')}',),
+                    '$implementation\nEvents: ${activeEvents.isEmpty ? 'None' : activeEvents.join(', ')}',
+                  ),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
                         onPressed: () => _showNotificationEditorDialog(
-                            context, ref, notification,),
+                          context,
+                          ref,
+                          notification,
+                        ),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),

--- a/services/service_sonarr/lib/src/home/settings/download_clients_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/download_clients_screen.dart
@@ -71,7 +71,9 @@ class _DownloadClientsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectClientPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(sonarrDownloadClientSchemaProvider(instance));
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
@@ -114,7 +116,8 @@ class _DownloadClientsTab extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showClientEditorDialog(context, ref, preset, isNew: true);
+                        _showClientEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -128,8 +131,11 @@ class _DownloadClientsTab extends ConsumerWidget {
   }
 
   Future<void> _showClientEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> client,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> client, {
+    bool isNew = false,
+  }) async {
     final fields = (client['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -140,21 +146,24 @@ class _DownloadClientsTab extends ConsumerWidget {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          title: Text(isNew ? 'Add ${client['name']}' : 'Edit ${client['name']}'),
+          title:
+              Text(isNew ? 'Add ${client['name']}' : 'Edit ${client['name']}'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(client);
                   payload['fields'] = updatedFields;
                   await api.testDownloadClient(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(sonarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(sonarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(client);
                     payload['fields'] = updatedFields;
 
@@ -169,8 +178,10 @@ class _DownloadClientsTab extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                            content: Text(
-                                'Download client ${isNew ? 'added' : 'updated'}!',),),
+                          content: Text(
+                            'Download client ${isNew ? 'added' : 'updated'}!',
+                          ),
+                        ),
                       );
                     }
                   } catch (e) {
@@ -190,7 +201,10 @@ class _DownloadClientsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteClient(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     if (!await confirmDelete(context, 'this download client')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -210,8 +224,11 @@ class _DownloadClientsTab extends ConsumerWidget {
     }
   }
 
-  String _extractField(Map<String, dynamic> client, String fieldName,
-      [String fallback = '',]) {
+  String _extractField(
+    Map<String, dynamic> client,
+    String fieldName, [
+    String fallback = '',
+  ]) {
     final fields = client['fields'] as List<dynamic>?;
     if (fields == null) return fallback;
     final typedFields = fields.cast<Map<String, dynamic>>();
@@ -296,13 +313,16 @@ class _DownloadClientsTab extends ConsumerWidget {
                             final payload = Map<String, dynamic>.from(client);
                             payload['enable'] = val;
                             await api.updateDownloadClient(payload);
-                            ref.invalidate(sonarrDownloadClientsProvider(instance));
+                            ref.invalidate(
+                                sonarrDownloadClientsProvider(instance));
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
-                                    content: Text(
-                                        'Failed to update client status: $e',),),
+                                  content: Text(
+                                    'Failed to update client status: $e',
+                                  ),
+                                ),
                               );
                             }
                           }
@@ -338,11 +358,17 @@ class _RemotePathMappingsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showMappingDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? mapping,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? mapping,
+  ]) async {
     final isEdit = mapping != null;
-    final hostController = TextEditingController(text: mapping?['host'] as String? ?? '');
-    final remoteController = TextEditingController(text: mapping?['remotePath'] as String? ?? '');
-    final localController = TextEditingController(text: mapping?['localPath'] as String? ?? '');
+    final hostController =
+        TextEditingController(text: mapping?['host'] as String? ?? '');
+    final remoteController =
+        TextEditingController(text: mapping?['remotePath'] as String? ?? '');
+    final localController =
+        TextEditingController(text: mapping?['localPath'] as String? ?? '');
 
     await showDialog<void>(
       context: context,
@@ -388,7 +414,8 @@ class _RemotePathMappingsTab extends ConsumerWidget {
             ElevatedButton(
               onPressed: () async {
                 try {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   final payload = mapping != null
                       ? Map<String, dynamic>.from(mapping)
                       : <String, dynamic>{};
@@ -427,7 +454,10 @@ class _RemotePathMappingsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteMapping(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     if (!await confirmDelete(context, 'this path mapping')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -495,7 +525,8 @@ class _RemotePathMappingsTab extends ConsumerWidget {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showMappingDialog(context, ref, mapping),
+                        onPressed: () =>
+                            _showMappingDialog(context, ref, mapping),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),
@@ -553,10 +584,10 @@ class _DownloadClientOptionsTabState
       payload['enableCompletedDownloadHandling'] =
           _enableCompletedDownloadHandling;
       payload['autoRedownloadFailed'] = _autoRedownloadFailed;
-      
+
       await api.updateDownloadClientConfig(payload);
       ref.invalidate(sonarrDownloadClientConfigProvider(widget.instance));
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Completed download options saved!')),
@@ -613,17 +644,20 @@ class _DownloadClientOptionsTabState
                         contentPadding: EdgeInsets.zero,
                         title: const Text('Enable Completed Download Handling'),
                         subtitle: const Text(
-                            'Automatically import finished downloads from clients',),
+                          'Automatically import finished downloads from clients',
+                        ),
                         value: _enableCompletedDownloadHandling,
                         onChanged: (val) {
-                          setState(() => _enableCompletedDownloadHandling = val);
+                          setState(
+                              () => _enableCompletedDownloadHandling = val);
                         },
                       ),
                       SwitchListTile(
                         contentPadding: EdgeInsets.zero,
                         title: const Text('Redownload Failed'),
                         subtitle: const Text(
-                            'Search for a release alternative if download reports failure',),
+                          'Search for a release alternative if download reports failure',
+                        ),
                         value: _autoRedownloadFailed,
                         onChanged: (val) {
                           setState(() => _autoRedownloadFailed = val);

--- a/services/service_sonarr/lib/src/home/settings/general_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/general_settings_screen.dart
@@ -147,7 +147,8 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
 
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('General configuration settings saved!')),
+          const SnackBar(
+              content: Text('General configuration settings saved!')),
         );
         Navigator.pop(context);
       }
@@ -165,7 +166,8 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final hostConfigAsync = ref.watch(sonarrHostConfigProvider(widget.instance));
+    final hostConfigAsync =
+        ref.watch(sonarrHostConfigProvider(widget.instance));
 
     return Scaffold(
       appBar: AppBar(
@@ -227,7 +229,9 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                             helperText: 'Use * to bind to all interfaces',
                           ),
                           validator: (val) =>
-                              (val == null || val.trim().isEmpty) ? 'Required' : null,
+                              (val == null || val.trim().isEmpty)
+                                  ? 'Required'
+                                  : null,
                         ),
                         const SizedBox(height: Insets.md),
                         Row(
@@ -240,10 +244,10 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                                   labelText: 'Port Number',
                                   border: OutlineInputBorder(),
                                 ),
-                                validator: (val) =>
-                                    (val == null || int.tryParse(val.trim()) == null)
-                                        ? 'Must be integer'
-                                        : null,
+                                validator: (val) => (val == null ||
+                                        int.tryParse(val.trim()) == null)
+                                    ? 'Must be integer'
+                                    : null,
                               ),
                             ),
                             const SizedBox(width: Insets.md),
@@ -255,10 +259,10 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                                   labelText: 'SSL Port Number',
                                   border: OutlineInputBorder(),
                                 ),
-                                validator: (val) =>
-                                    (val == null || int.tryParse(val.trim()) == null)
-                                        ? 'Must be integer'
-                                        : null,
+                                validator: (val) => (val == null ||
+                                        int.tryParse(val.trim()) == null)
+                                    ? 'Must be integer'
+                                    : null,
                               ),
                             ),
                           ],
@@ -336,9 +340,12 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                               icon: const Icon(Icons.copy),
                               tooltip: 'Copy API Key',
                               onPressed: () {
-                                Clipboard.setData(ClipboardData(text: _apiKeyController.text));
+                                Clipboard.setData(ClipboardData(
+                                    text: _apiKeyController.text));
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(content: Text('API Key copied to clipboard!')),
+                                  const SnackBar(
+                                      content:
+                                          Text('API Key copied to clipboard!')),
                                 );
                               },
                             ),
@@ -378,22 +385,36 @@ class _GeneralSettingsScreenState extends ConsumerState<GeneralSettingsScreen> {
                           ),
                           items: [
                             const DropdownMenuItem(
-                                value: 'fatal', child: Text('Fatal'),),
+                              value: 'fatal',
+                              child: Text('Fatal'),
+                            ),
                             const DropdownMenuItem(
-                                value: 'error', child: Text('Error'),),
+                              value: 'error',
+                              child: Text('Error'),
+                            ),
                             const DropdownMenuItem(
-                                value: 'warn', child: Text('Warn'),),
+                              value: 'warn',
+                              child: Text('Warn'),
+                            ),
                             const DropdownMenuItem(
-                                value: 'info', child: Text('Info'),),
+                              value: 'info',
+                              child: Text('Info'),
+                            ),
                             const DropdownMenuItem(
-                                value: 'debug', child: Text('Debug'),),
+                              value: 'debug',
+                              child: Text('Debug'),
+                            ),
                             const DropdownMenuItem(
-                                value: 'trace', child: Text('Trace'),),
+                              value: 'trace',
+                              child: Text('Trace'),
+                            ),
                             // Keep any unexpected server value selectable so
                             // the dropdown never hits the missing-value assert.
                             if (!_logLevels.contains(_logLevel))
                               DropdownMenuItem(
-                                  value: _logLevel, child: Text(_logLevel),),
+                                value: _logLevel,
+                                child: Text(_logLevel),
+                              ),
                           ],
                           onChanged: (val) {
                             if (val != null) {

--- a/services/service_sonarr/lib/src/home/settings/indexers_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/indexers_settings_screen.dart
@@ -70,9 +70,11 @@ class _IndexersTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectIndexerPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(sonarrIndexerSchemaProvider(instance));
-    
+
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -113,7 +115,8 @@ class _IndexersTab extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showIndexerEditorDialog(context, ref, preset, isNew: true);
+                        _showIndexerEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -127,8 +130,11 @@ class _IndexersTab extends ConsumerWidget {
   }
 
   Future<void> _showIndexerEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> indexer,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> indexer, {
+    bool isNew = false,
+  }) async {
     final fields = (indexer['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -139,21 +145,24 @@ class _IndexersTab extends ConsumerWidget {
       barrierDismissible: false,
       builder: (context) {
         return AlertDialog(
-          title: Text(isNew ? 'Add ${indexer['name']}' : 'Edit ${indexer['name']}'),
+          title: Text(
+              isNew ? 'Add ${indexer['name']}' : 'Edit ${indexer['name']}'),
           content: SizedBox(
             width: double.maxFinite,
             child: SingleChildScrollView(
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(indexer);
                   payload['fields'] = updatedFields;
                   await api.testIndexer(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(sonarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(sonarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(indexer);
                     payload['fields'] = updatedFields;
 
@@ -168,8 +177,10 @@ class _IndexersTab extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                            content: Text(
-                                'Indexer ${isNew ? 'added' : 'updated'}!',),),
+                          content: Text(
+                            'Indexer ${isNew ? 'added' : 'updated'}!',
+                          ),
+                        ),
                       );
                     }
                   } catch (e) {
@@ -189,7 +200,10 @@ class _IndexersTab extends ConsumerWidget {
   }
 
   Future<void> _deleteIndexer(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       await api.deleteIndexer(id);
@@ -253,7 +267,8 @@ class _IndexersTab extends ConsumerWidget {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  subtitle: Text('$implementation • Protocol: ${protocol.toUpperCase()}'),
+                  subtitle: Text(
+                      '$implementation • Protocol: ${protocol.toUpperCase()}'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -287,7 +302,9 @@ class _ImportListsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _selectImportListPresetAndAdd(
-      BuildContext context, WidgetRef ref,) async {
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
     final schemasAsync = ref.read(sonarrImportListSchemaProvider(instance));
     final presets = schemasAsync.value ?? [];
     if (presets.isEmpty) {
@@ -329,7 +346,8 @@ class _ImportListsTab extends ConsumerWidget {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () {
                         Navigator.pop(context);
-                        _showImportListEditorDialog(context, ref, preset, isNew: true);
+                        _showImportListEditorDialog(context, ref, preset,
+                            isNew: true);
                       },
                     );
                   },
@@ -343,8 +361,11 @@ class _ImportListsTab extends ConsumerWidget {
   }
 
   Future<void> _showImportListEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> list,
-      {bool isNew = false,}) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> list, {
+    bool isNew = false,
+  }) async {
     final fields = (list['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
@@ -362,14 +383,16 @@ class _ImportListsTab extends ConsumerWidget {
               child: DynamicSchemaForm(
                 fields: fields,
                 onTest: (updatedFields) async {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   final payload = Map<String, dynamic>.from(list);
                   payload['fields'] = updatedFields;
                   await api.testImportList(payload);
                 },
                 onSave: (updatedFields) async {
                   try {
-                    final api = await ref.read(sonarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(sonarrApiProvider(instance).future);
                     final payload = Map<String, dynamic>.from(list);
                     payload['fields'] = updatedFields;
 
@@ -417,14 +440,17 @@ class _ImportListsTab extends ConsumerWidget {
                       Navigator.pop(context);
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
-                            content: Text(
-                                'Import list ${isNew ? 'added' : 'updated'}!',),),
+                          content: Text(
+                            'Import list ${isNew ? 'added' : 'updated'}!',
+                          ),
+                        ),
                       );
                     }
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to save import list: $e')),
+                        SnackBar(
+                            content: Text('Failed to save import list: $e')),
                       );
                     }
                   }
@@ -438,7 +464,10 @@ class _ImportListsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteImportList(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       await api.deleteImportList(id);
@@ -544,7 +573,7 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
   late final TextEditingController _retentionController;
   late final TextEditingController _maxSizeController;
   late final TextEditingController _rssIntervalController;
-  
+
   bool _initialized = false;
   bool _saving = false;
   Map<String, dynamic>? _rawConfig;
@@ -575,7 +604,8 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
     _minAgeController.text = (config['minimumAge'] as int? ?? 0).toString();
     _retentionController.text = (config['retention'] as int? ?? 0).toString();
     _maxSizeController.text = (config['maximumSize'] as int? ?? 0).toString();
-    _rssIntervalController.text = (config['rssSyncInterval'] as int? ?? 15).toString();
+    _rssIntervalController.text =
+        (config['rssSyncInterval'] as int? ?? 15).toString();
   }
 
   Future<void> _save() async {
@@ -589,13 +619,16 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
       final payload = Map<String, dynamic>.from(_rawConfig!);
 
       payload['minimumAge'] = int.tryParse(_minAgeController.text.trim()) ?? 0;
-      payload['retention'] = int.tryParse(_retentionController.text.trim()) ?? 0;
-      payload['maximumSize'] = int.tryParse(_maxSizeController.text.trim()) ?? 0;
-      payload['rssSyncInterval'] = int.tryParse(_rssIntervalController.text.trim()) ?? 15;
+      payload['retention'] =
+          int.tryParse(_retentionController.text.trim()) ?? 0;
+      payload['maximumSize'] =
+          int.tryParse(_maxSizeController.text.trim()) ?? 0;
+      payload['rssSyncInterval'] =
+          int.tryParse(_rssIntervalController.text.trim()) ?? 15;
 
       await api.updateIndexerConfig(payload);
       ref.invalidate(sonarrIndexerConfigProvider(widget.instance));
-      
+
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(content: Text('Indexer options saved!')),
@@ -662,7 +695,8 @@ class _IndexerOptionsTabState extends ConsumerState<_IndexerOptionsTab> {
                         keyboardType: TextInputType.number,
                         decoration: const InputDecoration(
                           labelText: 'Retention (Days)',
-                          helperText: 'Usenet only: max retention age (0 = unlimited)',
+                          helperText:
+                              'Usenet only: max retention age (0 = unlimited)',
                           border: OutlineInputBorder(),
                         ),
                       ),

--- a/services/service_sonarr/lib/src/home/settings/media_management_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/media_management_settings_screen.dart
@@ -46,7 +46,7 @@ class _MediaManagementSettingsScreenState
   bool _autoUnmonitorPreviouslyDownloadedEpisodes = false;
   bool _skipFreeSpaceCheckWhenImporting = false;
   bool _setPermissionsLinux = false;
-  
+
   late final TextEditingController _recycleBinController;
   late final TextEditingController _recycleBinCleanupDaysController;
   late final TextEditingController _chmodFolderController;
@@ -136,9 +136,10 @@ class _MediaManagementSettingsScreenState
     _enableMediaInfo = mediaMgmt['enableMediaInfo'] as bool? ?? false;
     _minimumFreeSpaceController.text =
         (mediaMgmt['minimumFreeSpaceWhenImporting'] as int? ?? 0).toString();
-    
+
     _autoUnmonitorPreviouslyDownloadedEpisodes =
-        mediaMgmt['autoUnmonitorPreviouslyDownloadedEpisodes'] as bool? ?? false;
+        mediaMgmt['autoUnmonitorPreviouslyDownloadedEpisodes'] as bool? ??
+            false;
     _skipFreeSpaceCheckWhenImporting =
         mediaMgmt['skipFreeSpaceCheckWhenImporting'] as bool? ?? false;
     _setPermissionsLinux = mediaMgmt['setPermissionsLinux'] as bool? ?? false;
@@ -150,7 +151,8 @@ class _MediaManagementSettingsScreenState
     _chownGroupController.text = (mediaMgmt['chownGroup'] as String?) ?? '';
 
     _downloadPropersAndRepacks =
-        (mediaMgmt['downloadPropersAndRepacks'] as String?) ?? 'preferAndUpgrade';
+        (mediaMgmt['downloadPropersAndRepacks'] as String?) ??
+            'preferAndUpgrade';
     _fileDate = (mediaMgmt['fileDate'] as String?) ?? 'none';
     _rescanAfterRefresh =
         (mediaMgmt['rescanAfterRefresh'] as String?) ?? 'always';
@@ -209,20 +211,21 @@ class _MediaManagementSettingsScreenState
       mediaMgmtPayload['enableMediaInfo'] = _enableMediaInfo;
       mediaMgmtPayload['minimumFreeSpaceWhenImporting'] =
           int.tryParse(_minimumFreeSpaceController.text.trim()) ?? 0;
-      
+
       mediaMgmtPayload['autoUnmonitorPreviouslyDownloadedEpisodes'] =
           _autoUnmonitorPreviouslyDownloadedEpisodes;
       mediaMgmtPayload['skipFreeSpaceCheckWhenImporting'] =
           _skipFreeSpaceCheckWhenImporting;
       mediaMgmtPayload['setPermissionsLinux'] = _setPermissionsLinux;
-      
+
       mediaMgmtPayload['recycleBin'] = _recycleBinController.text.trim();
       mediaMgmtPayload['recycleBinCleanupDays'] =
           int.tryParse(_recycleBinCleanupDaysController.text.trim()) ?? 7;
       mediaMgmtPayload['chmodFolder'] = _chmodFolderController.text.trim();
       mediaMgmtPayload['chownGroup'] = _chownGroupController.text.trim();
 
-      mediaMgmtPayload['downloadPropersAndRepacks'] = _downloadPropersAndRepacks;
+      mediaMgmtPayload['downloadPropersAndRepacks'] =
+          _downloadPropersAndRepacks;
       mediaMgmtPayload['fileDate'] = _fileDate;
       mediaMgmtPayload['rescanAfterRefresh'] = _rescanAfterRefresh;
       mediaMgmtPayload['episodeTitleRequired'] = _episodeTitleRequired;
@@ -300,7 +303,8 @@ class _MediaManagementSettingsScreenState
                       elevation: 0,
                       shape: RoundedRectangleBorder(
                         side: BorderSide(
-                            color: theme.colorScheme.outlineVariant,),
+                          color: theme.colorScheme.outlineVariant,
+                        ),
                         borderRadius: Radii.card,
                       ),
                       child: Padding(
@@ -320,7 +324,8 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Rename Episodes'),
                               subtitle: const Text(
-                                  'Change episode file names based on naming format',),
+                                'Change episode file names based on naming format',
+                              ),
                               value: _renameEpisodes,
                               onChanged: (val) =>
                                   setState(() => _renameEpisodes = val),
@@ -329,10 +334,12 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Replace Illegal Characters'),
                               subtitle: const Text(
-                                  'Sanitize standard OS invalid filename characters',),
+                                'Sanitize standard OS invalid filename characters',
+                              ),
                               value: _replaceIllegalCharacters,
-                              onChanged: (val) => setState(() =>
-                                  _replaceIllegalCharacters = val,),
+                              onChanged: (val) => setState(
+                                () => _replaceIllegalCharacters = val,
+                              ),
                             ),
                             const SizedBox(height: Insets.sm),
                             DropdownButtonFormField<int>(
@@ -343,16 +350,25 @@ class _MediaManagementSettingsScreenState
                               ),
                               items: [
                                 const DropdownMenuItem(
-                                    value: 0, child: Text('Delete'),),
+                                  value: 0,
+                                  child: Text('Delete'),
+                                ),
                                 const DropdownMenuItem(
-                                    value: 1, child: Text('Replace with Space'),),
+                                  value: 1,
+                                  child: Text('Replace with Space'),
+                                ),
                                 const DropdownMenuItem(
-                                    value: 2, child: Text('Replace with Dash'),),
+                                  value: 2,
+                                  child: Text('Replace with Dash'),
+                                ),
                                 const DropdownMenuItem(
-                                    value: 3,
-                                    child: Text('Replace with Space Dash Space'),),
+                                  value: 3,
+                                  child: Text('Replace with Space Dash Space'),
+                                ),
                                 const DropdownMenuItem(
-                                    value: 4, child: Text('Smart Replace'),),
+                                  value: 4,
+                                  child: Text('Smart Replace'),
+                                ),
                                 if (_colonReplacementFormat < 0 ||
                                     _colonReplacementFormat > 4)
                                   DropdownMenuItem(
@@ -429,7 +445,8 @@ class _MediaManagementSettingsScreenState
                       elevation: 0,
                       shape: RoundedRectangleBorder(
                         side: BorderSide(
-                            color: theme.colorScheme.outlineVariant,),
+                          color: theme.colorScheme.outlineVariant,
+                        ),
                         borderRadius: Radii.card,
                       ),
                       child: Padding(
@@ -449,25 +466,29 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Create Empty Series Folders'),
                               subtitle: const Text(
-                                  'Create directories automatically on disk scanner activity',),
+                                'Create directories automatically on disk scanner activity',
+                              ),
                               value: _createEmptySeriesFolders,
-                              onChanged: (val) =>
-                                  setState(() => _createEmptySeriesFolders = val),
+                              onChanged: (val) => setState(
+                                  () => _createEmptySeriesFolders = val),
                             ),
                             SwitchListTile(
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Delete Empty Folders'),
                               subtitle: const Text(
-                                  'Remove folders that have no media assets remaining',),
+                                'Remove folders that have no media assets remaining',
+                              ),
                               value: _deleteEmptyFolders,
                               onChanged: (val) =>
                                   setState(() => _deleteEmptyFolders = val),
                             ),
                             SwitchListTile(
                               contentPadding: EdgeInsets.zero,
-                              title: const Text('Use Hardlinks instead of Copy'),
+                              title:
+                                  const Text('Use Hardlinks instead of Copy'),
                               subtitle: const Text(
-                                  'Highly recommended for same-pool storage seeding setups',),
+                                'Highly recommended for same-pool storage seeding setups',
+                              ),
                               value: _copyUsingHardlinks,
                               onChanged: (val) =>
                                   setState(() => _copyUsingHardlinks = val),
@@ -475,20 +496,27 @@ class _MediaManagementSettingsScreenState
                             SwitchListTile(
                               contentPadding: EdgeInsets.zero,
                               title: const Text(
-                                  'Auto Unmonitor Previously Downloaded',),
+                                'Auto Unmonitor Previously Downloaded',
+                              ),
                               subtitle: const Text(
-                                  'Unmonitor episodes once they have been deleted from disk',),
+                                'Unmonitor episodes once they have been deleted from disk',
+                              ),
                               value: _autoUnmonitorPreviouslyDownloadedEpisodes,
-                              onChanged: (val) => setState(() =>
-                                  _autoUnmonitorPreviouslyDownloadedEpisodes = val,),
+                              onChanged: (val) => setState(
+                                () =>
+                                    _autoUnmonitorPreviouslyDownloadedEpisodes =
+                                        val,
+                              ),
                             ),
                             SwitchListTile(
                               contentPadding: EdgeInsets.zero,
                               title: const Text(
-                                  'Skip Free Space Check When Importing',),
+                                'Skip Free Space Check When Importing',
+                              ),
                               value: _skipFreeSpaceCheckWhenImporting,
-                              onChanged: (val) => setState(() =>
-                                  _skipFreeSpaceCheckWhenImporting = val,),
+                              onChanged: (val) => setState(
+                                () => _skipFreeSpaceCheckWhenImporting = val,
+                              ),
                             ),
                             const SizedBox(height: Insets.sm),
                             TextFormField(
@@ -515,14 +543,19 @@ class _MediaManagementSettingsScreenState
                                 labelText: 'Propers and Repacks',
                                 border: OutlineInputBorder(),
                               ),
-                              items: _dropdownItems(const {
-                                'preferAndUpgrade': 'Prefer and Upgrade',
-                                'doNotUpgrade': 'Do Not Upgrade Automatically',
-                                'doNotPrefer': 'Do Not Prefer',
-                              }, _downloadPropersAndRepacks,),
+                              items: _dropdownItems(
+                                const {
+                                  'preferAndUpgrade': 'Prefer and Upgrade',
+                                  'doNotUpgrade':
+                                      'Do Not Upgrade Automatically',
+                                  'doNotPrefer': 'Do Not Prefer',
+                                },
+                                _downloadPropersAndRepacks,
+                              ),
                               onChanged: (val) {
                                 if (val != null) {
-                                  setState(() => _downloadPropersAndRepacks = val);
+                                  setState(
+                                      () => _downloadPropersAndRepacks = val);
                                 }
                               },
                             ),
@@ -533,12 +566,15 @@ class _MediaManagementSettingsScreenState
                                 labelText: 'Episode Title Required',
                                 border: OutlineInputBorder(),
                               ),
-                              items: _dropdownItems(const {
-                                'always': 'Always',
-                                'bulkSeasonReleases':
-                                    'Only for Bulk Season Releases',
-                                'never': 'Never',
-                              }, _episodeTitleRequired,),
+                              items: _dropdownItems(
+                                const {
+                                  'always': 'Always',
+                                  'bulkSeasonReleases':
+                                      'Only for Bulk Season Releases',
+                                  'never': 'Never',
+                                },
+                                _episodeTitleRequired,
+                              ),
                               onChanged: (val) {
                                 if (val != null) {
                                   setState(() => _episodeTitleRequired = val);
@@ -552,11 +588,14 @@ class _MediaManagementSettingsScreenState
                                 labelText: 'File Date',
                                 border: OutlineInputBorder(),
                               ),
-                              items: _dropdownItems(const {
-                                'none': 'None',
-                                'localAirDate': 'Local Air Date',
-                                'utcAirDate': 'UTC Air Date',
-                              }, _fileDate,),
+                              items: _dropdownItems(
+                                const {
+                                  'none': 'None',
+                                  'localAirDate': 'Local Air Date',
+                                  'utcAirDate': 'UTC Air Date',
+                                },
+                                _fileDate,
+                              ),
                               onChanged: (val) {
                                 if (val != null) {
                                   setState(() => _fileDate = val);
@@ -570,11 +609,14 @@ class _MediaManagementSettingsScreenState
                                 labelText: 'Rescan After Refresh',
                                 border: OutlineInputBorder(),
                               ),
-                              items: _dropdownItems(const {
-                                'always': 'Always',
-                                'afterManual': 'After Manual Refresh',
-                                'never': 'Never',
-                              }, _rescanAfterRefresh,),
+                              items: _dropdownItems(
+                                const {
+                                  'always': 'Always',
+                                  'afterManual': 'After Manual Refresh',
+                                  'never': 'Never',
+                                },
+                                _rescanAfterRefresh,
+                              ),
                               onChanged: (val) {
                                 if (val != null) {
                                   setState(() => _rescanAfterRefresh = val);
@@ -592,7 +634,8 @@ class _MediaManagementSettingsScreenState
                       elevation: 0,
                       shape: RoundedRectangleBorder(
                         side: BorderSide(
-                            color: theme.colorScheme.outlineVariant,),
+                          color: theme.colorScheme.outlineVariant,
+                        ),
                         borderRadius: Radii.card,
                       ),
                       child: Padding(
@@ -612,7 +655,8 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Import Extra Files'),
                               subtitle: const Text(
-                                  'Move subtitles, NFO, or metadata with video files',),
+                                'Move subtitles, NFO, or metadata with video files',
+                              ),
                               value: _importExtraFiles,
                               onChanged: (val) =>
                                   setState(() => _importExtraFiles = val),
@@ -634,7 +678,8 @@ class _MediaManagementSettingsScreenState
                               contentPadding: EdgeInsets.zero,
                               title: const Text('Enable Media Info'),
                               subtitle: const Text(
-                                  'Extract audio channels, video codec, and subtitle info',),
+                                'Extract audio channels, video codec, and subtitle info',
+                              ),
                               value: _enableMediaInfo,
                               onChanged: (val) =>
                                   setState(() => _enableMediaInfo = val),
@@ -650,7 +695,8 @@ class _MediaManagementSettingsScreenState
                       elevation: 0,
                       shape: RoundedRectangleBorder(
                         side: BorderSide(
-                            color: theme.colorScheme.outlineVariant,),
+                          color: theme.colorScheme.outlineVariant,
+                        ),
                         borderRadius: Radii.card,
                       ),
                       child: Padding(
@@ -704,7 +750,8 @@ class _MediaManagementSettingsScreenState
                       elevation: 0,
                       shape: RoundedRectangleBorder(
                         side: BorderSide(
-                            color: theme.colorScheme.outlineVariant,),
+                          color: theme.colorScheme.outlineVariant,
+                        ),
                         borderRadius: Radii.card,
                       ),
                       child: Padding(

--- a/services/service_sonarr/lib/src/home/settings/metadata_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/metadata_settings_screen.dart
@@ -15,13 +15,17 @@ class MetadataSettingsScreen extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showMetadataEditorDialog(
-      BuildContext context, WidgetRef ref, Map<String, dynamic> metadata,) async {
+    BuildContext context,
+    WidgetRef ref,
+    Map<String, dynamic> metadata,
+  ) async {
     final fields = (metadata['fields'] as List<dynamic>?)
             ?.map((dynamic f) => f as Map<String, dynamic>)
             .toList() ??
         [];
 
-    final enableController = ValueNotifier<bool>(metadata['enable'] as bool? ?? false);
+    final enableController =
+        ValueNotifier<bool>(metadata['enable'] as bool? ?? false);
 
     await showDialog<void>(
       context: context,
@@ -58,20 +62,24 @@ class MetadataSettingsScreen extends ConsumerWidget {
 
                             await api.updateMetadataConfig(payload);
 
-                            ref.invalidate(sonarrMetadataConfigsProvider(instance));
+                            ref.invalidate(
+                                sonarrMetadataConfigsProvider(instance));
                             if (context.mounted) {
                               Navigator.pop(context);
                               ScaffoldMessenger.of(context).showSnackBar(
                                 const SnackBar(
-                                    content: Text('Metadata consumer updated!'),),
+                                  content: Text('Metadata consumer updated!'),
+                                ),
                               );
                             }
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
-                                    content: Text(
-                                        'Failed to save metadata consumer: $e',),),
+                                  content: Text(
+                                    'Failed to save metadata consumer: $e',
+                                  ),
+                                ),
                               );
                             }
                           }
@@ -91,7 +99,8 @@ class MetadataSettingsScreen extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final metadataListAsync = ref.watch(sonarrMetadataConfigsProvider(instance));
+    final metadataListAsync =
+        ref.watch(sonarrMetadataConfigsProvider(instance));
 
     return Scaffold(
       appBar: AppBar(
@@ -102,7 +111,8 @@ class MetadataSettingsScreen extends ConsumerWidget {
         error: (err, stack) => Center(child: Text('Error: $err')),
         data: (configs) {
           if (configs.isEmpty) {
-            return const Center(child: Text('No metadata consumers configured.'));
+            return const Center(
+                child: Text('No metadata consumers configured.'));
           }
 
           return ListView.builder(
@@ -140,7 +150,8 @@ class MetadataSettingsScreen extends ConsumerWidget {
                       fontWeight: FontWeight.bold,
                     ),
                   ),
-                  subtitle: Text('$implementation • Status: ${isEnabled ? 'Enabled' : 'Disabled'}'),
+                  subtitle: Text(
+                      '$implementation • Status: ${isEnabled ? 'Enabled' : 'Disabled'}'),
                   trailing: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
@@ -153,13 +164,16 @@ class MetadataSettingsScreen extends ConsumerWidget {
                             final payload = Map<String, dynamic>.from(metadata);
                             payload['enable'] = val;
                             await api.updateMetadataConfig(payload);
-                            ref.invalidate(sonarrMetadataConfigsProvider(instance));
+                            ref.invalidate(
+                                sonarrMetadataConfigsProvider(instance));
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
                                 SnackBar(
-                                    content: Text(
-                                        'Failed to update metadata status: $e',),),
+                                  content: Text(
+                                    'Failed to update metadata status: $e',
+                                  ),
+                                ),
                               );
                             }
                           }

--- a/services/service_sonarr/lib/src/home/settings/parse_title_dialog.dart
+++ b/services/service_sonarr/lib/src/home/settings/parse_title_dialog.dart
@@ -11,10 +11,12 @@ class SonarrParseTitleDialog extends ConsumerStatefulWidget {
   final Instance instance;
 
   @override
-  ConsumerState<SonarrParseTitleDialog> createState() => _SonarrParseTitleDialogState();
+  ConsumerState<SonarrParseTitleDialog> createState() =>
+      _SonarrParseTitleDialogState();
 }
 
-class _SonarrParseTitleDialogState extends ConsumerState<SonarrParseTitleDialog> {
+class _SonarrParseTitleDialogState
+    extends ConsumerState<SonarrParseTitleDialog> {
   final _controller = TextEditingController();
   String _query = '';
 
@@ -27,7 +29,7 @@ class _SonarrParseTitleDialogState extends ConsumerState<SonarrParseTitleDialog>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    
+
     final parseAsync = _query.trim().isNotEmpty
         ? ref.watch(sonarrParseResultProvider((widget.instance, _query.trim())))
         : null;
@@ -108,30 +110,44 @@ class _SonarrParseTitleDialogState extends ConsumerState<SonarrParseTitleDialog>
                   child: parseAsync.when(
                     data: (data) {
                       if (data == null) {
-                        return const Center(child: Text('Failed to parse title.'));
+                        return const Center(
+                            child: Text('Failed to parse title.'));
                       }
-                      final parsedInfo = data['parsedEpisodeInfo'] as Map<String, dynamic>?;
+                      final parsedInfo =
+                          data['parsedEpisodeInfo'] as Map<String, dynamic>?;
                       if (parsedInfo == null) {
-                        return const Center(child: Text('Could not extract episode details.'));
+                        return const Center(
+                            child: Text('Could not extract episode details.'));
                       }
 
-                      final String? parsedSeriesTitle = parsedInfo['seriesTitle'] as String?;
-                      final int? seasonNumber = parsedInfo['seasonNumber'] as int?;
-                      final List<dynamic>? episodeNumbers = parsedInfo['episodeNumbers'] as List<dynamic>?;
-                      final String? releaseGroup = parsedInfo['releaseGroup'] as String?;
-                      
-                      final qualityMap = parsedInfo['quality'] as Map<String, dynamic>?;
-                      final qualityInner = qualityMap?['quality'] as Map<String, dynamic>?;
-                      final String? qualityName = qualityInner?['name'] as String?;
-                      
-                      final languages = parsedInfo['languages'] as List<dynamic>?;
+                      final String? parsedSeriesTitle =
+                          parsedInfo['seriesTitle'] as String?;
+                      final int? seasonNumber =
+                          parsedInfo['seasonNumber'] as int?;
+                      final List<dynamic>? episodeNumbers =
+                          parsedInfo['episodeNumbers'] as List<dynamic>?;
+                      final String? releaseGroup =
+                          parsedInfo['releaseGroup'] as String?;
+
+                      final qualityMap =
+                          parsedInfo['quality'] as Map<String, dynamic>?;
+                      final qualityInner =
+                          qualityMap?['quality'] as Map<String, dynamic>?;
+                      final String? qualityName =
+                          qualityInner?['name'] as String?;
+
+                      final languages =
+                          parsedInfo['languages'] as List<dynamic>?;
                       final List<String> languageNames = languages
-                              ?.map((l) => (l as Map<String, dynamic>)['name'] as String)
+                              ?.map((l) =>
+                                  (l as Map<String, dynamic>)['name'] as String)
                               .toList() ??
                           [];
 
-                      final matchingSeries = data['series'] as Map<String, dynamic>?;
-                      final matchingSeriesTitle = matchingSeries?['title'] as String?;
+                      final matchingSeries =
+                          data['series'] as Map<String, dynamic>?;
+                      final matchingSeriesTitle =
+                          matchingSeries?['title'] as String?;
 
                       return SingleChildScrollView(
                         child: Column(
@@ -145,7 +161,8 @@ class _SonarrParseTitleDialogState extends ConsumerState<SonarrParseTitleDialog>
                               ),
                             ),
                             const SizedBox(height: Insets.sm),
-                            _buildInfoRow(theme, 'Series Name', parsedSeriesTitle ?? 'N/A'),
+                            _buildInfoRow(theme, 'Series Name',
+                                parsedSeriesTitle ?? 'N/A'),
                             _buildInfoRow(
                               theme,
                               'Season / Episode',
@@ -153,9 +170,16 @@ class _SonarrParseTitleDialogState extends ConsumerState<SonarrParseTitleDialog>
                                   ? 'Season $seasonNumber, Episode ${episodeNumbers?.join(', ') ?? ''}'
                                   : 'N/A',
                             ),
-                            _buildInfoRow(theme, 'Quality', qualityName ?? 'N/A'),
-                            _buildInfoRow(theme, 'Release Group', releaseGroup ?? 'N/A'),
-                            _buildInfoRow(theme, 'Language', languageNames.isNotEmpty ? languageNames.join(', ') : 'N/A'),
+                            _buildInfoRow(
+                                theme, 'Quality', qualityName ?? 'N/A'),
+                            _buildInfoRow(
+                                theme, 'Release Group', releaseGroup ?? 'N/A'),
+                            _buildInfoRow(
+                                theme,
+                                'Language',
+                                languageNames.isNotEmpty
+                                    ? languageNames.join(', ')
+                                    : 'N/A'),
                             const SizedBox(height: Insets.md),
                             Text(
                               'Sonarr Database Match',
@@ -199,7 +223,8 @@ class _SonarrParseTitleDialogState extends ConsumerState<SonarrParseTitleDialog>
     );
   }
 
-  Widget _buildInfoRow(ThemeData theme, String label, String value, {Color? valueColor}) {
+  Widget _buildInfoRow(ThemeData theme, String label, String value,
+      {Color? valueColor}) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 4),
       child: Row(

--- a/services/service_sonarr/lib/src/home/settings/profiles_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/profiles_settings_screen.dart
@@ -37,7 +37,6 @@ class _ProfilesSettingsScreenState extends ConsumerState<ProfilesSettingsScreen>
 
   @override
   Widget build(BuildContext context) {
-
     return Scaffold(
       appBar: AppBar(
         title: const Text('Profiles & Formats'),
@@ -74,15 +73,20 @@ class _QualityProfilesTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showProfileDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? profile,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? profile,
+  ]) async {
     // Fetch schema to get all available quality items
     Map<String, dynamic>? schema;
     try {
-      schema = await ref.read(sonarrQualityProfileSchemaProvider(instance).future);
+      schema =
+          await ref.read(sonarrQualityProfileSchemaProvider(instance).future);
     } catch (_) {
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Failed to load quality profile schema')),
+          const SnackBar(
+              content: Text('Failed to load quality profile schema')),
         );
       }
       return;
@@ -96,10 +100,12 @@ class _QualityProfilesTab extends ConsumerWidget {
     );
 
     // Build the items list from profile (edit) or schema (new)
-    final sourceItems = (profile?['items'] ?? schema!['items']) as List<dynamic>;
+    final sourceItems =
+        (profile?['items'] ?? schema!['items']) as List<dynamic>;
     // Deep copy so we can toggle allowed flags
     final editableItems = sourceItems
-        .map((dynamic e) => Map<String, dynamic>.from(e as Map<String, dynamic>))
+        .map(
+            (dynamic e) => Map<String, dynamic>.from(e as Map<String, dynamic>))
         .toList();
 
     // Deep copy nested quality groups
@@ -107,7 +113,8 @@ class _QualityProfilesTab extends ConsumerWidget {
       final subItems = editableItems[i]['items'] as List<dynamic>?;
       if (subItems != null && subItems.isNotEmpty) {
         editableItems[i]['items'] = subItems
-            .map((dynamic e) => Map<String, dynamic>.from(e as Map<String, dynamic>))
+            .map((dynamic e) =>
+                Map<String, dynamic>.from(e as Map<String, dynamic>))
             .toList();
       }
     }
@@ -136,7 +143,8 @@ class _QualityProfilesTab extends ConsumerWidget {
             }
 
             return AlertDialog(
-              title: Text(isEdit ? 'Edit Quality Profile' : 'Add Quality Profile'),
+              title:
+                  Text(isEdit ? 'Edit Quality Profile' : 'Add Quality Profile'),
               content: SizedBox(
                 width: double.maxFinite,
                 child: SingleChildScrollView(
@@ -156,7 +164,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                         contentPadding: EdgeInsets.zero,
                         title: const Text('Allow Upgrades'),
                         value: upgradeAllowed,
-                        onChanged: (val) => setDialogState(() => upgradeAllowed = val),
+                        onChanged: (val) =>
+                            setDialogState(() => upgradeAllowed = val),
                       ),
                       if (upgradeAllowed) ...[
                         const SizedBox(height: 8),
@@ -165,7 +174,10 @@ class _QualityProfilesTab extends ConsumerWidget {
                             labelText: 'Upgrade Until (Cutoff)',
                             border: OutlineInputBorder(),
                           ),
-                          initialValue: cutoffOptions.any((q) => q['id'] == cutoffId) ? cutoffId : null,
+                          initialValue:
+                              cutoffOptions.any((q) => q['id'] == cutoffId)
+                                  ? cutoffId
+                                  : null,
                           items: cutoffOptions.map((q) {
                             return DropdownMenuItem<int>(
                               value: q['id'] as int,
@@ -173,7 +185,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                             );
                           }).toList(),
                           onChanged: (val) {
-                            if (val != null) setDialogState(() => cutoffId = val);
+                            if (val != null)
+                              setDialogState(() => cutoffId = val);
                           },
                         ),
                       ],
@@ -181,13 +194,14 @@ class _QualityProfilesTab extends ConsumerWidget {
                       Text(
                         'Qualities',
                         style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                              fontWeight: FontWeight.bold,
+                            ),
                       ),
                       const SizedBox(height: 8),
                       // Render each quality item with a checkbox
                       ...editableItems.map((item) {
-                        final quality = item['quality'] as Map<String, dynamic>?;
+                        final quality =
+                            item['quality'] as Map<String, dynamic>?;
                         final isGroup = quality == null;
                         final name = isGroup
                             ? (item['name'] as String? ?? 'Group')
@@ -195,11 +209,13 @@ class _QualityProfilesTab extends ConsumerWidget {
                         final allowed = item['allowed'] as bool? ?? false;
 
                         return CheckboxListTile(
-                          contentPadding: EdgeInsets.only(left: isGroup ? 0 : 16),
+                          contentPadding:
+                              EdgeInsets.only(left: isGroup ? 0 : 16),
                           title: Text(
                             name,
                             style: TextStyle(
-                              fontWeight: isGroup ? FontWeight.bold : FontWeight.normal,
+                              fontWeight:
+                                  isGroup ? FontWeight.bold : FontWeight.normal,
                             ),
                           ),
                           value: allowed,
@@ -208,10 +224,12 @@ class _QualityProfilesTab extends ConsumerWidget {
                               item['allowed'] = val ?? false;
                               // If it's a group, propagate to sub-items
                               if (isGroup) {
-                                final subItems = item['items'] as List<dynamic>?;
+                                final subItems =
+                                    item['items'] as List<dynamic>?;
                                 if (subItems != null) {
                                   for (final sub in subItems) {
-                                    (sub as Map<String, dynamic>)['allowed'] = val ?? false;
+                                    (sub as Map<String, dynamic>)['allowed'] =
+                                        val ?? false;
                                   }
                                 }
                               }
@@ -259,7 +277,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                         : allowedIds.first;
 
                     try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
+                      final api =
+                          await ref.read(sonarrApiProvider(instance).future);
                       final payload = isEdit
                           ? Map<String, dynamic>.from(profile)
                           : Map<String, dynamic>.from(schema!);
@@ -281,7 +300,9 @@ class _QualityProfilesTab extends ConsumerWidget {
                       if (context.mounted) {
                         Navigator.pop(context);
                         ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Quality profile ${isEdit ? 'updated' : 'created'}!')),
+                          SnackBar(
+                              content: Text(
+                                  'Quality profile ${isEdit ? 'updated' : 'created'}!')),
                         );
                       }
                     } catch (e) {
@@ -302,7 +323,8 @@ class _QualityProfilesTab extends ConsumerWidget {
     );
   }
 
-  Future<void> _deleteProfile(BuildContext context, WidgetRef ref, int id) async {
+  Future<void> _deleteProfile(
+      BuildContext context, WidgetRef ref, int id) async {
     if (!await confirmDelete(context, 'this quality profile')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -358,14 +380,14 @@ class _QualityProfilesTab extends ConsumerWidget {
               final cutoffMap = itemsList?.firstWhere(
                 (item) {
                   final quality = item['quality'] as Map<String, dynamic>?;
-                  return quality?['id'] == cutoffItem || item['id'] == cutoffItem;
+                  return quality?['id'] == cutoffItem ||
+                      item['id'] == cutoffItem;
                 },
                 orElse: () => <String, dynamic>{},
               );
               final cutoffQuality =
                   cutoffMap?['quality'] as Map<String, dynamic>?;
-              final cutoffName =
-                  (cutoffQuality?['name'] as String?) ??
+              final cutoffName = (cutoffQuality?['name'] as String?) ??
                   (cutoffMap?['name'] as String?) ??
                   'Unknown';
 
@@ -373,12 +395,11 @@ class _QualityProfilesTab extends ConsumerWidget {
               final enabledQualities = rawItems
                   .where((item) => item['allowed'] as bool? ?? false)
                   .map((item) {
-                    final quality = item['quality'] as Map<String, dynamic>?;
-                    return (quality?['name'] as String?) ??
-                        (item['name'] as String?) ??
-                        'Unknown';
-                  })
-                  .toList();
+                final quality = item['quality'] as Map<String, dynamic>?;
+                return (quality?['name'] as String?) ??
+                    (item['name'] as String?) ??
+                    'Unknown';
+              }).toList();
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.md),
@@ -430,8 +451,8 @@ class _QualityProfilesTab extends ConsumerWidget {
                                     q,
                                     style: theme.textTheme.bodySmall?.copyWith(
                                       color: isCutoff
-                                          ? theme.colorScheme
-                                              .onSecondaryContainer
+                                          ? theme
+                                              .colorScheme.onSecondaryContainer
                                           : null,
                                       fontWeight:
                                           isCutoff ? FontWeight.bold : null,
@@ -460,11 +481,11 @@ class _QualityProfilesTab extends ConsumerWidget {
                               TextButton.icon(
                                 onPressed: () =>
                                     _deleteProfile(context, ref, id),
-                                icon: const Icon(Icons.delete_outline, size: 18),
+                                icon:
+                                    const Icon(Icons.delete_outline, size: 18),
                                 label: const Text('Delete'),
                                 style: TextButton.styleFrom(
-                                  foregroundColor:
-                                      theme.colorScheme.error,
+                                  foregroundColor: theme.colorScheme.error,
                                 ),
                               ),
                             ],
@@ -483,7 +504,6 @@ class _QualityProfilesTab extends ConsumerWidget {
   }
 }
 
-
 // ==========================================
 // 2. DELAY PROFILES TAB
 // ==========================================
@@ -493,16 +513,22 @@ class _DelayProfilesTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showDelayProfileDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? profile,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? profile,
+  ]) async {
     final isEdit = profile != null;
-    
+
     bool enableUsenet = profile?['enableUsenet'] as bool? ?? true;
     bool enableTorrent = profile?['enableTorrent'] as bool? ?? true;
-    String preferredProtocol = profile?['preferredProtocol'] as String? ?? 'usenet';
+    String preferredProtocol =
+        profile?['preferredProtocol'] as String? ?? 'usenet';
     final usenetDelayController = TextEditingController(
-        text: (profile?['usenetDelay'] as int? ?? 0).toString(),);
+      text: (profile?['usenetDelay'] as int? ?? 0).toString(),
+    );
     final torrentDelayController = TextEditingController(
-        text: (profile?['torrentDelay'] as int? ?? 0).toString(),);
+      text: (profile?['torrentDelay'] as int? ?? 0).toString(),
+    );
     bool bypassIfHighest = profile?['bypassIfHighestQuality'] as bool? ?? true;
 
     await showDialog<void>(
@@ -520,7 +546,8 @@ class _DelayProfilesTab extends ConsumerWidget {
                       contentPadding: EdgeInsets.zero,
                       title: const Text('Enable Usenet'),
                       value: enableUsenet,
-                      onChanged: (val) => setDialogState(() => enableUsenet = val),
+                      onChanged: (val) =>
+                          setDialogState(() => enableUsenet = val),
                     ),
                     if (enableUsenet)
                       TextField(
@@ -536,7 +563,8 @@ class _DelayProfilesTab extends ConsumerWidget {
                       contentPadding: EdgeInsets.zero,
                       title: const Text('Enable Torrent'),
                       value: enableTorrent,
-                      onChanged: (val) => setDialogState(() => enableTorrent = val),
+                      onChanged: (val) =>
+                          setDialogState(() => enableTorrent = val),
                     ),
                     if (enableTorrent)
                       TextField(
@@ -559,9 +587,13 @@ class _DelayProfilesTab extends ConsumerWidget {
                       // never hits the missing-value assert.
                       items: [
                         const DropdownMenuItem(
-                            value: 'usenet', child: Text('Usenet'),),
+                          value: 'usenet',
+                          child: Text('Usenet'),
+                        ),
                         const DropdownMenuItem(
-                            value: 'torrent', child: Text('Torrent'),),
+                          value: 'torrent',
+                          child: Text('Torrent'),
+                        ),
                         if (preferredProtocol != 'usenet' &&
                             preferredProtocol != 'torrent')
                           DropdownMenuItem(
@@ -580,7 +612,8 @@ class _DelayProfilesTab extends ConsumerWidget {
                       contentPadding: EdgeInsets.zero,
                       title: const Text('Bypass if Highest Quality'),
                       value: bypassIfHighest,
-                      onChanged: (val) => setDialogState(() => bypassIfHighest = val),
+                      onChanged: (val) =>
+                          setDialogState(() => bypassIfHighest = val),
                     ),
                   ],
                 ),
@@ -593,18 +626,21 @@ class _DelayProfilesTab extends ConsumerWidget {
                 ElevatedButton(
                   onPressed: () async {
                     try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
+                      final api =
+                          await ref.read(sonarrApiProvider(instance).future);
                       final payload = profile != null
                           ? Map<String, dynamic>.from(profile)
                           : <String, dynamic>{
                               'order': 1,
                               'tags': <int>[],
                             };
-                      
+
                       payload['enableUsenet'] = enableUsenet;
                       payload['enableTorrent'] = enableTorrent;
-                      payload['usenetDelay'] = int.tryParse(usenetDelayController.text) ?? 0;
-                      payload['torrentDelay'] = int.tryParse(torrentDelayController.text) ?? 0;
+                      payload['usenetDelay'] =
+                          int.tryParse(usenetDelayController.text) ?? 0;
+                      payload['torrentDelay'] =
+                          int.tryParse(torrentDelayController.text) ?? 0;
                       payload['preferredProtocol'] = preferredProtocol;
                       payload['bypassIfHighestQuality'] = bypassIfHighest;
 
@@ -618,7 +654,9 @@ class _DelayProfilesTab extends ConsumerWidget {
                       if (context.mounted) {
                         Navigator.pop(context);
                         ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Delay profile ${isEdit ? 'updated' : 'created'}!')),
+                          SnackBar(
+                              content: Text(
+                                  'Delay profile ${isEdit ? 'updated' : 'created'}!')),
                         );
                       }
                     } catch (e) {
@@ -640,7 +678,10 @@ class _DelayProfilesTab extends ConsumerWidget {
   }
 
   Future<void> _deleteDelayProfile(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     if (!await confirmDelete(context, 'this delay profile')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -686,8 +727,10 @@ class _DelayProfilesTab extends ConsumerWidget {
               final id = profile['id'] as int;
               final usenetDelay = profile['usenetDelay'] as int? ?? 0;
               final torrentDelay = profile['torrentDelay'] as int? ?? 0;
-              final preferred = profile['preferredProtocol'] as String? ?? 'usenet';
-              final bypass = profile['bypassIfHighestQuality'] as bool? ?? false;
+              final preferred =
+                  profile['preferredProtocol'] as String? ?? 'usenet';
+              final bypass =
+                  profile['bypassIfHighestQuality'] as bool? ?? false;
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.md),
@@ -712,7 +755,8 @@ class _DelayProfilesTab extends ConsumerWidget {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showDelayProfileDialog(context, ref, profile),
+                        onPressed: () =>
+                            _showDelayProfileDialog(context, ref, profile),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),
@@ -753,14 +797,20 @@ class _ReleaseProfilesTab extends ConsumerWidget {
       .toList();
 
   Future<void> _showReleaseProfileDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? profile,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? profile,
+  ]) async {
     final isEdit = profile != null;
 
-    final nameController = TextEditingController(text: profile?['name'] as String? ?? '');
+    final nameController =
+        TextEditingController(text: profile?['name'] as String? ?? '');
     final requiredController = TextEditingController(
-        text: _termsToText(profile?['required']),);
+      text: _termsToText(profile?['required']),
+    );
     final ignoredController = TextEditingController(
-        text: _termsToText(profile?['ignored']),);
+      text: _termsToText(profile?['ignored']),
+    );
     bool enabled = profile?['enabled'] as bool? ?? true;
 
     await showDialog<void>(
@@ -769,7 +819,8 @@ class _ReleaseProfilesTab extends ConsumerWidget {
         return StatefulBuilder(
           builder: (context, setDialogState) {
             return AlertDialog(
-              title: Text(isEdit ? 'Edit Release Profile' : 'Add Release Profile'),
+              title:
+                  Text(isEdit ? 'Edit Release Profile' : 'Add Release Profile'),
               content: SingleChildScrollView(
                 child: Column(
                   mainAxisSize: MainAxisSize.min,
@@ -815,7 +866,8 @@ class _ReleaseProfilesTab extends ConsumerWidget {
                 ElevatedButton(
                   onPressed: () async {
                     try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
+                      final api =
+                          await ref.read(sonarrApiProvider(instance).future);
                       final payload = profile != null
                           ? Map<String, dynamic>.from(profile)
                           : <String, dynamic>{
@@ -824,7 +876,8 @@ class _ReleaseProfilesTab extends ConsumerWidget {
                             };
 
                       payload['name'] = nameController.text.trim();
-                      payload['required'] = _textToTerms(requiredController.text);
+                      payload['required'] =
+                          _textToTerms(requiredController.text);
                       payload['ignored'] = _textToTerms(ignoredController.text);
                       payload['enabled'] = enabled;
 
@@ -838,7 +891,9 @@ class _ReleaseProfilesTab extends ConsumerWidget {
                       if (context.mounted) {
                         Navigator.pop(context);
                         ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Release profile ${isEdit ? 'updated' : 'created'}!')),
+                          SnackBar(
+                              content: Text(
+                                  'Release profile ${isEdit ? 'updated' : 'created'}!')),
                         );
                       }
                     } catch (e) {
@@ -860,7 +915,10 @@ class _ReleaseProfilesTab extends ConsumerWidget {
   }
 
   Future<void> _deleteReleaseProfile(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     if (!await confirmDelete(context, 'this release profile')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -883,7 +941,8 @@ class _ReleaseProfilesTab extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
-    final releaseProfilesAsync = ref.watch(sonarrReleaseProfilesProvider(instance));
+    final releaseProfilesAsync =
+        ref.watch(sonarrReleaseProfilesProvider(instance));
 
     return Scaffold(
       floatingActionButton: FloatingActionButton(
@@ -932,11 +991,13 @@ class _ReleaseProfilesTab extends ConsumerWidget {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showReleaseProfileDialog(context, ref, profile),
+                        onPressed: () =>
+                            _showReleaseProfileDialog(context, ref, profile),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),
-                        onPressed: () => _deleteReleaseProfile(context, ref, id),
+                        onPressed: () =>
+                            _deleteReleaseProfile(context, ref, id),
                       ),
                     ],
                   ),
@@ -959,11 +1020,16 @@ class _CustomFormatsTab extends ConsumerWidget {
   final Instance instance;
 
   Future<void> _showCustomFormatDialog(
-      BuildContext context, WidgetRef ref, [Map<String, dynamic>? format,]) async {
+    BuildContext context,
+    WidgetRef ref, [
+    Map<String, dynamic>? format,
+  ]) async {
     final isEdit = format != null;
-    
-    final nameController = TextEditingController(text: format?['name'] as String? ?? '');
-    bool includeWhenRenaming = format?['includeCustomFormatWhenRenaming'] as bool? ?? false;
+
+    final nameController =
+        TextEditingController(text: format?['name'] as String? ?? '');
+    bool includeWhenRenaming =
+        format?['includeCustomFormatWhenRenaming'] as bool? ?? false;
 
     await showDialog<void>(
       context: context,
@@ -987,9 +1053,11 @@ class _CustomFormatsTab extends ConsumerWidget {
                     SwitchListTile(
                       contentPadding: EdgeInsets.zero,
                       title: const Text('Include in Rename'),
-                      subtitle: const Text('Incorporate format in renaming output tokens'),
+                      subtitle: const Text(
+                          'Incorporate format in renaming output tokens'),
                       value: includeWhenRenaming,
-                      onChanged: (val) => setDialogState(() => includeWhenRenaming = val),
+                      onChanged: (val) =>
+                          setDialogState(() => includeWhenRenaming = val),
                     ),
                     if (!isEdit) ...[
                       const SizedBox(height: Insets.md),
@@ -1016,30 +1084,34 @@ class _CustomFormatsTab extends ConsumerWidget {
                   onPressed: !isEdit
                       ? null
                       : () async {
-                    try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
-                      final payload = Map<String, dynamic>.from(format);
+                          try {
+                            final api = await ref
+                                .read(sonarrApiProvider(instance).future);
+                            final payload = Map<String, dynamic>.from(format);
 
-                      payload['name'] = nameController.text.trim();
-                      payload['includeCustomFormatWhenRenaming'] = includeWhenRenaming;
+                            payload['name'] = nameController.text.trim();
+                            payload['includeCustomFormatWhenRenaming'] =
+                                includeWhenRenaming;
 
-                      await api.updateCustomFormat(payload);
+                            await api.updateCustomFormat(payload);
 
-                      ref.invalidate(sonarrCustomFormatsProvider(instance));
-                      if (context.mounted) {
-                        Navigator.pop(context);
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          const SnackBar(content: Text('Custom format updated!')),
-                        );
-                      }
-                    } catch (e) {
-                      if (context.mounted) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Error: $e')),
-                        );
-                      }
-                    }
-                  },
+                            ref.invalidate(
+                                sonarrCustomFormatsProvider(instance));
+                            if (context.mounted) {
+                              Navigator.pop(context);
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content: Text('Custom format updated!')),
+                              );
+                            }
+                          } catch (e) {
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Error: $e')),
+                              );
+                            }
+                          }
+                        },
                   child: const Text('Save'),
                 ),
               ],
@@ -1051,7 +1123,10 @@ class _CustomFormatsTab extends ConsumerWidget {
   }
 
   Future<void> _deleteCustomFormat(
-      BuildContext context, WidgetRef ref, int id,) async {
+    BuildContext context,
+    WidgetRef ref,
+    int id,
+  ) async {
     if (!await confirmDelete(context, 'this custom format')) return;
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
@@ -1096,7 +1171,8 @@ class _CustomFormatsTab extends ConsumerWidget {
               final format = formats[index];
               final id = format['id'] as int;
               final name = (format['name'] as String?) ?? 'Custom Format';
-              final includeRename = format['includeCustomFormatWhenRenaming'] as bool? ?? false;
+              final includeRename =
+                  format['includeCustomFormatWhenRenaming'] as bool? ?? false;
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.md),
@@ -1121,7 +1197,8 @@ class _CustomFormatsTab extends ConsumerWidget {
                     children: [
                       IconButton(
                         icon: const Icon(Icons.edit_outlined),
-                        onPressed: () => _showCustomFormatDialog(context, ref, format),
+                        onPressed: () =>
+                            _showCustomFormatDialog(context, ref, format),
                       ),
                       IconButton(
                         icon: const Icon(Icons.delete_outline),

--- a/services/service_sonarr/lib/src/home/settings/quality_definitions_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/quality_definitions_screen.dart
@@ -20,7 +20,8 @@ class QualityDefinitionsScreen extends ConsumerStatefulWidget {
       _QualityDefinitionsScreenState();
 }
 
-class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScreen> {
+class _QualityDefinitionsScreenState
+    extends ConsumerState<QualityDefinitionsScreen> {
   bool _initialized = false;
   bool _saving = false;
   late List<Map<String, dynamic>> _definitions;
@@ -29,9 +30,7 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
     if (_initialized) return;
     _initialized = true;
     // Perform deep copy so editing doesn't mutate cache directly before save
-    _definitions = data
-        .map(Map<String, dynamic>.from)
-        .toList();
+    _definitions = data.map(Map<String, dynamic>.from).toList();
   }
 
   Future<void> _save() async {
@@ -42,7 +41,8 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
       ref.invalidate(sonarrQualityDefinitionsProvider(widget.instance));
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Quality definitions updated successfully!')),
+          const SnackBar(
+              content: Text('Quality definitions updated successfully!')),
         );
         Navigator.pop(context);
       }
@@ -60,7 +60,8 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final definitionsAsync = ref.watch(sonarrQualityDefinitionsProvider(widget.instance));
+    final definitionsAsync =
+        ref.watch(sonarrQualityDefinitionsProvider(widget.instance));
 
     return Scaffold(
       appBar: AppBar(
@@ -95,11 +96,12 @@ class _QualityDefinitionsScreenState extends ConsumerState<QualityDefinitionsScr
               final def = _definitions[index];
               final qualityMap = def['quality'] as Map<String, dynamic>?;
               final qName = (qualityMap?['name'] as String?) ?? 'Unknown';
-              
+
               // min/max/preferred are usually represented as double (MB per minute)
               final double minVal = (def['minSize'] as num?)?.toDouble() ?? 0.0;
               final double? maxVal = (def['maxSize'] as num?)?.toDouble();
-              final double prefVal = (def['preferredSize'] as num?)?.toDouble() ?? minVal;
+              final double prefVal =
+                  (def['preferredSize'] as num?)?.toDouble() ?? minVal;
 
               final bool isUnlimited = maxVal == null || maxVal == 0;
 

--- a/services/service_sonarr/lib/src/home/settings/tags_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/tags_settings_screen.dart
@@ -40,7 +40,8 @@ class TagsSettingsScreen extends ConsumerWidget {
                 if (label.isEmpty) return;
 
                 try {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   await api.createTag(label);
                   ref.invalidate(sonarrTagsProvider(instance));
                   if (context.mounted) {

--- a/services/service_sonarr/lib/src/home/settings/ui_settings_screen.dart
+++ b/services/service_sonarr/lib/src/home/settings/ui_settings_screen.dart
@@ -23,7 +23,7 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
   int _firstDayOfWeek = 0;
   bool _showRelativeDates = true;
   bool _enableColorImpairedMode = false;
-  
+
   late final TextEditingController _shortDateFormatController;
   late final TextEditingController _longDateFormatController;
   late final TextEditingController _timeFormatController;
@@ -55,10 +55,13 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
 
     _firstDayOfWeek = config['firstDayOfWeek'] as int? ?? 0;
     _showRelativeDates = config['showRelativeDates'] as bool? ?? true;
-    _enableColorImpairedMode = config['enableColorImpairedMode'] as bool? ?? false;
+    _enableColorImpairedMode =
+        config['enableColorImpairedMode'] as bool? ?? false;
 
-    _shortDateFormatController.text = (config['shortDateFormat'] as String?) ?? 'MMM dd yyyy';
-    _longDateFormatController.text = (config['longDateFormat'] as String?) ?? 'dddd, MMMM dd yyyy';
+    _shortDateFormatController.text =
+        (config['shortDateFormat'] as String?) ?? 'MMM dd yyyy';
+    _longDateFormatController.text =
+        (config['longDateFormat'] as String?) ?? 'dddd, MMMM dd yyyy';
     _timeFormatController.text = (config['timeFormat'] as String?) ?? 'h:mmtt';
   }
 
@@ -166,7 +169,8 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                             DropdownMenuItem(value: 0, child: Text('Sunday')),
                             DropdownMenuItem(value: 1, child: Text('Monday')),
                             DropdownMenuItem(value: 2, child: Text('Tuesday')),
-                            DropdownMenuItem(value: 3, child: Text('Wednesday')),
+                            DropdownMenuItem(
+                                value: 3, child: Text('Wednesday')),
                             DropdownMenuItem(value: 4, child: Text('Thursday')),
                             DropdownMenuItem(value: 5, child: Text('Friday')),
                             DropdownMenuItem(value: 6, child: Text('Saturday')),
@@ -181,9 +185,11 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                         SwitchListTile(
                           contentPadding: EdgeInsets.zero,
                           title: const Text('Show Relative Dates'),
-                          subtitle: const Text('Show relative terms like "Yesterday", "Today", or "In 2 days"'),
+                          subtitle: const Text(
+                              'Show relative terms like "Yesterday", "Today", or "In 2 days"'),
                           value: _showRelativeDates,
-                          onChanged: (val) => setState(() => _showRelativeDates = val),
+                          onChanged: (val) =>
+                              setState(() => _showRelativeDates = val),
                         ),
                       ],
                     ),
@@ -218,7 +224,9 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                             border: OutlineInputBorder(),
                           ),
                           validator: (val) =>
-                              (val == null || val.trim().isEmpty) ? 'Required' : null,
+                              (val == null || val.trim().isEmpty)
+                                  ? 'Required'
+                                  : null,
                         ),
                         const SizedBox(height: Insets.md),
                         TextFormField(
@@ -228,7 +236,9 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                             border: OutlineInputBorder(),
                           ),
                           validator: (val) =>
-                              (val == null || val.trim().isEmpty) ? 'Required' : null,
+                              (val == null || val.trim().isEmpty)
+                                  ? 'Required'
+                                  : null,
                         ),
                         const SizedBox(height: Insets.md),
                         TextFormField(
@@ -238,7 +248,9 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                             border: OutlineInputBorder(),
                           ),
                           validator: (val) =>
-                              (val == null || val.trim().isEmpty) ? 'Required' : null,
+                              (val == null || val.trim().isEmpty)
+                                  ? 'Required'
+                                  : null,
                         ),
                       ],
                     ),
@@ -269,9 +281,11 @@ class _UiSettingsScreenState extends ConsumerState<UiSettingsScreen> {
                         SwitchListTile(
                           contentPadding: EdgeInsets.zero,
                           title: const Text('Enable Color-Impaired Mode'),
-                          subtitle: const Text('Uses high-contrast borders and symbols instead of green/red/orange'),
+                          subtitle: const Text(
+                              'Uses high-contrast borders and symbols instead of green/red/orange'),
                           value: _enableColorImpairedMode,
-                          onChanged: (val) => setState(() => _enableColorImpairedMode = val),
+                          onChanged: (val) =>
+                              setState(() => _enableColorImpairedMode = val),
                         ),
                       ],
                     ),

--- a/services/service_sonarr/lib/src/home/settings/widgets/dynamic_schema_form.dart
+++ b/services/service_sonarr/lib/src/home/settings/widgets/dynamic_schema_form.dart
@@ -41,8 +41,7 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       // keyValueList, ...) falls through to a text field and needs a
       // controller, otherwise the input is silently discarded on save.
       if (type == 'checkbox' || type == 'select') continue;
-      final text =
-          value is List ? value.join(',') : value?.toString() ?? '';
+      final text = value is List ? value.join(',') : value?.toString() ?? '';
       _controllers[name] = TextEditingController(text: text);
       _initialTexts[name] = text;
     }
@@ -132,7 +131,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final hasAdvanced = _localFields.any((f) => f['advanced'] as bool? ?? false);
+    final hasAdvanced =
+        _localFields.any((f) => f['advanced'] as bool? ?? false);
 
     // Filter fields to build based on hidden/visibility properties
     final visibleFields = _localFields.where((f) {
@@ -195,7 +195,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
               ),
               child: Row(
                 children: [
-                  Icon(Icons.check_circle_outline, color: theme.colorScheme.onPrimaryContainer),
+                  Icon(Icons.check_circle_outline,
+                      color: theme.colorScheme.onPrimaryContainer),
                   const SizedBox(width: Insets.sm),
                   Text(
                     'Connection Test Successful!',
@@ -275,10 +276,10 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       final selectOptions = ((field['selectOptions'] as List<dynamic>?) ?? [])
           .cast<Map<String, dynamic>>();
       final value = field['value'];
-      
+
       // Select value can be string, int, or List of options for multiselect
       final isMulti = selectOptions.isNotEmpty && value is List;
-      
+
       if (isMulti) {
         final List<dynamic> listValue = List<dynamic>.from(value);
         return Padding(
@@ -288,13 +289,15 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
             children: [
               Text(
                 label,
-                style: theme.textTheme.bodyMedium?.copyWith(fontWeight: FontWeight.bold),
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(fontWeight: FontWeight.bold),
               ),
               if (helpText != null) ...[
                 const SizedBox(height: 2),
                 Text(
                   helpText,
-                  style: theme.textTheme.bodySmall?.copyWith(color: theme.colorScheme.onSurfaceVariant),
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: theme.colorScheme.onSurfaceVariant),
                 ),
               ],
               const SizedBox(height: Insets.sm),
@@ -331,8 +334,10 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       // Validate that value matches one of the options
       dynamic matchedValue;
       final valStr = (value as Object?)?.toString();
-      if (selectOptions.any((opt) => (opt['value'] as Object).toString() == valStr)) {
-        matchedValue = selectOptions.firstWhere((opt) => (opt['value'] as Object).toString() == valStr)['value'];
+      if (selectOptions
+          .any((opt) => (opt['value'] as Object).toString() == valStr)) {
+        matchedValue = selectOptions.firstWhere(
+            (opt) => (opt['value'] as Object).toString() == valStr)['value'];
       } else if (selectOptions.isNotEmpty) {
         matchedValue = selectOptions.first['value'];
       }
@@ -348,8 +353,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
             border: const OutlineInputBorder(),
           ),
           items: selectOptions.map((opt) {
-            final optName = (opt['name'] as String?) ??
-                (opt['value'] as Object).toString();
+            final optName =
+                (opt['name'] as String?) ?? (opt['value'] as Object).toString();
             return DropdownMenuItem<dynamic>(
               value: opt['value'],
               child: Text(optName),
@@ -371,7 +376,8 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
       child: TextFormField(
         controller: _controllers[name],
         obscureText: isPassword,
-        keyboardType: type == 'number' ? TextInputType.number : TextInputType.text,
+        keyboardType:
+            type == 'number' ? TextInputType.number : TextInputType.text,
         decoration: InputDecoration(
           labelText: label,
           helperText: helpText,

--- a/services/service_sonarr/lib/src/home/settings_tab.dart
+++ b/services/service_sonarr/lib/src/home/settings_tab.dart
@@ -41,83 +41,92 @@ class SettingsTab extends StatelessWidget {
           _buildSettingsCard(
             context: context,
             title: 'Media Management',
-            subtitle: 'Rename episodes, configure empty folders, copy links & permission details.',
+            subtitle:
+                'Rename episodes, configure empty folders, copy links & permission details.',
             icon: Icons.folder_open_outlined,
             screen: MediaManagementSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Profiles',
-            subtitle: 'Manage quality profiles, delay profiles, release profiles, and custom formats.',
+            subtitle:
+                'Manage quality profiles, delay profiles, release profiles, and custom formats.',
             icon: Icons.high_quality_outlined,
             screen: ProfilesSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Quality Definitions',
-            subtitle: 'Configure minimum, maximum, and preferred size limits per quality type.',
+            subtitle:
+                'Configure minimum, maximum, and preferred size limits per quality type.',
             icon: Icons.aspect_ratio_outlined,
             screen: QualityDefinitionsScreen(instance: instance),
           ),
           const SizedBox(height: Insets.md),
-
           _buildCategoryHeader(context, 'Network & Integration'),
           _buildSettingsCard(
             context: context,
             title: 'Indexers & Trackers',
-            subtitle: 'RSS feeds, automatic search, indexers list, and import lists configurations.',
+            subtitle:
+                'RSS feeds, automatic search, indexers list, and import lists configurations.',
             icon: Icons.rss_feed_outlined,
             screen: IndexersSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Download Clients',
-            subtitle: 'Clients list, connections, download tracking, and path override mappings.',
+            subtitle:
+                'Clients list, connections, download tracking, and path override mappings.',
             icon: Icons.download_for_offline_outlined,
             screen: DownloadClientsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Connect',
-            subtitle: 'Discord, Telegram, Email, Plex notifications and trigger events.',
+            subtitle:
+                'Discord, Telegram, Email, Plex notifications and trigger events.',
             icon: Icons.connect_without_contact,
             screen: ConnectSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Metadata Consumers',
-            subtitle: 'Configure metadata files creation for Kodi, Plex, Emby, and WDTV.',
+            subtitle:
+                'Configure metadata files creation for Kodi, Plex, Emby, and WDTV.',
             icon: Icons.settings_applications_outlined,
             screen: MetadataSettingsScreen(instance: instance),
           ),
           const SizedBox(height: Insets.md),
-
           _buildCategoryHeader(context, 'Application System'),
           _buildSettingsCard(
             context: context,
             title: 'General',
-            subtitle: 'Set server listening port, SSL certifications, API Keys, and logs.',
+            subtitle:
+                'Set server listening port, SSL certifications, API Keys, and logs.',
             icon: Icons.dns_outlined,
             screen: GeneralSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'UI Settings',
-            subtitle: 'Date formatting, first day of week selection, and color options.',
+            subtitle:
+                'Date formatting, first day of week selection, and color options.',
             icon: Icons.palette_outlined,
             screen: UiSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Tags',
-            subtitle: 'Manage label identifiers for categories, series, and profiles.',
+            subtitle:
+                'Manage label identifiers for categories, series, and profiles.',
             icon: Icons.label_outline,
             screen: TagsSettingsScreen(instance: instance),
           ),
           _buildSettingsCard(
             context: context,
             title: 'Connection Settings',
-            subtitle: 'Edit connection URL, API Key, and label for this Sonarr instance in Atrium.',
+            subtitle:
+                'Edit connection URL, API Key, and label for this Sonarr instance in Atrium.',
             icon: Icons.key_outlined,
             onTap: () {
               context.pushNamed(
@@ -129,17 +138,18 @@ class SettingsTab extends StatelessWidget {
             },
           ),
           const SizedBox(height: Insets.md),
-
           _buildCategoryHeader(context, 'Diagnostics & Troubleshooting'),
           _buildSettingsCard(
             context: context,
             title: 'Parse Title',
-            subtitle: 'Extract metadata and check matching series database results for any release name.',
+            subtitle:
+                'Extract metadata and check matching series database results for any release name.',
             icon: Icons.troubleshoot_outlined,
             onTap: () {
               showDialog<void>(
                 context: context,
-                builder: (context) => SonarrParseTitleDialog(instance: instance),
+                builder: (context) =>
+                    SonarrParseTitleDialog(instance: instance),
               ).ignore();
             },
           ),
@@ -182,11 +192,12 @@ class SettingsTab extends StatelessWidget {
       ),
       child: InkWell(
         borderRadius: Radii.card,
-        onTap: onTap ?? () {
-          if (screen != null) {
-            pushScreen<void>(context, screen);
-          }
-        },
+        onTap: onTap ??
+            () {
+              if (screen != null) {
+                pushScreen<void>(context, screen);
+              }
+            },
         child: Padding(
           padding: const EdgeInsets.all(Insets.md),
           child: Row(

--- a/services/service_sonarr/lib/src/home/system_tab.dart
+++ b/services/service_sonarr/lib/src/home/system_tab.dart
@@ -8,6 +8,7 @@ import 'package:url_launcher/url_launcher.dart';
 
 import '../sonarr_api.dart';
 import '../sonarr_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class SystemTab extends ConsumerStatefulWidget {
   const SystemTab({required this.instance, super.key});
@@ -249,35 +250,23 @@ class _StatusTab extends ConsumerWidget {
 
           // ── About / Status ──
           statusAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
             error: (Object err, _) => _sectionError('Status', err),
             data: (Map<String, dynamic> s) {
-              final String version =
-                  s['version'] as String? ?? 'Unknown';
-              final String branch =
-                  s['branch'] as String? ?? 'Unknown';
-              final String osName =
-                  s['osName'] as String? ?? 'Unknown';
-              final String osVersion =
-                  s['osVersion'] as String? ?? '';
-              final String runtimeName =
-                  s['runtimeName'] as String? ?? '';
+              final String version = s['version'] as String? ?? 'Unknown';
+              final String branch = s['branch'] as String? ?? 'Unknown';
+              final String osName = s['osName'] as String? ?? 'Unknown';
+              final String osVersion = s['osVersion'] as String? ?? '';
+              final String runtimeName = s['runtimeName'] as String? ?? '';
               final String runtimeVersion =
                   s['runtimeVersion'] as String? ?? '';
               final bool isDocker = s['isDocker'] as bool? ?? false;
-              final String packageAuthor =
-                  s['packageAuthor'] as String? ?? '';
-              final String dbType =
-                  s['databaseType'] as String? ?? '';
-              final String dbVersion =
-                  s['databaseVersion'] as String? ?? '';
-              final String startTimeStr =
-                  s['startTime'] as String? ?? '';
-              final String appData =
-                  s['appData'] as String? ?? '';
-              final String startupPath =
-                  s['startupPath'] as String? ?? '';
+              final String packageAuthor = s['packageAuthor'] as String? ?? '';
+              final String dbType = s['databaseType'] as String? ?? '';
+              final String dbVersion = s['databaseVersion'] as String? ?? '';
+              final String startTimeStr = s['startTime'] as String? ?? '';
+              final String appData = s['appData'] as String? ?? '';
+              final String startupPath = s['startupPath'] as String? ?? '';
 
               String uptimeText = '';
               if (startTimeStr.isNotEmpty) {
@@ -289,8 +278,7 @@ class _StatusTab extends ConsumerWidget {
                   uptimeText =
                       '${uptime.inDays}d ${uptime.inHours % 24}h ${uptime.inMinutes % 60}m';
                 } else if (uptime.inHours > 0) {
-                  uptimeText =
-                      '${uptime.inHours}h ${uptime.inMinutes % 60}m';
+                  uptimeText = '${uptime.inHours}h ${uptime.inMinutes % 60}m';
                 } else {
                   uptimeText = '${uptime.inMinutes}m';
                 }
@@ -383,8 +371,7 @@ class _StatusTab extends ConsumerWidget {
                 children: <Widget>[
                   _sectionHeader(theme, 'Disk Space'),
                   ...disks.map(
-                    (Map<String, dynamic> d) =>
-                        _DiskSpaceCard(disk: d),
+                    (Map<String, dynamic> d) => _DiskSpaceCard(disk: d),
                   ),
                 ],
               );
@@ -547,8 +534,7 @@ class _DiskSpaceCard extends StatelessWidget {
     final int freeSpace = disk['freeSpace'] as int? ?? 0;
     final int totalSpace = disk['totalSpace'] as int? ?? 1;
     final int usedSpace = totalSpace - freeSpace;
-    final double usedPercent =
-        totalSpace > 0 ? usedSpace / totalSpace : 0.0;
+    final double usedPercent = totalSpace > 0 ? usedSpace / totalSpace : 0.0;
 
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -592,17 +578,13 @@ class _DiskSpaceCard extends StatelessWidget {
             const SizedBox(height: Insets.sm),
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
-                value: usedPercent,
-                minHeight: 8,
-                backgroundColor:
-                    theme.colorScheme.surfaceContainerHighest,
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  usedPercent > 0.9
+              child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
+                  value: usedPercent,
+                  trackColor: theme.colorScheme.surfaceContainerHighest,
+                  activeColor: usedPercent > 0.9
                       ? theme.colorScheme.error
-                      : theme.colorScheme.primary,
-                ),
-              ),
+                      : theme.colorScheme.primary),
             ),
             const SizedBox(height: Insets.xs),
             Text(
@@ -643,8 +625,7 @@ class _TasksTab extends ConsumerWidget {
     String taskName,
   ) async {
     try {
-      final SonarrApi api =
-          await ref.read(sonarrApiProvider(instance).future);
+      final SonarrApi api = await ref.read(sonarrApiProvider(instance).future);
       await api.runCommand(<String, dynamic>{'name': taskName});
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -674,10 +655,8 @@ class _TasksTab extends ConsumerWidget {
         await ref.read(sonarrTasksProvider(instance).future);
       },
       child: tasksAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> tasks) {
           if (tasks.isEmpty) {
             return const Center(child: Text('No scheduled tasks.'));
@@ -688,24 +667,16 @@ class _TasksTab extends ConsumerWidget {
             itemCount: tasks.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> task = tasks[index];
-              final String name =
-                  task['name'] as String? ?? 'Task';
-              final String taskName =
-                  task['taskName'] as String? ?? '';
-              final int interval =
-                  task['interval'] as int? ?? 0;
-              final String lastExecStr =
-                  task['lastExecution'] as String? ?? '';
-              final String nextExecStr =
-                  task['nextExecution'] as String? ?? '';
-              final String lastDuration =
-                  task['lastDuration'] as String? ?? '';
+              final String name = task['name'] as String? ?? 'Task';
+              final String taskName = task['taskName'] as String? ?? '';
+              final int interval = task['interval'] as int? ?? 0;
+              final String lastExecStr = task['lastExecution'] as String? ?? '';
+              final String nextExecStr = task['nextExecution'] as String? ?? '';
+              final String lastDuration = task['lastDuration'] as String? ?? '';
 
               final String intervalText = _formatInterval(interval);
-              final String lastExecText =
-                  _formatRelativeTime(lastExecStr);
-              final String nextExecText =
-                  _formatRelativeTime(nextExecStr);
+              final String lastExecText = _formatRelativeTime(lastExecStr);
+              final String nextExecText = _formatRelativeTime(nextExecStr);
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -748,8 +719,7 @@ class _TasksTab extends ConsumerWidget {
                   trailing: IconButton(
                     icon: const Icon(Icons.play_arrow_outlined),
                     tooltip: 'Run now',
-                    onPressed: () =>
-                        _runTask(context, ref, taskName),
+                    onPressed: () => _runTask(context, ref, taskName),
                   ),
                 ),
               );
@@ -826,10 +796,8 @@ class _UpdatesTab extends ConsumerWidget {
         await ref.read(sonarrUpdatesProvider(instance).future);
       },
       child: updatesAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> updates) {
           if (updates.isEmpty) {
             return const Center(
@@ -863,21 +831,18 @@ class _UpdateCard extends StatelessWidget {
     final String branch = update['branch'] as String? ?? '';
     final bool installed = update['installed'] as bool? ?? false;
     final bool latest = update['latest'] as bool? ?? false;
-    final String releaseDateStr =
-        update['releaseDate'] as String? ?? '';
+    final String releaseDateStr = update['releaseDate'] as String? ?? '';
     final Map<String, dynamic>? changes =
         update['changes'] as Map<String, dynamic>?;
 
-    final List<String> newItems =
-        (changes?['new'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
-    final List<String> fixedItems =
-        (changes?['fixed'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
+    final List<String> newItems = (changes?['new'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
+    final List<String> fixedItems = (changes?['fixed'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
 
     String releaseDateText = '';
     if (releaseDateStr.isNotEmpty) {
@@ -891,9 +856,8 @@ class _UpdateCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.md),
       elevation: 0,
-      color: installed
-          ? theme.colorScheme.primaryContainer.withAlpha(50)
-          : null,
+      color:
+          installed ? theme.colorScheme.primaryContainer.withAlpha(50) : null,
       shape: RoundedRectangleBorder(
         side: BorderSide(
           color: installed
@@ -925,23 +889,19 @@ class _UpdateCard extends StatelessWidget {
                       color: theme.colorScheme.onPrimaryContainer,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
                 if (latest && !installed)
                   Chip(
                     label: const Text('Latest'),
-                    backgroundColor:
-                        theme.colorScheme.tertiary.withAlpha(30),
-                    labelStyle:
-                        theme.textTheme.labelSmall?.copyWith(
+                    backgroundColor: theme.colorScheme.tertiary.withAlpha(30),
+                    labelStyle: theme.textTheme.labelSmall?.copyWith(
                       color: theme.colorScheme.tertiary,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
@@ -1062,12 +1022,14 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final logsAsync = ref.watch(
-      sonarrLogsProvider((
-        widget.instance,
-        page: _currentPage,
-        pageSize: _pageSize,
-        level: _levelFilter,
-      ),),
+      sonarrLogsProvider(
+        (
+          widget.instance,
+          page: _currentPage,
+          pageSize: _pageSize,
+          level: _levelFilter,
+        ),
+      ),
     );
 
     return Column(
@@ -1122,15 +1084,12 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
 
         Expanded(
           child: logsAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
-            error: (Object err, _) =>
-                Center(child: Text('Error: $err')),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
+            error: (Object err, _) => Center(child: Text('Error: $err')),
             data: (Map<String, dynamic> data) {
               final List<dynamic> records =
                   data['records'] as List<dynamic>? ?? <dynamic>[];
-              final int totalRecords =
-                  data['totalRecords'] as int? ?? 0;
+              final int totalRecords = data['totalRecords'] as int? ?? 0;
               final int totalPages =
                   (totalRecords / _pageSize).ceil().clamp(1, 9999);
 
@@ -1143,19 +1102,22 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                   Expanded(
                     child: M3RefreshIndicator(
                       onRefresh: () async {
-                        ref.invalidate(sonarrLogsProvider((
-                          widget.instance,
-                          page: _currentPage,
-                          pageSize: _pageSize,
-                          level: _levelFilter,
-                        ),),);
+                        ref.invalidate(
+                          sonarrLogsProvider(
+                            (
+                              widget.instance,
+                              page: _currentPage,
+                              pageSize: _pageSize,
+                              level: _levelFilter,
+                            ),
+                          ),
+                        );
                       },
                       child: ListView.builder(
                         padding:
                             const EdgeInsets.symmetric(horizontal: Insets.md),
                         itemCount: records.length,
-                        itemBuilder:
-                            (BuildContext context, int index) {
+                        itemBuilder: (BuildContext context, int index) {
                           final Map<String, dynamic> log =
                               records[index] as Map<String, dynamic>;
                           return _LogEntryTile(log: log);
@@ -1173,8 +1135,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_left),
                           onPressed: _currentPage > 1
-                              ? () =>
-                                  setState(() => _currentPage--)
+                              ? () => setState(() => _currentPage--)
                               : null,
                         ),
                         Text(
@@ -1184,8 +1145,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_right),
                           onPressed: _currentPage < totalPages
-                              ? () =>
-                                  setState(() => _currentPage++)
+                              ? () => setState(() => _currentPage++)
                               : null,
                         ),
                       ],
@@ -1317,8 +1277,7 @@ class _LogEntryTile extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 4),
                         child: Text(
                           exception,
-                          style:
-                              theme.textTheme.bodySmall?.copyWith(
+                          style: theme.textTheme.bodySmall?.copyWith(
                             color: theme.colorScheme.error,
                             fontFamily: 'monospace',
                             fontSize: 11,
@@ -1409,10 +1368,8 @@ class _BackupsTab extends ConsumerWidget {
         await ref.read(sonarrBackupsProvider(instance).future);
       },
       child: backupsAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> backups) {
           if (backups.isEmpty) {
             return const Center(child: Text('No backups found.'));
@@ -1423,14 +1380,11 @@ class _BackupsTab extends ConsumerWidget {
             itemCount: backups.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> backup = backups[index];
-              final String name =
-                  backup['name'] as String? ?? 'Backup';
-              final String type =
-                  backup['type'] as String? ?? 'unknown';
+              final String name = backup['name'] as String? ?? 'Backup';
+              final String type = backup['type'] as String? ?? 'unknown';
               final int size = backup['size'] as int? ?? 0;
               final int id = backup['id'] as int? ?? 0;
-              final String timeStr =
-                  backup['time'] as String? ?? '';
+              final String timeStr = backup['time'] as String? ?? '';
 
               String dateText = '';
               if (timeStr.isNotEmpty) {
@@ -1465,8 +1419,7 @@ class _BackupsTab extends ConsumerWidget {
                 ),
                 child: ListTile(
                   leading: CircleAvatar(
-                    backgroundColor:
-                        theme.colorScheme.surfaceContainerHighest,
+                    backgroundColor: theme.colorScheme.surfaceContainerHighest,
                     child: Icon(
                       typeIcon,
                       color: theme.colorScheme.onSurfaceVariant,
@@ -1491,8 +1444,7 @@ class _BackupsTab extends ConsumerWidget {
                       Icons.delete_outline,
                       color: theme.colorScheme.error,
                     ),
-                    onPressed: () =>
-                        _deleteBackup(context, ref, id, name),
+                    onPressed: () => _deleteBackup(context, ref, id, name),
                   ),
                 ),
               );

--- a/services/service_sonarr/lib/src/home/wanted_tab.dart
+++ b/services/service_sonarr/lib/src/home/wanted_tab.dart
@@ -105,7 +105,9 @@ class _WantedTabState extends ConsumerState<WantedTab>
       await api.performEpisodeSearch(ids);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Search started for ${ids.length} selected episodes.')),
+          SnackBar(
+              content:
+                  Text('Search started for ${ids.length} selected episodes.')),
         );
       }
     } catch (e) {
@@ -189,7 +191,8 @@ class _WantedTabState extends ConsumerState<WantedTab>
     final Set<int> selectedEpisodeIds =
         ref.watch(sonarrWantedSelectionProvider(widget.instance));
     final bool hasSelection = selectedEpisodeIds.isNotEmpty;
-    final bool isGrouped = ref.watch(sonarrWantedGroupedProvider(widget.instance));
+    final bool isGrouped =
+        ref.watch(sonarrWantedGroupedProvider(widget.instance));
 
     // Keep the local controller in sync when the search query is cleared
     // externally (SonarrHome unwinds search state on system back).
@@ -209,7 +212,8 @@ class _WantedTabState extends ConsumerState<WantedTab>
       child: Scaffold(
         backgroundColor: theme.colorScheme.surface,
         body: NestedScrollView(
-          headerSliverBuilder: (BuildContext innerContext, bool innerBoxIsScrolled) {
+          headerSliverBuilder:
+              (BuildContext innerContext, bool innerBoxIsScrolled) {
             return <Widget>[
               SliverAppBar(
                 floating: true,
@@ -302,12 +306,18 @@ class _WantedTabState extends ConsumerState<WantedTab>
                     : <Widget>[
                         IconButton(
                           icon: Icon(
-                            isGrouped ? Icons.format_list_bulleted : Icons.group_work_outlined,
+                            isGrouped
+                                ? Icons.format_list_bulleted
+                                : Icons.group_work_outlined,
                           ),
-                          tooltip: isGrouped ? 'Switch to plain list' : 'Switch to grouped view',
+                          tooltip: isGrouped
+                              ? 'Switch to plain list'
+                              : 'Switch to grouped view',
                           onPressed: () {
                             ref
-                                .read(sonarrWantedGroupedProvider(widget.instance).notifier)
+                                .read(
+                                    sonarrWantedGroupedProvider(widget.instance)
+                                        .notifier)
                                 .update((state) => !state);
                           },
                         ),
@@ -438,7 +448,8 @@ class _EpisodeListLayout extends ConsumerWidget {
   final String Function(String?) formatAirDate;
   final VoidCallback onBulkSearch;
 
-  Future<void> _triggerSingleSearch(BuildContext context, WidgetRef ref, int episodeId) async {
+  Future<void> _triggerSingleSearch(
+      BuildContext context, WidgetRef ref, int episodeId) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       await api.performEpisodeSearch([episodeId]);
@@ -456,7 +467,8 @@ class _EpisodeListLayout extends ConsumerWidget {
     }
   }
 
-  void _showEpisodeDetails(BuildContext context, WidgetRef ref, SonarrEpisode episode) {
+  void _showEpisodeDetails(
+      BuildContext context, WidgetRef ref, SonarrEpisode episode) {
     showModalBottomSheet<void>(
       context: context,
       useRootNavigator: true,
@@ -489,7 +501,8 @@ class _EpisodeListLayout extends ConsumerWidget {
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Icon(Icons.error_outline, size: 48, color: theme.colorScheme.error),
+              Icon(Icons.error_outline,
+                  size: 48, color: theme.colorScheme.error),
               const SizedBox(height: 16),
               Text(
                 'Failed to load episodes',
@@ -527,7 +540,9 @@ class _EpisodeListLayout extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  isCutoffTab ? 'No cutoff unmet episodes' : 'No missing episodes',
+                  isCutoffTab
+                      ? 'No cutoff unmet episodes'
+                      : 'No missing episodes',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                     fontWeight: FontWeight.bold,
@@ -540,11 +555,11 @@ class _EpisodeListLayout extends ConsumerWidget {
 
         // Grouping logic by seriesId
         final List<Widget> listItems = [];
-        
+
         if (isGrouped) {
           final Map<int, List<SonarrEpisode>> groupedMap = {};
           final List<SonarrSeries> seriesList = [];
-          
+
           for (final ep in list) {
             final series = ep.series;
             if (series == null) continue;
@@ -566,7 +581,8 @@ class _EpisodeListLayout extends ConsumerWidget {
                 onSelectionChanged: onSelectionChanged,
                 isCutoffTab: isCutoffTab,
                 formatAirDate: formatAirDate,
-                onSearchTriggered: (id) => _triggerSingleSearch(context, ref, id),
+                onSearchTriggered: (id) =>
+                    _triggerSingleSearch(context, ref, id),
                 onShowDetails: (ep) => _showEpisodeDetails(context, ref, ep),
               ),
             );
@@ -582,11 +598,14 @@ class _EpisodeListLayout extends ConsumerWidget {
               (img) => img.coverType == 'poster',
               orElse: () => const SonarrImage(coverType: 'poster'),
             );
-            final String? posterUrl =
-                api != null && posterImage != null ? api.posterUrl(posterImage, width: 120) : null;
+            final String? posterUrl = api != null && posterImage != null
+                ? api.posterUrl(posterImage, width: 120)
+                : null;
 
-            final String sSeason = episode.seasonNumber.toString().padLeft(2, '0');
-            final String sEpisode = episode.episodeNumber.toString().padLeft(2, '0');
+            final String sSeason =
+                episode.seasonNumber.toString().padLeft(2, '0');
+            final String sEpisode =
+                episode.episodeNumber.toString().padLeft(2, '0');
             final String episodeCode = 'S${sSeason}E$sEpisode';
 
             String? qualityLabel;
@@ -607,7 +626,8 @@ class _EpisodeListLayout extends ConsumerWidget {
                   side: BorderSide(
                     color: isSelected
                         ? theme.colorScheme.primary
-                        : theme.colorScheme.outlineVariant.withValues(alpha: 0.5),
+                        : theme.colorScheme.outlineVariant
+                            .withValues(alpha: 0.5),
                     width: isSelected ? 2.0 : 1.0,
                   ),
                 ),
@@ -643,7 +663,6 @@ class _EpisodeListLayout extends ConsumerWidget {
                           },
                         ),
                         const SizedBox(width: 4),
-
                         if (posterUrl != null)
                           ClipRRect(
                             borderRadius: BorderRadius.circular(8),
@@ -677,7 +696,6 @@ class _EpisodeListLayout extends ConsumerWidget {
                             child: const Icon(Icons.movie, size: 20),
                           ),
                         const SizedBox(width: 12),
-
                         Expanded(
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
@@ -699,13 +717,16 @@ class _EpisodeListLayout extends ConsumerWidget {
                                       vertical: 2,
                                     ),
                                     decoration: BoxDecoration(
-                                      color: theme.colorScheme.secondaryContainer,
+                                      color:
+                                          theme.colorScheme.secondaryContainer,
                                       borderRadius: BorderRadius.circular(6),
                                     ),
                                     child: Text(
                                       episodeCode,
-                                      style: theme.textTheme.labelSmall?.copyWith(
-                                        color: theme.colorScheme.onSecondaryContainer,
+                                      style:
+                                          theme.textTheme.labelSmall?.copyWith(
+                                        color: theme
+                                            .colorScheme.onSecondaryContainer,
                                         fontWeight: FontWeight.bold,
                                       ),
                                     ),
@@ -714,8 +735,10 @@ class _EpisodeListLayout extends ConsumerWidget {
                                   Expanded(
                                     child: Text(
                                       episode.title,
-                                      style: theme.textTheme.bodyMedium?.copyWith(
-                                        color: theme.colorScheme.onSurfaceVariant,
+                                      style:
+                                          theme.textTheme.bodyMedium?.copyWith(
+                                        color:
+                                            theme.colorScheme.onSurfaceVariant,
                                       ),
                                       maxLines: 1,
                                       overflow: TextOverflow.ellipsis,
@@ -746,13 +769,16 @@ class _EpisodeListLayout extends ConsumerWidget {
                                         vertical: 1,
                                       ),
                                       decoration: BoxDecoration(
-                                        color: theme.colorScheme.tertiaryContainer,
+                                        color:
+                                            theme.colorScheme.tertiaryContainer,
                                         borderRadius: BorderRadius.circular(4),
                                       ),
                                       child: Text(
                                         qualityLabel,
-                                        style: theme.textTheme.labelSmall?.copyWith(
-                                          color: theme.colorScheme.onTertiaryContainer,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: theme
+                                              .colorScheme.onTertiaryContainer,
                                           fontSize: 9,
                                         ),
                                       ),
@@ -764,17 +790,18 @@ class _EpisodeListLayout extends ConsumerWidget {
                           ),
                         ),
                         const SizedBox(width: 8),
-
                         Column(
                           mainAxisAlignment: MainAxisAlignment.center,
                           children: <Widget>[
                             IconButton(
                               icon: const Icon(Icons.search, size: 20),
                               tooltip: 'Automatic Search',
-                              onPressed: () => _triggerSingleSearch(context, ref, episode.id),
+                              onPressed: () => _triggerSingleSearch(
+                                  context, ref, episode.id),
                             ),
                             IconButton(
-                              icon: const Icon(Icons.person_search_outlined, size: 20),
+                              icon: const Icon(Icons.person_search_outlined,
+                                  size: 20),
                               tooltip: 'Interactive Search',
                               onPressed: () {
                                 pushScreen<void>(
@@ -789,13 +816,13 @@ class _EpisodeListLayout extends ConsumerWidget {
                           ],
                         ),
                       ],
+                    ),
                   ),
                 ),
               ),
-            ),
-          );
+            );
+          }
         }
-      }
 
         return M3RefreshIndicator(
           onRefresh: () async {
@@ -815,7 +842,9 @@ class _EpisodeListLayout extends ConsumerWidget {
                           onPressed: onBulkSearch,
                           icon: const Icon(Icons.search, size: 18),
                           label: Text(
-                            isCutoffTab ? 'Search Cutoff Unmet' : 'Search All Missing',
+                            isCutoffTab
+                                ? 'Search Cutoff Unmet'
+                                : 'Search All Missing',
                           ),
                         ),
                       ),
@@ -866,7 +895,8 @@ class _GroupedEpisodeCard extends ConsumerStatefulWidget {
   final ValueChanged<SonarrEpisode> onShowDetails;
 
   @override
-  ConsumerState<_GroupedEpisodeCard> createState() => _GroupedEpisodeCardState();
+  ConsumerState<_GroupedEpisodeCard> createState() =>
+      _GroupedEpisodeCardState();
 }
 
 class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
@@ -889,7 +919,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
     // Determine selection checkbox state for the group
     final Set<int> groupEpIds = widget.episodes.map((e) => e.id).toSet();
     final bool allSelected = widget.selectedIds.containsAll(groupEpIds);
-    final bool someSelected = !allSelected && widget.selectedIds.any(groupEpIds.contains);
+    final bool someSelected =
+        !allSelected && widget.selectedIds.any(groupEpIds.contains);
     final bool? checkboxState = someSelected ? null : allSelected;
 
     return Card(
@@ -997,7 +1028,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
 
                   // Wanted Count Badge
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(8),
@@ -1030,11 +1062,15 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                 itemCount: widget.episodes.length,
                 itemBuilder: (BuildContext context, int index) {
                   final episode = widget.episodes[index];
-                  final bool isEpSelected = widget.selectedIds.contains(episode.id);
-                  final String airDateStr = widget.formatAirDate(episode.airDateUtc);
+                  final bool isEpSelected =
+                      widget.selectedIds.contains(episode.id);
+                  final String airDateStr =
+                      widget.formatAirDate(episode.airDateUtc);
 
-                  final String sSeason = episode.seasonNumber.toString().padLeft(2, '0');
-                  final String sEpisode = episode.episodeNumber.toString().padLeft(2, '0');
+                  final String sSeason =
+                      episode.seasonNumber.toString().padLeft(2, '0');
+                  final String sEpisode =
+                      episode.episodeNumber.toString().padLeft(2, '0');
                   final String episodeCode = 'S${sSeason}E$sEpisode';
 
                   String? qualityLabel;
@@ -1051,7 +1087,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                     elevation: 0,
                     margin: const EdgeInsets.symmetric(vertical: 4),
                     color: isEpSelected
-                        ? theme.colorScheme.primaryContainer.withValues(alpha: 0.15)
+                        ? theme.colorScheme.primaryContainer
+                            .withValues(alpha: 0.15)
                         : theme.colorScheme.surface.withValues(alpha: 0.5),
                     shape: RoundedRectangleBorder(
                       borderRadius: BorderRadius.circular(12),
@@ -1065,7 +1102,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                       borderRadius: BorderRadius.circular(12),
                       onTap: () => widget.onShowDetails(episode),
                       child: Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 8),
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 8, vertical: 8),
                         child: Row(
                           children: <Widget>[
                             Checkbox(
@@ -1083,7 +1121,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                             ),
                             const SizedBox(width: 4),
                             Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 6, vertical: 2),
                               decoration: BoxDecoration(
                                 color: theme.colorScheme.secondaryContainer,
                                 borderRadius: BorderRadius.circular(6),
@@ -1114,7 +1153,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                                     children: [
                                       Text(
                                         airDateStr,
-                                        style: theme.textTheme.bodySmall?.copyWith(
+                                        style:
+                                            theme.textTheme.bodySmall?.copyWith(
                                           color: theme.colorScheme.outline,
                                           fontSize: 11,
                                         ),
@@ -1127,13 +1167,17 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                                             vertical: 1,
                                           ),
                                           decoration: BoxDecoration(
-                                            color: theme.colorScheme.tertiaryContainer,
-                                            borderRadius: BorderRadius.circular(4),
+                                            color: theme
+                                                .colorScheme.tertiaryContainer,
+                                            borderRadius:
+                                                BorderRadius.circular(4),
                                           ),
                                           child: Text(
                                             qualityLabel,
-                                            style: theme.textTheme.labelSmall?.copyWith(
-                                              color: theme.colorScheme.onTertiaryContainer,
+                                            style: theme.textTheme.labelSmall
+                                                ?.copyWith(
+                                              color: theme.colorScheme
+                                                  .onTertiaryContainer,
                                               fontSize: 8,
                                             ),
                                           ),
@@ -1148,7 +1192,8 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                             IconButton(
                               icon: const Icon(Icons.search, size: 18),
                               tooltip: 'Automatic Search',
-                              onPressed: () => widget.onSearchTriggered(episode.id),
+                              onPressed: () =>
+                                  widget.onSearchTriggered(episode.id),
                             ),
                           ],
                         ),
@@ -1179,7 +1224,8 @@ class _EpisodeDetailsSheet extends ConsumerStatefulWidget {
   final ValueChanged<int> onSearchTriggered;
 
   @override
-  ConsumerState<_EpisodeDetailsSheet> createState() => _EpisodeDetailsSheetState();
+  ConsumerState<_EpisodeDetailsSheet> createState() =>
+      _EpisodeDetailsSheetState();
 }
 
 class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
@@ -1196,7 +1242,8 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
   Future<void> _loadHistory() async {
     try {
       final api = await ref.read(sonarrApiProvider(widget.instance).future);
-      final logs = await api.getHistory(pageSize: 50, episodeId: widget.episode.id);
+      final logs =
+          await api.getHistory(pageSize: 50, episodeId: widget.episode.id);
       if (mounted) {
         setState(() {
           _history = logs;
@@ -1218,8 +1265,10 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
     final theme = Theme.of(context);
     final cs = theme.colorScheme;
 
-    final String sSeason = widget.episode.seasonNumber.toString().padLeft(2, '0');
-    final String sEpisode = widget.episode.episodeNumber.toString().padLeft(2, '0');
+    final String sSeason =
+        widget.episode.seasonNumber.toString().padLeft(2, '0');
+    final String sEpisode =
+        widget.episode.episodeNumber.toString().padLeft(2, '0');
     final String episodeCode = 'S${sSeason}E$sEpisode';
 
     return SizedBox(
@@ -1238,13 +1287,14 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
               ),
             ),
             const SizedBox(height: 16),
-
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 20),
               child: Row(
                 children: [
                   Icon(
-                    widget.episode.monitored ? Icons.bookmark : Icons.bookmark_border,
+                    widget.episode.monitored
+                        ? Icons.bookmark
+                        : Icons.bookmark_border,
                     color: widget.episode.monitored ? cs.primary : cs.outline,
                   ),
                   const SizedBox(width: 8),
@@ -1274,9 +1324,9 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
               ),
             ),
             const SizedBox(height: 8),
-
             TabBar(
-              dividerColor: theme.colorScheme.outlineVariant.withValues(alpha: 0.3),
+              dividerColor:
+                  theme.colorScheme.outlineVariant.withValues(alpha: 0.3),
               indicatorSize: TabBarIndicatorSize.tab,
               tabs: const <Widget>[
                 Tab(text: 'Details'),
@@ -1284,7 +1334,6 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
                 Tab(text: 'Search'),
               ],
             ),
-
             Expanded(
               child: TabBarView(
                 children: <Widget>[
@@ -1326,7 +1375,9 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
                             borderRadius: BorderRadius.circular(8),
                           ),
                           child: Text(
-                            widget.episode.series?.monitored == true ? 'Yes' : 'No',
+                            widget.episode.series?.monitored == true
+                                ? 'Yes'
+                                : 'No',
                             style: theme.textTheme.labelMedium?.copyWith(
                               color: cs.onPrimaryContainer,
                               fontWeight: FontWeight.bold,
@@ -1343,7 +1394,8 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
                         ),
                         const SizedBox(height: 6),
                         Text(
-                          widget.episode.overview != null && widget.episode.overview!.isNotEmpty
+                          widget.episode.overview != null &&
+                                  widget.episode.overview!.isNotEmpty
                               ? widget.episode.overview!
                               : 'No overview details are available for this episode.',
                           style: theme.textTheme.bodyMedium?.copyWith(
@@ -1370,7 +1422,6 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
                       ],
                     ),
                   ),
-
                   _historyLoading
                       ? const Center(child: ExpressiveProgressIndicator())
                       : _historyError != null
@@ -1382,25 +1433,33 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
                               ),
                             )
                           : _history.isEmpty
-                              ? const Center(child: Text('No history items for this episode.'))
+                              ? const Center(
+                                  child: Text(
+                                      'No history items for this episode.'))
                               : ListView.builder(
                                   padding: const EdgeInsets.all(16),
                                   itemCount: _history.length,
-                                  itemBuilder: (BuildContext context, int index) {
+                                  itemBuilder:
+                                      (BuildContext context, int index) {
                                     final log = _history[index];
                                     final DateTime? dt = log.date != null
-                                        ? DateTime.tryParse(log.date!)?.toLocal()
+                                        ? DateTime.tryParse(log.date!)
+                                            ?.toLocal()
                                         : null;
                                     final date = dt != null
                                         ? DateFormat.yMMMd().add_jm().format(dt)
                                         : 'Unknown Date';
-                                    final eventType = log.eventType?.toUpperCase() ?? 'UNKNOWN';
+                                    final eventType =
+                                        log.eventType?.toUpperCase() ??
+                                            'UNKNOWN';
                                     return ListTile(
                                       leading: Icon(
                                         log.eventType == 'grabbed'
                                             ? Icons.cloud_download_outlined
                                             : Icons.save_alt_outlined,
-                                        color: log.eventType == 'grabbed' ? cs.primary : cs.secondary,
+                                        color: log.eventType == 'grabbed'
+                                            ? cs.primary
+                                            : cs.secondary,
                                       ),
                                       title: Text(eventType),
                                       subtitle: Text(
@@ -1410,7 +1469,6 @@ class _EpisodeDetailsSheetState extends ConsumerState<_EpisodeDetailsSheet> {
                                     );
                                   },
                                 ),
-
                   Padding(
                     padding: const EdgeInsets.all(24.0),
                     child: Column(

--- a/services/service_sonarr/lib/src/series_detail_screen.dart
+++ b/services/service_sonarr/lib/src/series_detail_screen.dart
@@ -12,6 +12,7 @@ import 'sonarr_api.dart';
 import 'sonarr_providers.dart';
 import 'sonarr_release_search_screen.dart';
 import 'sonarr_settings_form_screen.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class SeriesDetailScreen extends ConsumerWidget {
   const SeriesDetailScreen({
@@ -85,7 +86,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
   }
 
   void _invalidateProviders() {
-    ref.invalidate(sonarrSeriesByIdProvider((widget.instance, widget.series.id)));
+    ref.invalidate(
+        sonarrSeriesByIdProvider((widget.instance, widget.series.id)));
     ref.invalidate(sonarrEpisodesProvider((widget.instance, widget.series.id)));
     ref.invalidate(sonarrSeriesProvider(widget.instance));
   }
@@ -118,7 +120,9 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
             builder: (BuildContext context, constraints) {
               const double expandedHeight = 250.0;
               final double scrollOffset = constraints.scrollOffset;
-              final double progress = (scrollOffset / (expandedHeight - kToolbarHeight)).clamp(0.0, 1.0);
+              final double progress =
+                  (scrollOffset / (expandedHeight - kToolbarHeight))
+                      .clamp(0.0, 1.0);
 
               // The expanded title sits over the backdrop's bottom band, which
               // the scrim fades to opaque cs.surface (a light surface with no
@@ -128,7 +132,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
               // white->onSurface lerp because their 0.35-alpha bubbles plus the
               // top scrim back them over the image when expanded.
               final Color titleColor = cs.onSurface;
-              final Color iconColor = Color.lerp(Colors.white, cs.onSurface, progress)!;
+              final Color iconColor =
+                  Color.lerp(Colors.white, cs.onSurface, progress)!;
               final double bubbleOpacity = 1.0 - progress;
 
               return SliverAppBar(
@@ -143,7 +148,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                     height: 38,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: Colors.black.withValues(alpha: 0.35 * bubbleOpacity),
+                      color:
+                          Colors.black.withValues(alpha: 0.35 * bubbleOpacity),
                     ),
                     child: IconButton(
                       icon: Icon(Icons.arrow_back, size: 20, color: iconColor),
@@ -160,7 +166,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                       margin: const EdgeInsets.only(right: 16),
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.black.withValues(alpha: 0.35 * bubbleOpacity),
+                        color: Colors.black
+                            .withValues(alpha: 0.35 * bubbleOpacity),
                       ),
                       child: _OverflowMenu(
                         instance: widget.instance,
@@ -282,7 +289,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                   data: (List<SonarrEpisode> episodes) {
                     final Map<int, List<SonarrEpisode>> episodesBySeason =
                         groupBy(episodes, (e) => e.seasonNumber);
-                    final List<int> sortedSeasons = episodesBySeason.keys.toList()
+                    final List<int> sortedSeasons = episodesBySeason.keys
+                        .toList()
                       ..sort((a, b) => b.compareTo(a)); // newest first
 
                     for (final seasonNum in sortedSeasons) {
@@ -293,39 +301,48 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                       if (sortedSeasons.isNotEmpty) ...[
                         SingleChildScrollView(
                           scrollDirection: Axis.horizontal,
-                          padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+                          padding:
+                              const EdgeInsets.symmetric(vertical: Insets.xs),
                           child: Row(
                             children: [
                               ActionChip(
                                 label: const Text('All'),
                                 onPressed: () {
-                                  if (_seasonsHeaderKey.currentContext != null) {
+                                  if (_seasonsHeaderKey.currentContext !=
+                                      null) {
                                     Scrollable.ensureVisible(
                                       _seasonsHeaderKey.currentContext!,
-                                      duration: const Duration(milliseconds: 500),
+                                      duration:
+                                          const Duration(milliseconds: 500),
                                       curve: Curves.easeInOut,
                                     );
                                   }
                                 },
                               ),
                               ...sortedSeasons.map((seasonNum) {
-                                final label = seasonNum == 0 ? 'Specials' : 'Season $seasonNum';
+                                final label = seasonNum == 0
+                                    ? 'Specials'
+                                    : 'Season $seasonNum';
                                 return Padding(
-                                  padding: const EdgeInsets.only(left: Insets.xs),
+                                  padding:
+                                      const EdgeInsets.only(left: Insets.xs),
                                   child: ActionChip(
                                     label: Text(label),
                                     onPressed: () {
-                                      if (!_expandedSeasons.contains(seasonNum)) {
+                                      if (!_expandedSeasons
+                                          .contains(seasonNum)) {
                                         setState(() {
                                           _expandedSeasons.add(seasonNum);
                                         });
                                       }
-                                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                                      WidgetsBinding.instance
+                                          .addPostFrameCallback((_) {
                                         final key = _seasonKeys[seasonNum];
                                         if (key?.currentContext != null) {
                                           Scrollable.ensureVisible(
                                             key!.currentContext!,
-                                            duration: const Duration(milliseconds: 500),
+                                            duration: const Duration(
+                                                milliseconds: 500),
                                             curve: Curves.easeInOut,
                                           );
                                         }
@@ -340,7 +357,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                         const SizedBox(height: Insets.md),
                       ],
                       Column(
-                        children: _buildSeasonCards(context, episodesBySeason, sortedSeasons),
+                        children: _buildSeasonCards(
+                            context, episodesBySeason, sortedSeasons),
                       ),
                     ];
                   },
@@ -369,7 +387,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                             const SizedBox(height: Insets.sm),
                             FilledButton.tonal(
                               onPressed: () => ref.invalidate(
-                                sonarrEpisodesProvider((widget.instance, widget.series.id)),
+                                sonarrEpisodesProvider(
+                                    (widget.instance, widget.series.id)),
                               ),
                               child: const Text('Retry'),
                             ),
@@ -601,14 +620,11 @@ class _StatsCard extends StatelessWidget {
           const SizedBox(height: Insets.md),
           ClipRRect(
             borderRadius: BorderRadius.circular(Radii.sm),
-            child: LinearProgressIndicator(
-              value: progress,
-              minHeight: 8,
-              backgroundColor: cs.surfaceContainerHighest,
-              valueColor: AlwaysStoppedAnimation<Color>(
-                progress >= 1.0 ? cs.tertiary : cs.primary,
-              ),
-            ),
+            child: LinearProgressIndicatorM3E(
+                shape: ProgressM3EShape.flat,
+                value: progress,
+                trackColor: cs.surfaceContainerHighest,
+                activeColor: progress >= 1.0 ? cs.tertiary : cs.primary),
           ),
         ],
       ),
@@ -699,9 +715,7 @@ class _ActionsRow extends ConsumerWidget {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              !series.monitored
-                  ? 'Series monitored.'
-                  : 'Series unmonitored.',
+              !series.monitored ? 'Series monitored.' : 'Series unmonitored.',
             ),
           ),
         );
@@ -962,9 +976,8 @@ class _SeasonCard extends ConsumerWidget {
         .where((e) => e.hasFile)
         .map((e) => (e.episodeFile?['size'] as num?)?.toDouble() ?? 0.0)
         .sum;
-    final String seasonSizeStr = seasonSizeBytes > 0
-        ? ' • ${_formatSize(seasonSizeBytes.toInt())}'
-        : '';
+    final String seasonSizeStr =
+        seasonSizeBytes > 0 ? ' • ${_formatSize(seasonSizeBytes.toInt())}' : '';
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 200),
@@ -998,8 +1011,10 @@ class _SeasonCard extends ConsumerWidget {
                       size: 18,
                       color: isMonitored ? cs.primary : cs.outline,
                     ),
-                    tooltip: isMonitored ? 'Unmonitor Season' : 'Monitor Season',
-                    onPressed: () => _toggleSeasonMonitoring(context, ref, isMonitored),
+                    tooltip:
+                        isMonitored ? 'Unmonitor Season' : 'Monitor Season',
+                    onPressed: () =>
+                        _toggleSeasonMonitoring(context, ref, isMonitored),
                     visualDensity: VisualDensity.compact,
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(
@@ -1028,14 +1043,13 @@ class _SeasonCard extends ConsumerWidget {
                             Expanded(
                               child: ClipRRect(
                                 borderRadius: BorderRadius.circular(4),
-                                child: LinearProgressIndicator(
-                                  value: progress,
-                                  minHeight: 4,
-                                  backgroundColor: cs.surfaceContainerHighest,
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                    progress >= 1.0 ? cs.tertiary : cs.primary,
-                                  ),
-                                ),
+                                child: LinearProgressIndicatorM3E(
+                                    shape: ProgressM3EShape.flat,
+                                    value: progress,
+                                    trackColor: cs.surfaceContainerHighest,
+                                    activeColor: progress >= 1.0
+                                        ? cs.tertiary
+                                        : cs.primary),
                               ),
                             ),
                             const SizedBox(width: Insets.sm),
@@ -1107,14 +1121,16 @@ class _SeasonCard extends ConsumerWidget {
                         const SizedBox(width: Insets.xs),
                         Expanded(
                           child: TextButton.icon(
-                            icon: Icon(Icons.delete_outline, color: cs.error, size: 16),
+                            icon: Icon(Icons.delete_outline,
+                                color: cs.error, size: 16),
                             label: Text(
                               'Delete',
                               style: TextStyle(color: cs.error, fontSize: 12),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            onPressed: () => _confirmDeleteSeasonFiles(context, ref),
+                            onPressed: () =>
+                                _confirmDeleteSeasonFiles(context, ref),
                           ),
                         ),
                       ],
@@ -1144,11 +1160,12 @@ class _SeasonCard extends ConsumerWidget {
     );
   }
 
-  Future<void> _toggleSeasonMonitoring(BuildContext context, WidgetRef ref, bool currentMonitored) async {
+  Future<void> _toggleSeasonMonitoring(
+      BuildContext context, WidgetRef ref, bool currentMonitored) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       final raw = await api.getSeriesRaw(series.id);
-      
+
       final List<dynamic> seasons = raw['seasons'] as List<dynamic>;
       for (final dynamic s in seasons) {
         final Map<String, dynamic> season = s as Map<String, dynamic>;
@@ -1157,7 +1174,7 @@ class _SeasonCard extends ConsumerWidget {
           break;
         }
       }
-      
+
       await api.updateSeriesRaw(raw);
 
       if (!context.mounted) return;
@@ -1183,7 +1200,8 @@ class _SeasonCard extends ConsumerWidget {
     }
   }
 
-  Future<void> _confirmDeleteSeasonFiles(BuildContext context, WidgetRef ref) async {
+  Future<void> _confirmDeleteSeasonFiles(
+      BuildContext context, WidgetRef ref) async {
     final theme = Theme.of(context);
     final confirm = await showDialog<bool>(
       context: context,
@@ -1211,7 +1229,7 @@ class _SeasonCard extends ConsumerWidget {
 
     if (confirm == true) {
       if (!context.mounted) return;
-      
+
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('Deleting season files...'),
@@ -1255,7 +1273,8 @@ class _SeasonCard extends ConsumerWidget {
       if (context.mounted) {
         if (failedCount == 0) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Successfully deleted $deletedCount file(s).')),
+            SnackBar(
+                content: Text('Successfully deleted $deletedCount file(s).')),
           );
         } else {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -1270,7 +1289,8 @@ class _SeasonCard extends ConsumerWidget {
     }
   }
 
-  Future<void> _searchSeason(BuildContext context, WidgetRef ref, int seasonNum) async {
+  Future<void> _searchSeason(
+      BuildContext context, WidgetRef ref, int seasonNum) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       await api.runCommand(<String, dynamic>{
@@ -1319,7 +1339,8 @@ class _EpisodeRow extends ConsumerWidget {
   final SonarrSeries series;
   final SonarrEpisode episode;
 
-  Future<void> _toggleEpisodeMonitored(BuildContext context, WidgetRef ref) async {
+  Future<void> _toggleEpisodeMonitored(
+      BuildContext context, WidgetRef ref) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       final updated = episode.copyWith(monitored: !episode.monitored);
@@ -1374,8 +1395,10 @@ class _EpisodeRow extends ConsumerWidget {
     }
 
     final Map<String, dynamic>? fileMap = episode.episodeFile;
-    final Map<String, dynamic>? qualityObj = fileMap?['quality'] as Map<String, dynamic>?;
-    final Map<String, dynamic>? qualityInner = qualityObj?['quality'] as Map<String, dynamic>?;
+    final Map<String, dynamic>? qualityObj =
+        fileMap?['quality'] as Map<String, dynamic>?;
+    final Map<String, dynamic>? qualityInner =
+        qualityObj?['quality'] as Map<String, dynamic>?;
     final String? quality = qualityInner?['name'] as String?;
     final int? sizeBytes = fileMap?['size'] as int?;
     final String? sizeStr = sizeBytes != null ? _formatSize(sizeBytes) : null;
@@ -1477,8 +1500,10 @@ void _showEpisodeBottomSheet({
   final ColorScheme cs = theme.colorScheme;
 
   final Map<String, dynamic>? fileMap = episode.episodeFile;
-  final Map<String, dynamic>? qualityObj = fileMap?['quality'] as Map<String, dynamic>?;
-  final Map<String, dynamic>? qualityInner = qualityObj?['quality'] as Map<String, dynamic>?;
+  final Map<String, dynamic>? qualityObj =
+      fileMap?['quality'] as Map<String, dynamic>?;
+  final Map<String, dynamic>? qualityInner =
+      qualityObj?['quality'] as Map<String, dynamic>?;
   final String? quality = qualityInner?['name'] as String?;
   final int? sizeBytes = fileMap?['size'] as int?;
   final String? sizeStr = sizeBytes != null ? _formatSize(sizeBytes) : null;
@@ -1491,208 +1516,232 @@ void _showEpisodeBottomSheet({
       return SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(Insets.lg, 0, Insets.lg, Insets.lg),
+            padding:
+                const EdgeInsets.fromLTRB(Insets.lg, 0, Insets.lg, Insets.lg),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-              // Title / Header
-              Text(
-                'Season ${episode.seasonNumber}, Episode ${episode.episodeNumber}',
-                style: theme.textTheme.labelSmall?.copyWith(color: cs.outline),
-              ),
-              const SizedBox(height: Insets.xs),
-              Text(
-                episode.title,
-                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: Insets.sm),
-
-              // Air date + File size / Quality row
-              Wrap(
-                spacing: Insets.xs,
-                runSpacing: Insets.xs,
-                children: <Widget>[
-                  if (episode.airDate != null)
-                    _MetaChip(label: 'Aired: ${episode.airDate}'),
-                  if (quality != null) _MetaChip(label: quality),
-                  if (sizeStr != null) _MetaChip(label: sizeStr),
-                  _MetaChip(
-                    label: episode.monitored ? 'Monitored' : 'Unmonitored',
-                  ),
-                ],
-              ),
-              const SizedBox(height: Insets.md),
-
-              // Synopsis / Overview
-              Text(
-                'Overview',
-                style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: Insets.xs),
-              Text(
-                episode.overview != null && episode.overview!.isNotEmpty
-                    ? episode.overview!
-                    : 'No overview available.',
-                style: theme.textTheme.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
-              ),
-              const SizedBox(height: Insets.md),
-
-              // File Path (if downloaded)
-              if (relativePath != null) ...[
+                // Title / Header
                 Text(
-                  'Path',
-                  style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+                  'Season ${episode.seasonNumber}, Episode ${episode.episodeNumber}',
+                  style:
+                      theme.textTheme.labelSmall?.copyWith(color: cs.outline),
                 ),
                 const SizedBox(height: Insets.xs),
                 Text(
-                  relativePath,
-                  style: theme.textTheme.bodySmall?.copyWith(color: cs.outline),
+                  episode.title,
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: Insets.sm),
+
+                // Air date + File size / Quality row
+                Wrap(
+                  spacing: Insets.xs,
+                  runSpacing: Insets.xs,
+                  children: <Widget>[
+                    if (episode.airDate != null)
+                      _MetaChip(label: 'Aired: ${episode.airDate}'),
+                    if (quality != null) _MetaChip(label: quality),
+                    if (sizeStr != null) _MetaChip(label: sizeStr),
+                    _MetaChip(
+                      label: episode.monitored ? 'Monitored' : 'Unmonitored',
+                    ),
+                  ],
                 ),
                 const SizedBox(height: Insets.md),
-              ],
 
-              // Action buttons
-              Row(
-                children: <Widget>[
-                  // Monitor/Unmonitor Toggle
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      icon: Icon(
-                        episode.monitored ? Icons.bookmark : Icons.bookmark_border,
-                        size: 18,
-                      ),
-                      label: Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        try {
-                          final api = await ref.read(sonarrApiProvider(instance).future);
-                          final updated = episode.copyWith(monitored: !episode.monitored);
-                          await api.updateEpisode(updated.toJson());
-                          ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
-                        } catch (e) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('Failed: $e')),
-                            );
-                          }
-                        }
-                      },
-                    ),
+                // Synopsis / Overview
+                Text(
+                  'Overview',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: Insets.xs),
+                Text(
+                  episode.overview != null && episode.overview!.isNotEmpty
+                      ? episode.overview!
+                      : 'No overview available.',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                ),
+                const SizedBox(height: Insets.md),
+
+                // File Path (if downloaded)
+                if (relativePath != null) ...[
+                  Text(
+                    'Path',
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.bold),
                   ),
+                  const SizedBox(height: Insets.xs),
+                  Text(
+                    relativePath,
+                    style:
+                        theme.textTheme.bodySmall?.copyWith(color: cs.outline),
+                  ),
+                  const SizedBox(height: Insets.md),
                 ],
-              ),
-              const SizedBox(height: Insets.sm),
-              Row(
-                children: <Widget>[
-                  // Automatic Search
-                  Expanded(
-                    child: FilledButton.icon(
-                      icon: const Icon(Icons.search, size: 18),
-                      label: const Text('Auto Search'),
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        try {
-                          final api = await ref.read(sonarrApiProvider(instance).future);
-                          await api.runCommand(<String, dynamic>{
-                            'name': 'EpisodeSearch',
-                            'episodeIds': <int>[episode.id],
-                          });
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('Search queued for episode.')),
-                            );
-                          }
-                        } catch (e) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('Failed to queue search: $e')),
-                            );
-                          }
-                        }
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: Insets.sm),
 
-                  // Interactive Search
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      icon: const Icon(Icons.person_search, size: 18),
-                      label: const Text('Interactive'),
-                      onPressed: () {
-                        Navigator.pop(context);
-                        pushScreen<void>(
-                          context,
-                          SonarrReleaseSearchScreen(
-                            instance: instance,
-                            episode: episode,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-
-                  // Delete file (if has file)
-                  if (episode.hasFile && episode.episodeFileId != null) ...[
-                    const SizedBox(width: Insets.sm),
-                    IconButton.filledTonal(
-                      icon: Icon(Icons.delete_outline, color: cs.error),
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        final confirm = await showDialog<bool>(
-                          context: context,
-                          builder: (context) => AlertDialog(
-                            title: const Text('Delete Episode File'),
-                            content: const Text(
-                              'Are you sure? This will delete the file from disk and cannot be undone.',
-                            ),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, false),
-                                  child: const Text('Cancel'),
-                              ),
-                              FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: cs.error,
-                                  foregroundColor: cs.onError,
-                                ),
-                                onPressed: () => Navigator.pop(context, true),
-                                child: const Text('Delete'),
-                              ),
-                            ],
-                          ),
-                        );
-
-                        if (confirm == true) {
+                // Action buttons
+                Row(
+                  children: <Widget>[
+                    // Monitor/Unmonitor Toggle
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        icon: Icon(
+                          episode.monitored
+                              ? Icons.bookmark
+                              : Icons.bookmark_border,
+                          size: 18,
+                        ),
+                        label:
+                            Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
+                        onPressed: () async {
+                          Navigator.pop(context);
                           try {
-                            final api = await ref.read(sonarrApiProvider(instance).future);
-                            await api.deleteEpisodeFile(episode.episodeFileId!);
-                            ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+                            final api = await ref
+                                .read(sonarrApiProvider(instance).future);
+                            final updated =
+                                episode.copyWith(monitored: !episode.monitored);
+                            await api.updateEpisode(updated.toJson());
+                            ref.invalidate(
+                                sonarrEpisodesProvider((instance, series.id)));
+                          } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('File deleted.')),
+                                SnackBar(content: Text('Failed: $e')),
+                              );
+                            }
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Insets.sm),
+                Row(
+                  children: <Widget>[
+                    // Automatic Search
+                    Expanded(
+                      child: FilledButton.icon(
+                        icon: const Icon(Icons.search, size: 18),
+                        label: const Text('Auto Search'),
+                        onPressed: () async {
+                          Navigator.pop(context);
+                          try {
+                            final api = await ref
+                                .read(sonarrApiProvider(instance).future);
+                            await api.runCommand(<String, dynamic>{
+                              'name': 'EpisodeSearch',
+                              'episodeIds': <int>[episode.id],
+                            });
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content:
+                                        Text('Search queued for episode.')),
                               );
                             }
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text('Failed to delete: $e')),
+                                SnackBar(
+                                    content:
+                                        Text('Failed to queue search: $e')),
                               );
                             }
                           }
-                        }
-                      },
+                        },
+                      ),
                     ),
+                    const SizedBox(width: Insets.sm),
+
+                    // Interactive Search
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        icon: const Icon(Icons.person_search, size: 18),
+                        label: const Text('Interactive'),
+                        onPressed: () {
+                          Navigator.pop(context);
+                          pushScreen<void>(
+                            context,
+                            SonarrReleaseSearchScreen(
+                              instance: instance,
+                              episode: episode,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+
+                    // Delete file (if has file)
+                    if (episode.hasFile && episode.episodeFileId != null) ...[
+                      const SizedBox(width: Insets.sm),
+                      IconButton.filledTonal(
+                        icon: Icon(Icons.delete_outline, color: cs.error),
+                        onPressed: () async {
+                          Navigator.pop(context);
+                          final confirm = await showDialog<bool>(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text('Delete Episode File'),
+                              content: const Text(
+                                'Are you sure? This will delete the file from disk and cannot be undone.',
+                              ),
+                              actions: <Widget>[
+                                TextButton(
+                                  onPressed: () =>
+                                      Navigator.pop(context, false),
+                                  child: const Text('Cancel'),
+                                ),
+                                FilledButton(
+                                  style: FilledButton.styleFrom(
+                                    backgroundColor: cs.error,
+                                    foregroundColor: cs.onError,
+                                  ),
+                                  onPressed: () => Navigator.pop(context, true),
+                                  child: const Text('Delete'),
+                                ),
+                              ],
+                            ),
+                          );
+
+                          if (confirm == true) {
+                            try {
+                              final api = await ref
+                                  .read(sonarrApiProvider(instance).future);
+                              await api
+                                  .deleteEpisodeFile(episode.episodeFileId!);
+                              ref.invalidate(sonarrEpisodesProvider(
+                                  (instance, series.id)));
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text('File deleted.')),
+                                );
+                              }
+                            } catch (e) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                      content: Text('Failed to delete: $e')),
+                                );
+                              }
+                            }
+                          }
+                        },
+                      ),
+                    ],
                   ],
-                ],
-              ),
-            ],
+                ),
+              ],
+            ),
           ),
         ),
-      ),
-    );
-  },
+      );
+    },
   );
 }
 
@@ -1947,7 +1996,8 @@ void _showMonitorSeriesDialog({
                 onPressed: () async {
                   Navigator.of(context).pop();
                   try {
-                    final api = await ref.read(sonarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(sonarrApiProvider(instance).future);
                     await api.updateSeasonPass(
                       seriesIds: [series.id],
                       monitorType: selectedType,
@@ -1967,7 +2017,8 @@ void _showMonitorSeriesDialog({
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to update monitoring: $e')),
+                        SnackBar(
+                            content: Text('Failed to update monitoring: $e')),
                       );
                     }
                   }
@@ -2022,7 +2073,8 @@ class _StatusPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final bool isContinuing = status?.toLowerCase() == 'continuing';
-    final Color tint = isContinuing ? theme.colorScheme.tertiary : theme.colorScheme.outline;
+    final Color tint =
+        isContinuing ? theme.colorScheme.tertiary : theme.colorScheme.outline;
     final String label = status ?? 'Unknown';
 
     return Container(

--- a/services/service_sonarr/lib/src/sonarr_add_series_sheet.dart
+++ b/services/service_sonarr/lib/src/sonarr_add_series_sheet.dart
@@ -8,6 +8,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'models/sonarr_series.dart';
 import 'sonarr_api.dart';
 import 'sonarr_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class SonarrAddSeriesSheet extends ConsumerStatefulWidget {
   const SonarrAddSeriesSheet({
@@ -196,7 +197,9 @@ class _SonarrAddSeriesSheetState extends ConsumerState<SonarrAddSeriesSheet> {
                                   },
                                 );
                               },
-                              loading: () => const LinearProgressIndicator(),
+                              loading: () => const LinearProgressIndicatorM3E(
+                                shape: ProgressM3EShape.flat,
+                              ),
                               error: (e, s) =>
                                   Text('Error loading folders: $e'),
                             ),
@@ -467,7 +470,8 @@ class _SonarrAddSeriesSheetState extends ConsumerState<SonarrAddSeriesSheet> {
     if (_selectedRootFolder == null || _selectedQualityProfileId == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: const Text('Please select a root folder and quality profile.'),
+          content:
+              const Text('Please select a root folder and quality profile.'),
           backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );

--- a/services/service_sonarr/lib/src/sonarr_api.dart
+++ b/services/service_sonarr/lib/src/sonarr_api.dart
@@ -117,12 +117,14 @@ class SonarrApi {
     required String monitorType,
   }) async {
     try {
-      final List<Map<String, dynamic>> seriesList = seriesIds.map(
-        (id) => <String, dynamic>{
-          'id': id,
-          'monitored': monitorType != 'none',
-        },
-      ).toList();
+      final List<Map<String, dynamic>> seriesList = seriesIds
+          .map(
+            (id) => <String, dynamic>{
+              'id': id,
+              'monitored': monitorType != 'none',
+            },
+          )
+          .toList();
 
       await _dio.post<dynamic>(
         '$_base/seasonpass',
@@ -307,7 +309,8 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createQualityProfile(
-      Map<String, dynamic> payload,) async {
+    Map<String, dynamic> payload,
+  ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
         '$_base/qualityprofile',
@@ -319,7 +322,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateQualityProfile(Map<String, dynamic> payload,
+  Future<void> updateQualityProfile(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -407,7 +411,8 @@ class SonarrApi {
       if (records is List<dynamic>) {
         return records
             .map(
-              (dynamic e) => SonarrQueueItem.fromJson(e as Map<String, dynamic>),
+              (dynamic e) =>
+                  SonarrQueueItem.fromJson(e as Map<String, dynamic>),
             )
             .toList();
       }
@@ -657,7 +662,8 @@ class SonarrApi {
         queryParameters: <String, dynamic>{
           'path': path,
           'includeFiles': includeFiles,
-          'allowFoldersWithoutTrailingSlashes': allowFoldersWithoutTrailingSlashes,
+          'allowFoldersWithoutTrailingSlashes':
+              allowFoldersWithoutTrailingSlashes,
         },
       );
       final dynamic data = resp.data;
@@ -852,6 +858,7 @@ class SonarrApi {
       throw NetworkException.fromDio(e);
     }
   }
+
   Future<void> updateDownloadClientConfig(Map<String, dynamic> config) async {
     try {
       await _dio.put<dynamic>(
@@ -874,6 +881,7 @@ class SonarrApi {
       throw NetworkException.fromDio(e);
     }
   }
+
   // --- Indexers CRUD ---
   Future<List<Map<String, dynamic>>> getIndexerSchema() async {
     try {
@@ -888,7 +896,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createIndexer(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -902,7 +910,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateIndexer(Map<String, dynamic> payload,
+  Future<void> updateIndexer(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -923,7 +932,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> testIndexer(Map<String, dynamic> payload,
+  Future<void> testIndexer(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.post<dynamic>(
@@ -1003,7 +1013,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createImportList(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1017,7 +1027,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateImportList(Map<String, dynamic> payload,
+  Future<void> updateImportList(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1038,7 +1049,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> testImportList(Map<String, dynamic> payload,
+  Future<void> testImportList(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.post<dynamic>(
@@ -1064,7 +1076,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createDownloadClient(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1086,7 +1098,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> testDownloadClient(Map<String, dynamic> payload,
+  Future<void> testDownloadClient(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.post<dynamic>(
@@ -1112,7 +1125,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createRemotePathMapping(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1125,7 +1138,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateRemotePathMapping(Map<String, dynamic> payload,
+  Future<void> updateRemotePathMapping(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1171,7 +1185,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createNotification(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1185,7 +1199,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateNotification(Map<String, dynamic> payload,
+  Future<void> updateNotification(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1206,7 +1221,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> testNotification(Map<String, dynamic> payload,
+  Future<void> testNotification(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.post<dynamic>(
@@ -1221,8 +1237,7 @@ class SonarrApi {
   // --- Metadata Consumers ---
   Future<List<Map<String, dynamic>>> getMetadataConfigs() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('$_base/metadata');
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/metadata');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();
@@ -1243,7 +1258,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateMetadataConfig(Map<String, dynamic> payload,
+  Future<void> updateMetadataConfig(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1270,7 +1286,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createDelayProfile(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1283,7 +1299,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateDelayProfile(Map<String, dynamic> payload,
+  Future<void> updateDelayProfile(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1317,7 +1334,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createReleaseProfile(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1330,7 +1347,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateReleaseProfile(Map<String, dynamic> payload,
+  Future<void> updateReleaseProfile(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1376,7 +1394,7 @@ class SonarrApi {
   }
 
   Future<Map<String, dynamic>> createCustomFormat(
-      Map<String, dynamic> payload,
+    Map<String, dynamic> payload,
   ) async {
     try {
       final Response<dynamic> resp = await _dio.post<dynamic>(
@@ -1389,7 +1407,8 @@ class SonarrApi {
     }
   }
 
-  Future<void> updateCustomFormat(Map<String, dynamic> payload,
+  Future<void> updateCustomFormat(
+    Map<String, dynamic> payload,
   ) async {
     try {
       await _dio.put<dynamic>(
@@ -1444,8 +1463,7 @@ class SonarrApi {
 
   Future<List<Map<String, dynamic>>> getHealth() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('$_base/health');
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/health');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();
@@ -1480,8 +1498,7 @@ class SonarrApi {
 
   Future<List<Map<String, dynamic>>> getUpdates() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('$_base/update');
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/update');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();
@@ -1519,8 +1536,7 @@ class SonarrApi {
 
   Future<List<Map<String, dynamic>>> getLogFiles() async {
     try {
-      final Response<dynamic> resp =
-          await _dio.get<dynamic>('$_base/log/file');
+      final Response<dynamic> resp = await _dio.get<dynamic>('$_base/log/file');
       return (resp.data as List<dynamic>)
           .map((dynamic e) => e as Map<String, dynamic>)
           .toList();

--- a/services/service_sonarr/lib/src/sonarr_home.dart
+++ b/services/service_sonarr/lib/src/sonarr_home.dart
@@ -87,18 +87,21 @@ class SonarrHome extends ConsumerWidget {
     ];
 
     return Scaffold(
-      drawerEdgeDragWidth: drawer != null ? MediaQuery.sizeOf(context).width * 0.15 : null,
+      drawerEdgeDragWidth:
+          drawer != null ? MediaQuery.sizeOf(context).width * 0.15 : null,
       drawer: drawer,
       body: NotificationListener<UserScrollNotification>(
         onNotification: (UserScrollNotification notification) {
           if (notification.metrics.axis == Axis.vertical) {
             final ScrollDirection direction = notification.direction;
             if (direction == ScrollDirection.reverse) {
-              ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
-                  false;
+              ref
+                  .read(sonarrBottomNavVisibleProvider(instance).notifier)
+                  .state = false;
             } else if (direction == ScrollDirection.forward) {
-              ref.read(sonarrBottomNavVisibleProvider(instance).notifier).state =
-                  true;
+              ref
+                  .read(sonarrBottomNavVisibleProvider(instance).notifier)
+                  .state = true;
             }
           }
           return false;
@@ -127,7 +130,7 @@ class SonarrHome extends ConsumerWidget {
                       .state = 0;
                   return;
                 }
-                
+
                 // If nothing to unwind, go back to dashboard.
                 GoRouter.of(context).go(AtriumRoutes.dashboard);
               },

--- a/services/service_sonarr/lib/src/sonarr_providers.dart
+++ b/services/service_sonarr/lib/src/sonarr_providers.dart
@@ -281,7 +281,8 @@ final sonarrEpisodesProvider =
   ]);
 
   final List<SonarrEpisode> episodes = results[0] as List<SonarrEpisode>;
-  final List<Map<String, dynamic>> files = results[1] as List<Map<String, dynamic>>;
+  final List<Map<String, dynamic>> files =
+      results[1] as List<Map<String, dynamic>>;
 
   final Map<int, Map<String, dynamic>> filesById = {
     for (final file in files) file['id'] as int: file,
@@ -448,8 +449,8 @@ final sonarrWantedCutoffProvider =
 });
 
 /// The calendar entries for an instance for a given month.
-final sonarrCalendarProvider =
-    FutureProvider.autoDispose.family<List<SonarrEpisode>, (Instance, DateTime)>((
+final sonarrCalendarProvider = FutureProvider.autoDispose
+    .family<List<SonarrEpisode>, (Instance, DateTime)>((
   Ref ref,
   (Instance, DateTime) key,
 ) async {
@@ -458,7 +459,8 @@ final sonarrCalendarProvider =
 
   // Calculate local month boundaries
   final DateTime start = DateTime(month.year, month.month);
-  final DateTime end = DateTime(month.year, month.month + 1).subtract(const Duration(seconds: 1));
+  final DateTime end = DateTime(month.year, month.month + 1)
+      .subtract(const Duration(seconds: 1));
 
   final List<SonarrEpisode> episodes = await api.getCalendar(
     start: start,
@@ -488,7 +490,8 @@ final sonarrWantedFilteredMissingProvider = Provider.autoDispose
         .where(
           (SonarrEpisode ep) =>
               ep.title.toLowerCase().contains(lowercaseQuery) ||
-              (ep.series?.title.toLowerCase().contains(lowercaseQuery) ?? false),
+              (ep.series?.title.toLowerCase().contains(lowercaseQuery) ??
+                  false),
         )
         .toList();
   });
@@ -510,7 +513,8 @@ final sonarrWantedFilteredCutoffProvider = Provider.autoDispose
         .where(
           (SonarrEpisode ep) =>
               ep.title.toLowerCase().contains(lowercaseQuery) ||
-              (ep.series?.title.toLowerCase().contains(lowercaseQuery) ?? false),
+              (ep.series?.title.toLowerCase().contains(lowercaseQuery) ??
+                  false),
         )
         .toList();
   });
@@ -573,8 +577,8 @@ final sonarrUiConfigProvider =
 });
 
 /// Quality definitions provider.
-final sonarrQualityDefinitionsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrQualityDefinitionsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -583,8 +587,8 @@ final sonarrQualityDefinitionsProvider = FutureProvider.autoDispose
 });
 
 /// Indexers configuration provider.
-final sonarrIndexersProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrIndexersProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -593,8 +597,8 @@ final sonarrIndexersProvider = FutureProvider.autoDispose
 });
 
 /// Download Clients configuration provider.
-final sonarrDownloadClientsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrDownloadClientsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -613,8 +617,8 @@ final sonarrDownloadClientConfigProvider =
 });
 
 /// Indexer schemas provider.
-final sonarrIndexerSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrIndexerSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -623,8 +627,8 @@ final sonarrIndexerSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Import lists provider.
-final sonarrImportListsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrImportListsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -653,8 +657,8 @@ final sonarrIndexerConfigProvider =
 });
 
 /// Import list schemas provider.
-final sonarrImportListSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrImportListSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -663,8 +667,8 @@ final sonarrImportListSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Download client schemas provider.
-final sonarrDownloadClientSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrDownloadClientSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -673,8 +677,8 @@ final sonarrDownloadClientSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Remote path mappings provider.
-final sonarrRemotePathMappingsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrRemotePathMappingsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -683,8 +687,8 @@ final sonarrRemotePathMappingsProvider = FutureProvider.autoDispose
 });
 
 /// Notifications provider.
-final sonarrNotificationsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrNotificationsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -693,8 +697,8 @@ final sonarrNotificationsProvider = FutureProvider.autoDispose
 });
 
 /// Notification schemas provider.
-final sonarrNotificationSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrNotificationSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -703,8 +707,8 @@ final sonarrNotificationSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Metadata configurations provider.
-final sonarrMetadataConfigsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrMetadataConfigsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -713,8 +717,8 @@ final sonarrMetadataConfigsProvider = FutureProvider.autoDispose
 });
 
 /// Metadata schemas provider.
-final sonarrMetadataSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrMetadataSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -723,8 +727,8 @@ final sonarrMetadataSchemaProvider = FutureProvider.autoDispose
 });
 
 /// Delay profiles provider.
-final sonarrDelayProfilesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrDelayProfilesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -733,8 +737,8 @@ final sonarrDelayProfilesProvider = FutureProvider.autoDispose
 });
 
 /// Release profiles provider.
-final sonarrReleaseProfilesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrReleaseProfilesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -743,8 +747,8 @@ final sonarrReleaseProfilesProvider = FutureProvider.autoDispose
 });
 
 /// Custom formats provider.
-final sonarrCustomFormatsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrCustomFormatsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -753,8 +757,8 @@ final sonarrCustomFormatsProvider = FutureProvider.autoDispose
 });
 
 /// Custom format schemas provider.
-final sonarrCustomFormatSchemaProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrCustomFormatSchemaProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -767,8 +771,8 @@ final sonarrCustomFormatSchemaProvider = FutureProvider.autoDispose
 // ==========================================
 
 /// System status (version, OS, uptime, etc.).
-final sonarrSystemStatusProvider = FutureProvider.autoDispose
-    .family<Map<String, dynamic>, Instance>((
+final sonarrSystemStatusProvider =
+    FutureProvider.autoDispose.family<Map<String, dynamic>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -777,8 +781,8 @@ final sonarrSystemStatusProvider = FutureProvider.autoDispose
 });
 
 /// Health check warnings/errors.
-final sonarrHealthProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrHealthProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -787,8 +791,8 @@ final sonarrHealthProvider = FutureProvider.autoDispose
 });
 
 /// Disk space for all root paths.
-final sonarrDiskSpaceProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrDiskSpaceProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -797,8 +801,8 @@ final sonarrDiskSpaceProvider = FutureProvider.autoDispose
 });
 
 /// Scheduled tasks list.
-final sonarrTasksProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrTasksProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -807,8 +811,8 @@ final sonarrTasksProvider = FutureProvider.autoDispose
 });
 
 /// Available software updates.
-final sonarrUpdatesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrUpdatesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -817,9 +821,8 @@ final sonarrUpdatesProvider = FutureProvider.autoDispose
 });
 
 /// Paginated logs. Key is (instance, page, pageSize, level).
-final sonarrLogsProvider = FutureProvider.autoDispose
-    .family<Map<String, dynamic>,
-        (Instance, {int page, int pageSize, String? level})>((
+final sonarrLogsProvider = FutureProvider.autoDispose.family<
+    Map<String, dynamic>, (Instance, {int page, int pageSize, String? level})>((
   Ref ref,
   (Instance, {int page, int pageSize, String? level}) key,
 ) async {
@@ -829,8 +832,8 @@ final sonarrLogsProvider = FutureProvider.autoDispose
 });
 
 /// Log files list.
-final sonarrLogFilesProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrLogFilesProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
@@ -839,8 +842,8 @@ final sonarrLogFilesProvider = FutureProvider.autoDispose
 });
 
 /// Backups list.
-final sonarrBackupsProvider = FutureProvider.autoDispose
-    .family<List<Map<String, dynamic>>, Instance>((
+final sonarrBackupsProvider =
+    FutureProvider.autoDispose.family<List<Map<String, dynamic>>, Instance>((
   Ref ref,
   Instance instance,
 ) async {

--- a/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
@@ -623,8 +623,8 @@ class _SonarrReleaseSearchScreenState
                               ? const SizedBox(
                                   width: 24,
                                   height: 24,
-                                  child:
-                                      ExpressiveProgressIndicator(strokeWidth: 2),
+                                  child: ExpressiveProgressIndicator(
+                                      strokeWidth: 2),
                                 )
                               : IconButton(
                                   icon: Icon(

--- a/services/service_sonarr/lib/src/sonarr_settings_form_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_settings_form_screen.dart
@@ -346,8 +346,7 @@ class _SonarrSettingsFormScreenState
                                 children: [
                                   Text(
                                     'Tags',
-                                    style: theme.textTheme.titleSmall
-                                        ?.copyWith(
+                                    style: theme.textTheme.titleSmall?.copyWith(
                                       fontWeight: FontWeight.bold,
                                     ),
                                   ),

--- a/services/service_sonarr/pubspec.yaml
+++ b/services/service_sonarr/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   cached_network_image: ^3.4.1
   collection: ^1.18.0
   core_models:

--- a/services/service_tautulli/lib/src/models/tautulli_json.dart
+++ b/services/service_tautulli/lib/src/models/tautulli_json.dart
@@ -18,7 +18,8 @@ int tInt(dynamic v) {
   if (v is num) {
     return v.toInt();
   }
-  return int.tryParse(v.toString()) ?? (double.tryParse(v.toString())?.toInt() ?? 0);
+  return int.tryParse(v.toString()) ??
+      (double.tryParse(v.toString())?.toInt() ?? 0);
 }
 
 double tDouble(dynamic v) {

--- a/services/service_tautulli/lib/src/tautulli_api.dart
+++ b/services/service_tautulli/lib/src/tautulli_api.dart
@@ -51,9 +51,8 @@ class TautulliApi {
         'api/v2',
         queryParameters: <String, dynamic>{'cmd': cmd, ...?params},
       );
-      final Map<String, dynamic> envelope =
-          (resp.data as Map<String, dynamic>)['response']
-              as Map<String, dynamic>;
+      final Map<String, dynamic> envelope = (resp.data
+          as Map<String, dynamic>)['response'] as Map<String, dynamic>;
       if (tString(envelope['result']) != 'success') {
         final String message = tString(envelope['message']);
         throw NetworkUnknownException(
@@ -75,7 +74,8 @@ class TautulliApi {
   }
 
   /// Watch history, newest first.
-  Future<TautulliHistoryPage> getHistory({int length = 100, int start = 0}) async {
+  Future<TautulliHistoryPage> getHistory(
+      {int length = 100, int start = 0}) async {
     final dynamic data = await _cmd('get_history', <String, dynamic>{
       'length': length,
       'start': start,
@@ -96,7 +96,8 @@ class TautulliApi {
       'stats_count': statsCount,
     });
     return ((data as List<dynamic>?) ?? <dynamic>[])
-        .map((dynamic e) => TautulliHomeStat.fromJson(e as Map<String, dynamic>))
+        .map(
+            (dynamic e) => TautulliHomeStat.fromJson(e as Map<String, dynamic>))
         .toList();
   }
 

--- a/services/service_tautulli/lib/src/tautulli_home.dart
+++ b/services/service_tautulli/lib/src/tautulli_home.dart
@@ -12,6 +12,7 @@ import 'models/tautulli_activity.dart';
 import 'models/tautulli_models.dart';
 import 'tautulli_api.dart';
 import 'tautulli_providers.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Tautulli's per-instance UI: Activity (live streams w/ detail + terminate),
 /// History, Stats, and Users tabs - all poster-rich via Tautulli's image proxy.
@@ -194,8 +195,8 @@ class _StatTile extends StatelessWidget {
           value,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.titleLarge
-              ?.copyWith(fontWeight: FontWeight.w700),
+          style:
+              theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: 2),
         Text(
@@ -332,8 +333,8 @@ class _SessionCard extends StatelessWidget {
                                       session.friendlyName,
                                       maxLines: 1,
                                       overflow: TextOverflow.ellipsis,
-                                      style: theme.textTheme.labelMedium
-                                          ?.copyWith(
+                                      style:
+                                          theme.textTheme.labelMedium?.copyWith(
                                         color: Colors.white,
                                         fontWeight: FontWeight.w600,
                                       ),
@@ -401,13 +402,13 @@ class _SessionCard extends StatelessWidget {
                 bottom: 0,
                 left: 0,
                 right: 0,
-                child: LinearProgressIndicator(
+                child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
                   value: pct.clamp(0, 1),
-                  minHeight: 5,
-                  color: playing
+                  activeColor: playing
                       ? theme.colorScheme.primary
                       : theme.colorScheme.outline,
-                  backgroundColor: Colors.white.withValues(alpha: 0.15),
+                  trackColor: Colors.white.withValues(alpha: 0.15),
                 ),
               ),
             ],
@@ -510,14 +511,16 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                _Poster(url: api?.imageUrl(s.posterThumb), width: 64, height: 96),
+                _Poster(
+                    url: api?.imageUrl(s.posterThumb), width: 64, height: 96),
                 const SizedBox(width: Insets.md),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(s.fullTitle, style: theme.textTheme.titleMedium),
-                      if (s.episodeLabel.isNotEmpty || s.year.isNotEmpty) ...<Widget>[
+                      if (s.episodeLabel.isNotEmpty ||
+                          s.year.isNotEmpty) ...<Widget>[
                         const SizedBox(height: Insets.xs),
                         Text(
                           <String>[
@@ -862,9 +865,8 @@ class _StatsTab extends ConsumerWidget {
         value: stats,
         onRetry: () => ref.invalidate(tautulliHomeStatsProvider(instance)),
         data: (List<TautulliHomeStat> all) {
-          final List<TautulliHomeStat> sections = all
-              .where((TautulliHomeStat s) => s.rows.isNotEmpty)
-              .toList();
+          final List<TautulliHomeStat> sections =
+              all.where((TautulliHomeStat s) => s.rows.isNotEmpty).toList();
           if (sections.isEmpty) {
             return const EmptyView(
               icon: Icons.bar_chart,
@@ -976,10 +978,10 @@ class _StatSection extends StatelessWidget {
                             const SizedBox(height: 4),
                             ClipRRect(
                               borderRadius: BorderRadius.circular(8),
-                              child: LinearProgressIndicator(
+                              child: LinearProgressIndicatorM3E(
+                                shape: ProgressM3EShape.flat,
                                 value: (metric(row) / maxMetric).clamp(0, 1),
-                                minHeight: 6,
-                                backgroundColor:
+                                trackColor:
                                     theme.colorScheme.surfaceContainerHighest,
                               ),
                             ),
@@ -1041,8 +1043,11 @@ class _StatLeading extends StatelessWidget {
       return CircleAvatar(
         radius: 17,
         backgroundColor: theme.colorScheme.surfaceContainerHighest,
-        child: Icon(Icons.devices_outlined,
-            size: 18, color: theme.colorScheme.onSurfaceVariant,),
+        child: Icon(
+          Icons.devices_outlined,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
       );
     }
     return _Poster(url: api?.imageUrl(row.posterThumb), width: 34, height: 51);

--- a/services/service_tautulli/lib/src/tautulli_providers.dart
+++ b/services/service_tautulli/lib/src/tautulli_providers.dart
@@ -14,60 +14,55 @@ const Duration tautulliActivityPollInterval = Duration(seconds: 10);
 ///
 /// Deliberately NOT autoDispose: the underlying Dio is shared and cheap to
 /// keep; disposing it per-screen would re-run the LAN/WAN probe needlessly.
-final tautulliApiProvider =
-    FutureProvider.family<TautulliApi, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final dio = await ref.watch(instanceDioProvider(instance).future);
-      final String? apiKey = switch (instance.auth) {
-        InstanceAuthApiKey(:final String apiKey) => apiKey,
-        _ => null,
-      };
-      return TautulliApi(dio, apiKey: apiKey);
-    });
+final tautulliApiProvider = FutureProvider.family<TautulliApi, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  final String? apiKey = switch (instance.auth) {
+    InstanceAuthApiKey(:final String apiKey) => apiKey,
+    _ => null,
+  };
+  return TautulliApi(dio, apiKey: apiKey);
+});
 
 /// Current activity (active streams). Polls while watched.
 final tautulliActivityProvider =
     FutureProvider.autoDispose.family<TautulliActivity, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      ref.pollEvery(tautulliActivityPollInterval);
-      final TautulliApi api =
-          await ref.watch(tautulliApiProvider(instance).future);
-      return api.getActivity();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  ref.pollEvery(tautulliActivityPollInterval);
+  final TautulliApi api = await ref.watch(tautulliApiProvider(instance).future);
+  return api.getActivity();
+});
 
 /// Watch history, newest first. Refreshed on demand (pull-to-refresh).
 final tautulliHistoryProvider =
     FutureProvider.autoDispose.family<TautulliHistoryPage, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final TautulliApi api =
-          await ref.watch(tautulliApiProvider(instance).future);
-      return api.getHistory();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final TautulliApi api = await ref.watch(tautulliApiProvider(instance).future);
+  return api.getHistory();
+});
 
 /// Home statistics for the last 30 days. Refreshed on demand.
 final tautulliHomeStatsProvider =
     FutureProvider.autoDispose.family<List<TautulliHomeStat>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final TautulliApi api =
-          await ref.watch(tautulliApiProvider(instance).future);
-      return api.getHomeStats();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final TautulliApi api = await ref.watch(tautulliApiProvider(instance).future);
+  return api.getHomeStats();
+});
 
 /// Users with play counts, most plays first. Refreshed on demand.
 final tautulliUsersProvider =
     FutureProvider.autoDispose.family<List<TautulliUser>, Instance>((
-      Ref ref,
-      Instance instance,
-    ) async {
-      final TautulliApi api =
-          await ref.watch(tautulliApiProvider(instance).future);
-      return api.getUsers();
-    });
+  Ref ref,
+  Instance instance,
+) async {
+  final TautulliApi api = await ref.watch(tautulliApiProvider(instance).future);
+  return api.getUsers();
+});

--- a/services/service_tautulli/pubspec.yaml
+++ b/services/service_tautulli/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  progress_indicator_m3e:
   cached_network_image: ^3.4.1
   collection: ^1.18.0
   core_models:

--- a/services/service_tautulli/test/tautulli_models_test.dart
+++ b/services/service_tautulli/test/tautulli_models_test.dart
@@ -161,7 +161,8 @@ void main() {
 
   test('parses home stats with per-stat row shapes', () {
     final List<TautulliHomeStat> stats = homeStatsJson
-        .map((dynamic e) => TautulliHomeStat.fromJson(e as Map<String, dynamic>))
+        .map(
+            (dynamic e) => TautulliHomeStat.fromJson(e as Map<String, dynamic>))
         .toList();
     expect(stats, hasLength(4));
 

--- a/tool/build_all.dart
+++ b/tool/build_all.dart
@@ -7,21 +7,26 @@ void main(List<String> args) async {
   final stopwatch = Stopwatch()..start();
 
   // If no arguments are provided, default to build with delete-conflicting-outputs
-  final commandArgs = args.isEmpty
-      ? ['build', '--delete-conflicting-outputs']
-      : args;
+  final commandArgs =
+      args.isEmpty ? ['build', '--delete-conflicting-outputs'] : args;
 
-  print('Starting build_runner in workspace packages with arguments: ${commandArgs.join(' ')}\n');
+  print(
+      'Starting build_runner in workspace packages with arguments: ${commandArgs.join(' ')}\n');
 
   final rootDir = Directory.current;
   final workspaceDirs = <Directory>[];
 
   // Recursively find all package directories containing a pubspec.yaml with build_runner
-  await for (final entity in rootDir.list(recursive: true, followLinks: false)) {
+  await for (final entity
+      in rootDir.list(recursive: true, followLinks: false)) {
     if (entity is Directory) {
-      final name = entity.uri.pathSegments.lastWhere((s) => s.isNotEmpty, orElse: () => '');
+      final name = entity.uri.pathSegments
+          .lastWhere((s) => s.isNotEmpty, orElse: () => '');
       // Skip common hidden or build directories
-      if (name.startsWith('.') || name == 'build' || name == 'ios' || name == 'android') {
+      if (name.startsWith('.') ||
+          name == 'build' ||
+          name == 'ios' ||
+          name == 'android') {
         continue;
       }
     } else if (entity is File && entity.path.endsWith('pubspec.yaml')) {
@@ -42,7 +47,8 @@ void main(List<String> args) async {
 
   print('Found ${workspaceDirs.length} packages to run build_runner in:');
   for (final dir in workspaceDirs) {
-    final relativePath = dir.path.replaceFirst(rootDir.path + Platform.pathSeparator, '');
+    final relativePath =
+        dir.path.replaceFirst(rootDir.path + Platform.pathSeparator, '');
     print('  - $relativePath');
   }
   print('');
@@ -51,10 +57,13 @@ void main(List<String> args) async {
   var failureCount = 0;
 
   for (final dir in workspaceDirs) {
-    final relativePath = dir.path.replaceFirst(rootDir.path + Platform.pathSeparator, '');
-    print('========================================================================');
+    final relativePath =
+        dir.path.replaceFirst(rootDir.path + Platform.pathSeparator, '');
+    print(
+        '========================================================================');
     print('Running build_runner in: $relativePath');
-    print('========================================================================');
+    print(
+        '========================================================================');
 
     final process = await Process.start(
       'dart',
@@ -76,13 +85,15 @@ void main(List<String> args) async {
   stopwatch.stop();
   final duration = stopwatch.elapsed;
 
-  print('========================================================================');
+  print(
+      '========================================================================');
   print('Summary:');
   print('  Total packages: ${workspaceDirs.length}');
   print('  Success: $successCount');
   print('  Failed: $failureCount');
   print('  Time elapsed: ${duration.inMinutes}m ${duration.inSeconds % 60}s');
-  print('========================================================================');
+  print(
+      '========================================================================');
 
   if (failureCount > 0) {
     exit(1);


### PR DESCRIPTION
### Summary
This PR completely overhauls the "Now Streaming" dashboard widget to provide a richer, more immersive visual experience, while also improving the consistency of progress indicators across the dashboard.

### Key Changes
- **Full-Bleed Banners**: Replaced the static streaming row layout with a rich `_StreamBanner` that displays full-bleed backdrop artwork with gradient scrims, matching the "Upcoming Releases" aesthetic.
- **Dynamic Theming**: Integrated `PaletteGenerator` to dynamically extract colors from the active streaming poster and apply them to the progress bar (mirroring native Emby/Jellyfin widgets).
- **Intelligent Art Fallbacks**: Added robust safety fallbacks to both the Streams widget and the Activity Feed cards. If a server (like Plex/Tautulli) returns a 404 for a missing wide backdrop (very common for music albums), the app will automatically catch the error and stretch the square album cover as a blurred banner backdrop instead. 
- **Uniform Dashboard Styling**: Explicitly set the M3E linear progress indicators to the thin `Small` size across all dashboard widgets (Disk Space, Downloads, Streams, and Server Info) for a cleaner, unified look without altering the thicker default progress bars used in the rest of the application.
- **Layout Alignment**: Standardized the poster bounds with `Center` alignment to ensure text columns stay perfectly aligned regardless of media aspect ratio (1:1 music albums vs 2:3 movie posters).
