### PR TITLE
M3 Expressive progress indicators, palette-themed streaming banners, and a 0% progress fix

### DIFF
--- a/app/lib/src/dashboard/widgets/disk_widget.dart
+++ b/app/lib/src/dashboard/widgets/disk_widget.dart
@@ -7,6 +7,7 @@ import 'package:service_sabnzbd/service_sabnzbd.dart';
 
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 class _DiskRow {
   const _DiskRow({
@@ -74,8 +75,7 @@ class DashboardDiskWidget extends ConsumerWidget {
       final AsyncValue<GlancesStats> stats = ref.watch(glancesStatsProvider(i));
       anyLoading |= stats.isLoading && !stats.hasValue;
       anyError |= stats.hasError;
-      for (final GlancesDisk d
-          in stats.value?.disks ?? const <GlancesDisk>[]) {
+      for (final GlancesDisk d in stats.value?.disks ?? const <GlancesDisk>[]) {
         if (d.total > 0) {
           rows.add(_DiskRow(
             label: '${i.name} ${d.path}',
@@ -169,11 +169,12 @@ class _BarRow extends StatelessWidget {
           const SizedBox(height: 4),
           ClipRRect(
             borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
+            child: LinearProgressIndicatorM3E(
+              size: LinearProgressM3ESize.s,
+              shape: ProgressM3EShape.flat,
               value: row.fraction,
-              minHeight: 5,
-              color: barColor,
-              backgroundColor: cs.surfaceContainerHighest,
+              activeColor: barColor,
+              trackColor: cs.surfaceContainerHighest,
             ),
           ),
         ],

--- a/app/lib/src/dashboard/widgets/downloads_widget.dart
+++ b/app/lib/src/dashboard/widgets/downloads_widget.dart
@@ -10,6 +10,7 @@ import 'package:service_sabnzbd/service_sabnzbd.dart';
 
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// qBittorrent states that count as actively downloading.
 const Set<String> _activeDlStates = <String>{
@@ -31,8 +32,7 @@ final activeDownloadCountProvider = Provider.autoDispose<int>((Ref ref) {
   for (final Instance i in instances) {
     if (i.kind == ServiceKind.qbittorrent) {
       final List<QbitTorrent> torrents =
-          ref.watch(qbitRawTorrentsProvider(i)).value ??
-              const <QbitTorrent>[];
+          ref.watch(qbitRawTorrentsProvider(i)).value ?? const <QbitTorrent>[];
       for (final QbitTorrent t in torrents) {
         if (_activeDlStates.contains(t.state)) {
           count++;
@@ -131,7 +131,8 @@ class DashboardDownloadsWidget extends ConsumerWidget {
       }
     }
 
-    rows.sort((_DownloadRow a, _DownloadRow b) => b.progress.compareTo(a.progress));
+    rows.sort(
+        (_DownloadRow a, _DownloadRow b) => b.progress.compareTo(a.progress));
     final List<_DownloadRow> top = rows.take(3).toList();
 
     Widget body;
@@ -226,11 +227,12 @@ class _ItemRow extends StatelessWidget {
             const SizedBox(height: 4),
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
+              child: LinearProgressIndicatorM3E(
+                size: LinearProgressM3ESize.s,
+                shape: ProgressM3EShape.flat,
                 value: row.progress,
-                minHeight: 5,
-                color: cs.primary,
-                backgroundColor: cs.surfaceContainerHighest,
+                activeColor: cs.primary,
+                trackColor: cs.surfaceContainerHighest,
               ),
             ),
           ],

--- a/app/lib/src/dashboard/widgets/streams_widget.dart
+++ b/app/lib/src/dashboard/widgets/streams_widget.dart
@@ -12,6 +12,8 @@ import 'package:service_tautulli/service_tautulli.dart';
 
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
+import 'package:palette_generator_plus/palette_generator_plus.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 /// Live count of active sessions across every Tautulli, Jellyfin and Emby
 /// instance. Instances still loading or in error contribute 0, so the
@@ -45,6 +47,7 @@ class _StreamRow {
     required this.instance,
     this.device = '',
     this.posterUrl,
+    this.backdropUrl,
     this.quality,
     this.transcoding = false,
     this.timeLabel,
@@ -59,6 +62,7 @@ class _StreamRow {
   /// Player / client the session is on (e.g. "Chrome", "Apple TV").
   final String device;
   final String? posterUrl;
+  final String? backdropUrl;
 
   /// Stream resolution (e.g. "1080p"), when the backend reports it.
   final String? quality;
@@ -113,6 +117,7 @@ class DashboardStreamsWidget extends ConsumerWidget {
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
           paused: s.state.toLowerCase() == 'paused',
           posterUrl: api?.imageUrl(s.posterThumb),
+          backdropUrl: api?.imageUrl(s.art),
           device: s.player,
           quality: s.videoResolution.isEmpty ? null : s.videoResolution,
           transcoding: s.transcodeDecision.toLowerCase() == 'transcode',
@@ -135,6 +140,7 @@ class DashboardStreamsWidget extends ConsumerWidget {
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
           paused: s.status.toLowerCase() == 'paused',
           posterUrl: s.posterUrl,
+          backdropUrl: s.backdropUrl,
           device: s.device,
           timeLabel: _timeLabel(s.timePosition, s.timeDuration),
           instance: i,
@@ -156,6 +162,7 @@ class DashboardStreamsWidget extends ConsumerWidget {
           progress: (s.progressPercent / 100).clamp(0, 1).toDouble(),
           paused: s.status.toLowerCase() == 'paused',
           posterUrl: s.posterUrl,
+          backdropUrl: s.backdropUrl,
           device: s.device,
           timeLabel: _timeLabel(s.timePosition, s.timeDuration),
           instance: i,
@@ -187,12 +194,13 @@ class DashboardStreamsWidget extends ConsumerWidget {
         children: <Widget>[
           for (int j = 0; j < top.length; j++) ...<Widget>[
             if (j > 0) const SizedBox(height: Insets.sm),
-            _SessionRow(row: top[j]),
+            _StreamBanner(row: top[j]),
           ],
           if (rows.length > top.length)
             Padding(
               padding: const EdgeInsets.only(top: Insets.sm),
-              child: DashboardIdleRow(text: '+${rows.length - top.length} more'),
+              child:
+                  DashboardIdleRow(text: '+${rows.length - top.length} more'),
             ),
         ],
       );
@@ -225,121 +233,259 @@ class DashboardStreamsWidget extends ConsumerWidget {
   }
 }
 
-class _SessionRow extends StatelessWidget {
-  const _SessionRow({required this.row});
+class _StreamBanner extends StatefulWidget {
+  const _StreamBanner({required this.row});
 
   final _StreamRow row;
 
   @override
+  State<_StreamBanner> createState() => _StreamBannerState();
+}
+
+class _StreamBannerState extends State<_StreamBanner> {
+  PaletteGenerator? _palette;
+  String? _lastPosterUrl;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updateColorScheme();
+  }
+
+  @override
+  void didUpdateWidget(covariant _StreamBanner oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.row.posterUrl != widget.row.posterUrl) {
+      _updateColorScheme();
+    }
+  }
+
+  void _updateColorScheme() {
+    final String? posterUrl = widget.row.posterUrl;
+    if (posterUrl == null || posterUrl == _lastPosterUrl) return;
+    _lastPosterUrl = posterUrl;
+
+    PaletteGenerator.fromImageProvider(
+      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      size: const Size(200, 300),
+    ).then((PaletteGenerator palette) {
+      if (mounted) {
+        setState(() {
+          _palette = palette;
+        });
+      }
+    }).catchError((_) {});
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final ThemeData theme = Theme.of(context);
+    ThemeData theme = Theme.of(context);
+
+    if (_palette != null) {
+      final Color dominant =
+          _palette!.dominantColor?.color ?? theme.colorScheme.surface;
+      final Color vibrant = _palette!.vibrantColor?.color ??
+          _palette!.lightVibrantColor?.color ??
+          dominant;
+      theme = theme.copyWith(
+        colorScheme: theme.colorScheme.copyWith(
+          primary: vibrant,
+        ),
+      );
+    }
     final ColorScheme cs = theme.colorScheme;
+    final _StreamRow row = widget.row;
+
     final String? poster = row.posterUrl;
-    return InkWell(
-      borderRadius: BorderRadius.circular(12),
-      onTap: () => context.go(
-        AtriumRoutes.servicePath(row.instance.kind.name, row.instance.id),
-      ),
-      child: Row(
-        children: <Widget>[
-          ClipRRect(
-            borderRadius: BorderRadius.circular(8),
-            child: SizedBox(
-              width: 40,
-              height: 56,
-              child: (poster == null || poster.isEmpty)
-                  ? _posterFallback(cs)
-                  : CachedNetworkImage(
-                      imageUrl: poster,
-                      fit: BoxFit.cover,
-                      memCacheWidth: 120,
-                      errorWidget: (_, __, ___) => _posterFallback(cs),
+    final String? backdrop =
+        (row.backdropUrl != null && row.backdropUrl!.trim().isNotEmpty)
+            ? row.backdropUrl
+            : poster;
+    final bool hasArt = backdrop != null && backdrop.trim().isNotEmpty;
+
+    final bool isLight = theme.brightness == Brightness.light;
+    final Color scrim = isLight ? Colors.white : Colors.black;
+    final Color onArt = isLight ? const Color(0xFF141414) : Colors.white;
+    final Color titleColor = hasArt ? onArt : cs.onSurface;
+    final Color subColor =
+        hasArt ? onArt.withValues(alpha: 0.78) : cs.onSurfaceVariant;
+
+    return Theme(
+      data: theme,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(16),
+        child: SizedBox(
+          height: 78,
+          child: Stack(
+            fit: StackFit.expand,
+            children: <Widget>[
+              if (hasArt)
+                CachedNetworkImage(
+                  imageUrl: backdrop,
+                  fit: BoxFit.cover,
+                  alignment: Alignment.center,
+                  memCacheWidth: 600,
+                  errorWidget: (_, __, ___) => (backdrop != poster &&
+                          poster != null &&
+                          poster.trim().isNotEmpty)
+                      ? CachedNetworkImage(
+                          imageUrl: poster,
+                          fit: BoxFit.cover,
+                          alignment: Alignment.center,
+                          memCacheWidth: 600,
+                          errorWidget: (_, __, ___) =>
+                              Container(color: cs.surfaceContainerHighest),
+                        )
+                      : Container(color: cs.surfaceContainerHighest),
+                )
+              else
+                Container(color: cs.surfaceContainerHighest),
+              if (hasArt)
+                DecoratedBox(
+                  decoration: BoxDecoration(
+                    gradient: LinearGradient(
+                      colors: <Color>[
+                        scrim.withValues(alpha: 0.88),
+                        scrim.withValues(alpha: 0.60),
+                        scrim.withValues(alpha: 0.20),
+                      ],
+                      stops: const <double>[0.0, 0.55, 1.0],
                     ),
-            ),
-          ),
-          const SizedBox(width: Insets.md),
-          Expanded(
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: Text(
-                        row.title,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.titleSmall
-                            ?.copyWith(fontWeight: FontWeight.w700),
-                      ),
-                    ),
-                    if (row.quality != null) ...<Widget>[
-                      const SizedBox(width: Insets.sm),
-                      _QualityChip(
-                        label: row.quality!,
-                        transcoding: row.transcoding,
-                      ),
-                    ],
-                  ],
+                  ),
                 ),
-                const SizedBox(height: 2),
-                Row(
-                  children: <Widget>[
-                    Icon(
-                      row.paused
-                          ? Icons.pause_rounded
-                          : Icons.play_arrow_rounded,
-                      size: 14,
-                      color: cs.onSurfaceVariant,
-                    ),
-                    const SizedBox(width: 2),
-                    Expanded(
-                      child: Text(
-                        row.device.isEmpty
-                            ? row.user
-                            : '${row.user} · ${row.device}',
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: theme.textTheme.bodySmall
-                            ?.copyWith(color: cs.onSurfaceVariant),
-                      ),
-                    ),
-                  ],
+              InkWell(
+                onTap: () => context.go(
+                  AtriumRoutes.servicePath(
+                      row.instance.kind.name, row.instance.id),
                 ),
-                const SizedBox(height: 6),
-                Row(
-                  children: <Widget>[
-                    Expanded(
-                      child: ClipRRect(
-                        borderRadius: BorderRadius.circular(4),
-                        child: LinearProgressIndicator(
-                          value: row.progress,
-                          minHeight: 5,
-                          color: cs.tertiary,
-                          backgroundColor: cs.surfaceContainerHighest,
+                child: Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  child: Row(
+                    children: <Widget>[
+                      SizedBox(
+                        width: 66,
+                        height: 66,
+                        child: Center(
+                          child: ClipRRect(
+                            borderRadius: BorderRadius.circular(8),
+                            child: ConstrainedBox(
+                              constraints: const BoxConstraints(
+                                minWidth: 44,
+                                maxWidth: 66,
+                              ),
+                              child: SizedBox(
+                                height: 66,
+                                child: (poster == null || poster.isEmpty)
+                                    ? _posterFallback(cs)
+                                    : CachedNetworkImage(
+                                        imageUrl: poster,
+                                        fit: BoxFit.cover,
+                                        memCacheWidth: 132,
+                                        errorWidget: (_, __, ___) =>
+                                            _posterFallback(cs),
+                                      ),
+                              ),
+                            ),
+                          ),
                         ),
                       ),
-                    ),
-                    const SizedBox(width: Insets.sm),
-                    Text(
-                      row.timeLabel ??
-                          '${(row.progress * 100).toStringAsFixed(0)}%',
-                      style: theme.textTheme.labelSmall
-                          ?.copyWith(color: cs.onSurfaceVariant),
-                    ),
-                  ],
+                      const SizedBox(width: Insets.md),
+                      Expanded(
+                        child: Column(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            Row(
+                              children: <Widget>[
+                                Expanded(
+                                  child: Text(
+                                    row.title,
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: theme.textTheme.titleSmall?.copyWith(
+                                      fontWeight: FontWeight.w700,
+                                      color: titleColor,
+                                    ),
+                                  ),
+                                ),
+                                if (row.quality != null) ...<Widget>[
+                                  const SizedBox(width: Insets.sm),
+                                  _QualityChip(
+                                    label: row.quality!,
+                                    transcoding: row.transcoding,
+                                  ),
+                                ],
+                              ],
+                            ),
+                            const SizedBox(height: 3),
+                            Row(
+                              children: <Widget>[
+                                Icon(
+                                  row.paused
+                                      ? Icons.pause_rounded
+                                      : Icons.play_arrow_rounded,
+                                  size: 14,
+                                  color: subColor,
+                                ),
+                                const SizedBox(width: 2),
+                                Expanded(
+                                  child: Text(
+                                    row.device.isEmpty
+                                        ? row.user
+                                        : '${row.user} • ${row.device}',
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: theme.textTheme.bodySmall
+                                        ?.copyWith(color: subColor),
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+                            Row(
+                              children: <Widget>[
+                                Expanded(
+                                  child: ClipRRect(
+                                    borderRadius: BorderRadius.circular(4),
+                                    child: LinearProgressIndicatorM3E(
+                                      size: LinearProgressM3ESize.s,
+                                      shape: ProgressM3EShape.flat,
+                                      value: row.progress.clamp(0, 1),
+                                      activeColor: !row.paused
+                                          ? theme.colorScheme.primary
+                                          : theme.colorScheme.outline,
+                                      trackColor: hasArt
+                                          ? scrim.withValues(alpha: 0.15)
+                                          : cs.surfaceContainerHighest,
+                                    ),
+                                  ),
+                                ),
+                                const SizedBox(width: Insets.sm),
+                                Text(
+                                  row.timeLabel ??
+                                      '${(row.progress * 100).toStringAsFixed(0)}%',
+                                  style: theme.textTheme.labelSmall
+                                      ?.copyWith(color: subColor),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
-        ],
+        ),
       ),
     );
   }
 
   Widget _posterFallback(ColorScheme cs) => Container(
-        color: cs.surfaceContainerHighest,
+        color: cs.surfaceContainerHigh,
         alignment: Alignment.center,
         child: Icon(
           Icons.play_circle_outline,

--- a/packages/progress_indicator_m3e_fixed/lib/src/circular_progress_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/circular_progress_m3e.dart
@@ -93,13 +93,15 @@ class _CircularProgressIndicatorM3EState
                   value: widget.value,
                   active: active,
                   track: track,
-                  rotation: rot,)
+                  rotation: rot,
+                )
               : _CircularFlatPainter(
                   value: widget.value,
                   active: active,
                   track: track,
                   rotation: rot,
-                  size: widget.size,),
+                  size: widget.size,
+                ),
         ),
       ),
     );
@@ -107,12 +109,13 @@ class _CircularProgressIndicatorM3EState
 }
 
 class _CircularFlatPainter extends CustomPainter {
-  _CircularFlatPainter(
-      {required this.value,
-      required this.active,
-      required this.track,
-      required this.rotation,
-      required this.size,});
+  _CircularFlatPainter({
+    required this.value,
+    required this.active,
+    required this.track,
+    required this.rotation,
+    required this.size,
+  });
 
   final double? value;
   final Color active;
@@ -127,19 +130,6 @@ class _CircularFlatPainter extends CustomPainter {
     final radius = (math.min(s.width, s.height) - stroke) / 2;
     final rect = Rect.fromCircle(center: center, radius: radius);
 
-    // gap before active in dp -> angle
-    const gapDp = 8.0;
-    final gapAngle = gapDp / radius; // s = r * angle
-
-    // active sweep
-    final sweep =
-        value == null ? math.pi * 1.5 : (value!.clamp(0.0, 1.0) * math.pi * 2);
-
-    final start = -math.pi / 2 + rotation;
-    final activeStart = start;
-    final activeEnd = start + sweep;
-
-    // TRACK: draw the rest of the ring, leaving a gap ahead of the active arc and no overlap.
     final trackPaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = stroke
@@ -147,23 +137,44 @@ class _CircularFlatPainter extends CustomPainter {
       ..isAntiAlias = true
       ..color = track;
 
-    const total = math.pi * 2;
-    final a1 = activeEnd + gapAngle;
-    final a2 = activeStart - gapAngle;
-    double sweep1 = a2 - a1;
-    while (sweep1 <= 0) {
-      sweep1 += total;
+    if (value == 0.0) {
+      canvas.drawCircle(center, radius, trackPaint);
+      return;
     }
-    canvas.drawArc(rect, a1, sweep1, false, trackPaint);
 
-    // ACTIVE arc
     final activePaint = Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = stroke
       ..strokeCap = StrokeCap.round
       ..isAntiAlias = true
       ..color = active;
-    canvas.drawArc(rect, activeStart, sweep, false, activePaint);
+
+    final start = -math.pi / 2 + rotation;
+    final sweep =
+        value == null ? math.pi * 1.5 : (value!.clamp(0.0, 1.0) * math.pi * 2);
+
+    if (value == 1.0) {
+      canvas.drawArc(rect, start, sweep, false, activePaint);
+      return;
+    }
+
+    // gap before active in dp -> angle
+    const gapDp = 8.0;
+    final gapAngle = gapDp / radius; // s = r * angle
+    const total = math.pi * 2;
+
+    if (sweep + 2 * gapAngle < total) {
+      final a1 = start + sweep + gapAngle;
+      final a2 = start - gapAngle;
+      double sweep1 = a2 - a1;
+      while (sweep1 <= 0) {
+        sweep1 += total;
+      }
+      canvas.drawArc(rect, a1, sweep1, false, trackPaint);
+    }
+
+    // ACTIVE arc
+    canvas.drawArc(rect, start, sweep, false, activePaint);
   }
 
   @override
@@ -176,11 +187,12 @@ class _CircularFlatPainter extends CustomPainter {
 }
 
 class _CircularWavyPainter extends CustomPainter {
-  _CircularWavyPainter(
-      {required this.value,
-      required this.active,
-      required this.track,
-      required this.rotation,});
+  _CircularWavyPainter({
+    required this.value,
+    required this.active,
+    required this.track,
+    required this.rotation,
+  });
 
   final double? value;
   final Color active;
@@ -192,6 +204,17 @@ class _CircularWavyPainter extends CustomPainter {
     const stroke = 4.0;
     final center = s.center(Offset.zero);
     final baseRadius = (math.min(s.width, s.height) - stroke) / 2;
+
+    if (value == 0.0) {
+      final trackPaint = Paint()
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = stroke
+        ..strokeCap = StrokeCap.round
+        ..isAntiAlias = true
+        ..color = track;
+      canvas.drawCircle(center, baseRadius, trackPaint);
+      return;
+    }
 
     const amp = 2.0; // radial amplitude of squiggle
     const scallopLen = 18.0; // along-arc wavelength proxy (dp)
@@ -207,23 +230,26 @@ class _CircularWavyPainter extends CustomPainter {
     // Track ring with gap around active (skip when wave-only: indeterminate or 100%)
     final bool waveOnly = value == null || (value != null && value! >= 1.0);
     if (!waveOnly) {
-      final trackPaint = Paint()
-        ..style = PaintingStyle.stroke
-        ..strokeWidth = stroke
-        ..strokeCap = StrokeCap.round
-        ..isAntiAlias = true
-        ..color = track;
-
       final gapAngle = 2.0 / baseRadius;
       final rect = Rect.fromCircle(center: center, radius: baseRadius);
       const total = math.pi * 2;
-      final a1 = end + gapAngle;
-      final a2 = start - gapAngle;
-      double sweep1 = a2 - a1;
-      while (sweep1 <= 0) {
-        sweep1 += total;
+
+      if (activeSweep + 2 * gapAngle < total) {
+        final trackPaint = Paint()
+          ..style = PaintingStyle.stroke
+          ..strokeWidth = stroke
+          ..strokeCap = StrokeCap.round
+          ..isAntiAlias = true
+          ..color = track;
+
+        final a1 = end + gapAngle;
+        final a2 = start - gapAngle;
+        double sweep1 = a2 - a1;
+        while (sweep1 <= 0) {
+          sweep1 += total;
+        }
+        canvas.drawArc(rect, a1, sweep1, false, trackPaint);
       }
-      canvas.drawArc(rect, a1, sweep1, false, trackPaint);
     }
 
     // Active squiggle path

--- a/packages/progress_indicator_m3e_fixed/lib/src/linear_progress_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/linear_progress_m3e.dart
@@ -161,12 +161,16 @@ class _LinearPainter extends CustomPainter {
     // Track occupies the remaining segment to the right of the active,
     // leaving a fixed inter-stroke gap. For indeterminate, fill full width.
     final double activeEndX = value == null ? right : (left + width * p);
-    final double trackStartX =
-        value == null ? left : math.min(right, activeEndX + spec.gap + spec.trackHeight);
+    final double trackStartX = value == null
+        ? left
+        : math.min(right, activeEndX + spec.gap + spec.trackHeight);
 
     if (!waveOnly) {
-      canvas.drawLine(Offset(trackStartX, trackCy), Offset(right, trackCy),
-          base..color = track,);
+      canvas.drawLine(
+        Offset(trackStartX, trackCy),
+        Offset(right, trackCy),
+        base..color = track,
+      );
     }
 
     // --- Active lane ---
@@ -191,30 +195,38 @@ class _LinearPainter extends CustomPainter {
       path.lineTo(end, y);
 
       canvas.drawPath(
-          path,
-          base
-            ..color = active
-            ..strokeWidth = spec.trackHeight,);
+        path,
+        base
+          ..color = active
+          ..strokeWidth = spec.trackHeight,
+      );
 
       // end dot: accent at far right end of the track (shared baseline)
       if (!waveOnly) {
         final dotCenterX = math.max(left, right - spec.dotOffset);
-        canvas.drawCircle(Offset(dotCenterX, trackCy), spec.dotDiameter / 2,
-            Paint()..color = active,);
+        canvas.drawCircle(
+          Offset(dotCenterX, trackCy),
+          spec.dotDiameter / 2,
+          Paint()..color = active,
+        );
       }
     } else {
       // flat active pill + end dot
       final start = left;
       final end = value == null ? right : (left + width * p);
       canvas.drawLine(
-          Offset(start, activeCy),
-          Offset(end, activeCy),
-          base
-            ..color = active
-            ..strokeWidth = spec.trackHeight,);
+        Offset(start, activeCy),
+        Offset(end, activeCy),
+        base
+          ..color = active
+          ..strokeWidth = spec.trackHeight,
+      );
       final dotCenterX = math.max(left, right - spec.dotOffset);
-      canvas.drawCircle(Offset(dotCenterX, trackCy), spec.dotDiameter / 2,
-          Paint()..color = active,);
+      canvas.drawCircle(
+        Offset(dotCenterX, trackCy),
+        spec.dotDiameter / 2,
+        Paint()..color = active,
+      );
     }
   }
 

--- a/packages/progress_indicator_m3e_fixed/lib/src/progress_with_label_m3e.dart
+++ b/packages/progress_indicator_m3e_fixed/lib/src/progress_with_label_m3e.dart
@@ -26,8 +26,10 @@ class ProgressWithLabelM3E extends StatelessWidget {
         alignment: Alignment.center,
         children: [
           CircularProgressIndicatorM3E(value: value, size: size),
-          Text('${(value * 100).round()}%',
-              style: textStyle ?? Theme.of(context).textTheme.labelMedium,),
+          Text(
+            '${(value * 100).round()}%',
+            style: textStyle ?? Theme.of(context).textTheme.labelMedium,
+          ),
         ],
       ),
     );

--- a/services/service_emby/lib/src/emby_home.dart
+++ b/services/service_emby/lib/src/emby_home.dart
@@ -6,6 +6,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:palette_generator_plus/palette_generator_plus.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'emby_client.dart';
 import 'emby_identify_screen.dart';
@@ -47,7 +48,8 @@ class EmbyHome extends ConsumerStatefulWidget {
 class _EmbyHomeState extends ConsumerState<EmbyHome> {
   @override
   Widget build(BuildContext context) {
-    final AsyncValue<List<EmbyView>> viewsAsync = ref.watch(embyViewsProvider(widget.instance));
+    final AsyncValue<List<EmbyView>> viewsAsync =
+        ref.watch(embyViewsProvider(widget.instance));
     final int index = ref.watch(embyActiveTabBarIndexProvider(widget.instance));
 
     return AsyncValueView<List<EmbyView>>(
@@ -61,11 +63,11 @@ class _EmbyHomeState extends ConsumerState<EmbyHome> {
             message: 'This Emby server has no libraries to show.',
           );
         }
-        
+
         final String libsKey = libraries.map((EmbyView l) => l.id).join(',');
         final int targetLength = libraries.length + 3;
         final int initialIndex = (index < targetLength) ? index : 0;
-        
+
         return DefaultTabController(
           key: ValueKey<String>(libsKey),
           length: targetLength,
@@ -717,11 +719,10 @@ class EmbyPosterCard extends ConsumerWidget {
                           ),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(6),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress.clamp(0, 1),
-                              minHeight: 6,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.5),
+                              trackColor: Colors.black.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -1086,10 +1087,10 @@ class EmbyBannerCard extends ConsumerWidget {
                               const SizedBox(height: 8),
                               ClipRRect(
                                 borderRadius: BorderRadius.circular(6),
-                                child: LinearProgressIndicator(
+                                child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
                                   value: progress.clamp(0, 1),
-                                  minHeight: 6,
-                                  backgroundColor:
+                                  trackColor:
                                       Colors.black.withValues(alpha: 0.1),
                                 ),
                               ),
@@ -1454,37 +1455,212 @@ class _SessionCardState extends State<_SessionCard> {
           borderRadius: BorderRadius.circular(24),
         ),
         child: InkWell(
-        onTap: () => pushScreen<void>(
-          context,
-          EmbySessionDetailScreen(
-            initialSession: session,
-            instance: widget.instance,
+          onTap: () => pushScreen<void>(
+            context,
+            EmbySessionDetailScreen(
+              initialSession: session,
+              instance: widget.instance,
+            ),
           ),
-        ),
-        child: Stack(
-          children: <Widget>[
-            // Backdrop
-            if (session.posterUrl != null)
-              Positioned.fill(
-                child: Stack(
-                  fit: StackFit.expand,
+          child: Stack(
+            children: <Widget>[
+              // Backdrop
+              if (session.posterUrl != null)
+                Positioned.fill(
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: <Widget>[
+                      Image.network(
+                        session.posterUrl!,
+                        fit: BoxFit.cover,
+                        alignment: Alignment.topCenter,
+                        errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                      ),
+                      Container(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: <Color>[
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.3),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.85),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.95),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+              // Content
+              Padding(
+                padding: const EdgeInsets.all(Insets.md),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Image.network(
-                      session.posterUrl!,
-                      fit: BoxFit.cover,
-                      alignment: Alignment.topCenter,
-                      errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    // Poster
+                    ConstrainedBox(
+                      constraints:
+                          const BoxConstraints(maxWidth: 120, maxHeight: 126),
+                      child: AspectRatio(
+                        aspectRatio: session.aspectRatio != null &&
+                                session.aspectRatio! > 0.0
+                            ? session.aspectRatio!
+                            : (2 / 3),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(12),
+                            boxShadow: <BoxShadow>[
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.25),
+                                blurRadius: 12,
+                                offset: const Offset(0, 6),
+                              ),
+                            ],
+                            image: session.posterUrl != null
+                                ? DecorationImage(
+                                    image: CachedNetworkImageProvider(
+                                      session.posterUrl!,
+                                    ),
+                                    fit: BoxFit.cover,
+                                    onError: (Object _, StackTrace? __) {},
+                                  )
+                                : null,
+                          ),
+                          child: session.posterUrl == null
+                              ? Icon(
+                                  Icons.movie_outlined,
+                                  color: theme.colorScheme.outline,
+                                  size: 32,
+                                )
+                              : null,
+                        ),
+                      ),
                     ),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: <Color>[
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.3),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.85),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.95),
+                    const SizedBox(width: Insets.lg),
+
+                    // Details
+                    Expanded(
+                      child: SizedBox(
+                        height: 126,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            // Title
+                            Text(
+                              session.showTitle,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18,
+                                shadows: <Shadow>[
+                                  Shadow(
+                                    color: Colors.black.withValues(alpha: 0.8),
+                                    offset: const Offset(0, 2),
+                                    blurRadius: 4,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+
+                            if (session.episodeName != null)
+                              Text(
+                                session.episodeName!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                  shadows: <Shadow>[
+                                    Shadow(
+                                      color:
+                                          Colors.black.withValues(alpha: 0.8),
+                                      offset: const Offset(0, 1),
+                                      blurRadius: 3,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                            const SizedBox(height: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.surfaceContainerHighest
+                                    .withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: theme.colorScheme.outlineVariant
+                                      .withValues(alpha: 0.5),
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: <Widget>[
+                                  Icon(
+                                    Icons.person,
+                                    size: 14,
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Flexible(
+                                    child: Text(
+                                      '${session.user}: ${session.device}',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
+                                        color:
+                                            theme.colorScheme.onSurfaceVariant,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+
+                            const Spacer(),
+
+                            // Progress Header
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: <Widget>[
+                                Text(
+                                  session.timePosition,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                Text(
+                                  session.timeDuration,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+
+                            // Progress Bar
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
+                                  value: pct.clamp(0.0, 1.0),
+                                  trackColor:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  activeColor: playing
+                                      ? theme.colorScheme.primary
+                                      : theme.colorScheme.outline,),
+                            ),
                           ],
                         ),
                       ),
@@ -1492,184 +1668,9 @@ class _SessionCardState extends State<_SessionCard> {
                   ],
                 ),
               ),
-
-            // Content
-            Padding(
-              padding: const EdgeInsets.all(Insets.md),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  // Poster
-                  ConstrainedBox(
-                    constraints:
-                        const BoxConstraints(maxWidth: 120, maxHeight: 126),
-                    child: AspectRatio(
-                      aspectRatio: session.aspectRatio != null &&
-                              session.aspectRatio! > 0.0
-                          ? session.aspectRatio!
-                          : (2 / 3),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(12),
-                          boxShadow: <BoxShadow>[
-                            BoxShadow(
-                              color: Colors.black.withValues(alpha: 0.25),
-                              blurRadius: 12,
-                              offset: const Offset(0, 6),
-                            ),
-                          ],
-                          image: session.posterUrl != null
-                              ? DecorationImage(
-                                  image: CachedNetworkImageProvider(
-                                    session.posterUrl!,
-                                  ),
-                                  fit: BoxFit.cover,
-                                  onError: (Object _, StackTrace? __) {},
-                                )
-                              : null,
-                        ),
-                        child: session.posterUrl == null
-                            ? Icon(
-                                Icons.movie_outlined,
-                                color: theme.colorScheme.outline,
-                                size: 32,
-                              )
-                            : null,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: Insets.lg),
-
-                  // Details
-                  Expanded(
-                    child: SizedBox(
-                      height: 126,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          // Title
-                          Text(
-                            session.showTitle,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 18,
-                              shadows: <Shadow>[
-                                Shadow(
-                                  color: Colors.black.withValues(alpha: 0.8),
-                                  offset: const Offset(0, 2),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-
-                          if (session.episodeName != null)
-                            Text(
-                              session.episodeName!,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                                shadows: <Shadow>[
-                                  Shadow(
-                                    color: Colors.black.withValues(alpha: 0.8),
-                                    offset: const Offset(0, 1),
-                                    blurRadius: 3,
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                          const SizedBox(height: 4),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest
-                                  .withValues(alpha: 0.5),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: theme.colorScheme.outlineVariant
-                                    .withValues(alpha: 0.5),
-                              ),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: <Widget>[
-                                Icon(
-                                  Icons.person,
-                                  size: 14,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                                const SizedBox(width: 4),
-                                Flexible(
-                                  child: Text(
-                                    '${session.user}: ${session.device}',
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: theme.textTheme.bodySmall?.copyWith(
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                          const Spacer(),
-
-                          // Progress Header
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: <Widget>[
-                              Text(
-                                session.timePosition,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                              Text(
-                                session.timeDuration,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  color: theme.colorScheme.outline,
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 6),
-
-                          // Progress Bar
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(8),
-                            child: LinearProgressIndicator(
-                              value: pct.clamp(0.0, 1.0),
-                              minHeight: 8,
-                              backgroundColor:
-                                  theme.colorScheme.surfaceContainerHighest,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                playing
-                                    ? theme.colorScheme.primary
-                                    : theme.colorScheme.outline,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
       ),
     );
   }

--- a/services/service_emby/pubspec.yaml
+++ b/services/service_emby/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   json_annotation: ^4.9.0
   meta: ^1.16.0
   palette_generator_plus: ^1.0.0
+  progress_indicator_m3e:
   url_launcher: ^6.3.2
 
 dev_dependencies:

--- a/services/service_jellyfin/lib/src/jellyfin_home.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_home.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:palette_generator_plus/palette_generator_plus.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'jellyfin_client.dart';
 import 'jellyfin_identify_screen.dart';
@@ -46,8 +47,10 @@ class JellyfinHome extends ConsumerStatefulWidget {
 class _JellyfinHomeState extends ConsumerState<JellyfinHome> {
   @override
   Widget build(BuildContext context) {
-    final AsyncValue<List<JellyfinView>> viewsAsync = ref.watch(jellyfinViewsProvider(widget.instance));
-    final int index = ref.watch(jellyfinActiveTabBarIndexProvider(widget.instance));
+    final AsyncValue<List<JellyfinView>> viewsAsync =
+        ref.watch(jellyfinViewsProvider(widget.instance));
+    final int index =
+        ref.watch(jellyfinActiveTabBarIndexProvider(widget.instance));
 
     return AsyncValueView<List<JellyfinView>>(
       value: viewsAsync,
@@ -60,11 +63,12 @@ class _JellyfinHomeState extends ConsumerState<JellyfinHome> {
             message: 'This Jellyfin server has no libraries to show.',
           );
         }
-        
-        final String libsKey = libraries.map((JellyfinView l) => l.id).join(',');
+
+        final String libsKey =
+            libraries.map((JellyfinView l) => l.id).join(',');
         final int targetLength = libraries.length + 3;
         final int initialIndex = (index < targetLength) ? index : 0;
-        
+
         return DefaultTabController(
           key: ValueKey<String>(libsKey),
           length: targetLength,
@@ -684,11 +688,10 @@ class JellyfinPosterCard extends ConsumerWidget {
                           ),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(6),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress.clamp(0, 1),
-                              minHeight: 6,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.5),
+                              trackColor: Colors.black.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -859,7 +862,8 @@ class JellyfinBannerCard extends ConsumerWidget {
                             ref.read(jellyfinClientProvider(instance)).value;
                         if (client != null) {
                           try {
-                            final bool isFav = item.userData?.isFavorite == true;
+                            final bool isFav =
+                                item.userData?.isFavorite == true;
                             await client.markFavorite(item.id, !isFav);
                             if (!context.mounted) return;
                             ref.invalidate(
@@ -868,7 +872,8 @@ class JellyfinBannerCard extends ConsumerWidget {
                             ref.invalidate(jellyfinFavoritesProvider(instance));
                             ref.invalidate(jellyfinItemsProvider);
                             ref.invalidate(jellyfinNextUpProvider(instance));
-                            ref.invalidate(jellyfinResumeItemsProvider(instance));
+                            ref.invalidate(
+                                jellyfinResumeItemsProvider(instance),);
                           } catch (_) {
                             // Action failed; no revert needed.
                           }
@@ -896,7 +901,8 @@ class JellyfinBannerCard extends ConsumerWidget {
                             );
                             ref.invalidate(jellyfinItemsProvider);
                             ref.invalidate(jellyfinNextUpProvider(instance));
-                            ref.invalidate(jellyfinResumeItemsProvider(instance));
+                            ref.invalidate(
+                                jellyfinResumeItemsProvider(instance),);
                           }
                         },
                       ),
@@ -1045,10 +1051,10 @@ class JellyfinBannerCard extends ConsumerWidget {
                               const SizedBox(height: 8),
                               ClipRRect(
                                 borderRadius: BorderRadius.circular(6),
-                                child: LinearProgressIndicator(
+                                child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
                                   value: progress.clamp(0, 1),
-                                  minHeight: 6,
-                                  backgroundColor:
+                                  trackColor:
                                       Colors.black.withValues(alpha: 0.1),
                                 ),
                               ),
@@ -1415,37 +1421,209 @@ class _SessionCardState extends State<_SessionCard> {
           borderRadius: BorderRadius.circular(24),
         ),
         child: InkWell(
-        onTap: () => pushScreen<void>(
-          context,
-          JellyfinSessionDetailScreen(
-            initialSession: session,
-            instance: widget.instance,
+          onTap: () => pushScreen<void>(
+            context,
+            JellyfinSessionDetailScreen(
+              initialSession: session,
+              instance: widget.instance,
+            ),
           ),
-        ),
-        child: Stack(
-          children: <Widget>[
-            // Backdrop
-            if (session.posterUrl != null)
-              Positioned.fill(
-                child: Stack(
-                  fit: StackFit.expand,
+          child: Stack(
+            children: <Widget>[
+              // Backdrop
+              if (session.posterUrl != null)
+                Positioned.fill(
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: <Widget>[
+                      Image.network(
+                        session.posterUrl!,
+                        fit: BoxFit.cover,
+                        alignment: Alignment.topCenter,
+                        errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                      ),
+                      Container(
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: <Color>[
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.3),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.85),
+                              theme.colorScheme.surfaceContainerLow
+                                  .withValues(alpha: 0.95),
+                            ],
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+
+              // Content
+              Padding(
+                padding: const EdgeInsets.all(Insets.md),
+                child: Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: <Widget>[
-                    Image.network(
-                      session.posterUrl!,
-                      fit: BoxFit.cover,
-                      alignment: Alignment.topCenter,
-                      errorBuilder: (_, __, ___) => const SizedBox.shrink(),
+                    // Poster
+                    ConstrainedBox(
+                      constraints:
+                          const BoxConstraints(maxWidth: 120, maxHeight: 126),
+                      child: AspectRatio(
+                        aspectRatio: session.aspectRatio != null &&
+                                session.aspectRatio! > 0.0
+                            ? session.aspectRatio!
+                            : (2 / 3),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceContainerHighest,
+                            borderRadius: BorderRadius.circular(12),
+                            boxShadow: <BoxShadow>[
+                              BoxShadow(
+                                color: Colors.black.withValues(alpha: 0.25),
+                                blurRadius: 12,
+                                offset: const Offset(0, 6),
+                              ),
+                            ],
+                            image: session.posterUrl != null
+                                ? DecorationImage(
+                                    image: NetworkImage(session.posterUrl!),
+                                    fit: BoxFit.cover,
+                                  )
+                                : null,
+                          ),
+                          child: session.posterUrl == null
+                              ? Icon(
+                                  Icons.movie_outlined,
+                                  color: theme.colorScheme.outline,
+                                  size: 32,
+                                )
+                              : null,
+                        ),
+                      ),
                     ),
-                    Container(
-                      decoration: BoxDecoration(
-                        gradient: LinearGradient(
-                          colors: <Color>[
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.3),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.85),
-                            theme.colorScheme.surfaceContainerLow
-                                .withValues(alpha: 0.95),
+                    const SizedBox(width: Insets.lg),
+
+                    // Details
+                    Expanded(
+                      child: SizedBox(
+                        height: 126,
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: <Widget>[
+                            // Title
+                            Text(
+                              session.showTitle,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.bold,
+                                fontSize: 18,
+                                shadows: <Shadow>[
+                                  Shadow(
+                                    color: Colors.black.withValues(alpha: 0.8),
+                                    offset: const Offset(0, 2),
+                                    blurRadius: 4,
+                                  ),
+                                ],
+                              ),
+                            ),
+                            const SizedBox(height: 2),
+
+                            if (session.episodeName != null)
+                              Text(
+                                session.episodeName!,
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                  shadows: <Shadow>[
+                                    Shadow(
+                                      color:
+                                          Colors.black.withValues(alpha: 0.8),
+                                      offset: const Offset(0, 1),
+                                      blurRadius: 3,
+                                    ),
+                                  ],
+                                ),
+                              ),
+
+                            const SizedBox(height: 4),
+                            Container(
+                              padding: const EdgeInsets.symmetric(
+                                horizontal: 8,
+                                vertical: 4,
+                              ),
+                              decoration: BoxDecoration(
+                                color: theme.colorScheme.surfaceContainerHighest
+                                    .withValues(alpha: 0.5),
+                                borderRadius: BorderRadius.circular(12),
+                                border: Border.all(
+                                  color: theme.colorScheme.outlineVariant
+                                      .withValues(alpha: 0.5),
+                                ),
+                              ),
+                              child: Row(
+                                mainAxisSize: MainAxisSize.min,
+                                children: <Widget>[
+                                  Icon(
+                                    Icons.person,
+                                    size: 14,
+                                    color: theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Flexible(
+                                    child: Text(
+                                      '${session.user}: ${session.device}',
+                                      maxLines: 1,
+                                      overflow: TextOverflow.ellipsis,
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
+                                        color:
+                                            theme.colorScheme.onSurfaceVariant,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+
+                            const Spacer(),
+
+                            // Progress Header
+                            Row(
+                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                              children: <Widget>[
+                                Text(
+                                  session.timePosition,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                Text(
+                                  session.timeDuration,
+                                  style: theme.textTheme.labelMedium?.copyWith(
+                                    color: theme.colorScheme.outline,
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const SizedBox(height: 6),
+
+                            // Progress Bar
+                            ClipRRect(
+                              borderRadius: BorderRadius.circular(8),
+                              child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
+                                  value: pct.clamp(0.0, 1.0),
+                                  trackColor:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  activeColor: playing
+                                      ? theme.colorScheme.primary
+                                      : theme.colorScheme.outline,),
+                            ),
                           ],
                         ),
                       ),
@@ -1453,181 +1631,9 @@ class _SessionCardState extends State<_SessionCard> {
                   ],
                 ),
               ),
-
-            // Content
-            Padding(
-              padding: const EdgeInsets.all(Insets.md),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  // Poster
-                  ConstrainedBox(
-                    constraints:
-                        const BoxConstraints(maxWidth: 120, maxHeight: 126),
-                    child: AspectRatio(
-                      aspectRatio: session.aspectRatio != null &&
-                              session.aspectRatio! > 0.0
-                          ? session.aspectRatio!
-                          : (2 / 3),
-                      child: Container(
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.surfaceContainerHighest,
-                          borderRadius: BorderRadius.circular(12),
-                          boxShadow: <BoxShadow>[
-                            BoxShadow(
-                              color: Colors.black.withValues(alpha: 0.25),
-                              blurRadius: 12,
-                              offset: const Offset(0, 6),
-                            ),
-                          ],
-                          image: session.posterUrl != null
-                              ? DecorationImage(
-                                  image: NetworkImage(session.posterUrl!),
-                                  fit: BoxFit.cover,
-                                )
-                              : null,
-                        ),
-                        child: session.posterUrl == null
-                            ? Icon(
-                                Icons.movie_outlined,
-                                color: theme.colorScheme.outline,
-                                size: 32,
-                              )
-                            : null,
-                      ),
-                    ),
-                  ),
-                  const SizedBox(width: Insets.lg),
-
-                  // Details
-                  Expanded(
-                    child: SizedBox(
-                      height: 126,
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          // Title
-                          Text(
-                            session.showTitle,
-                            maxLines: 1,
-                            overflow: TextOverflow.ellipsis,
-                            style: theme.textTheme.titleMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              fontSize: 18,
-                              shadows: <Shadow>[
-                                Shadow(
-                                  color: Colors.black.withValues(alpha: 0.8),
-                                  offset: const Offset(0, 2),
-                                  blurRadius: 4,
-                                ),
-                              ],
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-
-                          if (session.episodeName != null)
-                            Text(
-                              session.episodeName!,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                              style: theme.textTheme.bodyMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                                shadows: <Shadow>[
-                                  Shadow(
-                                    color: Colors.black.withValues(alpha: 0.8),
-                                    offset: const Offset(0, 1),
-                                    blurRadius: 3,
-                                  ),
-                                ],
-                              ),
-                            ),
-
-                          const SizedBox(height: 4),
-                          Container(
-                            padding: const EdgeInsets.symmetric(
-                              horizontal: 8,
-                              vertical: 4,
-                            ),
-                            decoration: BoxDecoration(
-                              color: theme.colorScheme.surfaceContainerHighest
-                                  .withValues(alpha: 0.5),
-                              borderRadius: BorderRadius.circular(12),
-                              border: Border.all(
-                                color: theme.colorScheme.outlineVariant
-                                    .withValues(alpha: 0.5),
-                              ),
-                            ),
-                            child: Row(
-                              mainAxisSize: MainAxisSize.min,
-                              children: <Widget>[
-                                Icon(
-                                  Icons.person,
-                                  size: 14,
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                                const SizedBox(width: 4),
-                                Flexible(
-                                  child: Text(
-                                    '${session.user}: ${session.device}',
-                                    maxLines: 1,
-                                    overflow: TextOverflow.ellipsis,
-                                    style: theme.textTheme.bodySmall?.copyWith(
-                                      color: theme.colorScheme.onSurfaceVariant,
-                                      fontWeight: FontWeight.w600,
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
-
-                          const Spacer(),
-
-                          // Progress Header
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: <Widget>[
-                              Text(
-                                session.timePosition,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                              Text(
-                                session.timeDuration,
-                                style: theme.textTheme.labelMedium?.copyWith(
-                                  color: theme.colorScheme.outline,
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 6),
-
-                          // Progress Bar
-                          ClipRRect(
-                            borderRadius: BorderRadius.circular(8),
-                            child: LinearProgressIndicator(
-                              value: pct.clamp(0.0, 1.0),
-                              minHeight: 8,
-                              backgroundColor:
-                                  theme.colorScheme.surfaceContainerHighest,
-                              valueColor: AlwaysStoppedAnimation<Color>(
-                                playing
-                                    ? theme.colorScheme.primary
-                                    : theme.colorScheme.outline,
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ),
       ),
     );
   }

--- a/services/service_jellyfin/pubspec.yaml
+++ b/services/service_jellyfin/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   json_annotation: ^4.9.0
   meta: ^1.16.0
   palette_generator_plus: ^1.0.0
+  progress_indicator_m3e:
   url_launcher: ^6.3.2
 dev_dependencies:
   build_runner: ^2.4.13

--- a/services/service_plex/lib/src/plex_home.dart
+++ b/services/service_plex/lib/src/plex_home.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_riverpod/misc.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/plex_models.dart';
 import 'models/plex_session.dart';
@@ -214,10 +215,9 @@ class _ItemsGridState extends ConsumerState<_ItemsGrid> {
   /// blocked. Once loaded, `.value` keeps the last-known genres through a
   /// later refresh error rather than dropping the strip.
   Widget _genreStrip() {
-    final List<PlexGenreDir> genres = ref
-            .watch(plexGenresProvider((widget.instance, widget.id)))
-            .value ??
-        const <PlexGenreDir>[];
+    final List<PlexGenreDir> genres =
+        ref.watch(plexGenresProvider((widget.instance, widget.id))).value ??
+            const <PlexGenreDir>[];
     if (genres.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -500,7 +500,8 @@ class _NowStreamingSection extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final List<PlexSession> sessions =
-        ref.watch(plexSessionsProvider(instance)).value ?? const <PlexSession>[];
+        ref.watch(plexSessionsProvider(instance)).value ??
+            const <PlexSession>[];
     if (sessions.isEmpty) {
       return const SizedBox.shrink();
     }
@@ -576,7 +577,8 @@ class _SessionCard extends ConsumerWidget {
         child: InkWell(
           onTap: () => pushScreen<void>(
             context,
-            PlexSessionDetailScreen(instance: instance, initialSession: session),
+            PlexSessionDetailScreen(
+                instance: instance, initialSession: session,),
           ),
           child: Stack(
             fit: StackFit.expand,
@@ -660,10 +662,10 @@ class _SessionCard extends ConsumerWidget {
               ),
               Align(
                 alignment: Alignment.bottomCenter,
-                child: LinearProgressIndicator(
+                child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
                   value: session.progress,
-                  minHeight: 4,
-                  backgroundColor: Colors.white.withValues(alpha: 0.25),
+                  trackColor: Colors.white.withValues(alpha: 0.25),
                 ),
               ),
             ],
@@ -821,11 +823,10 @@ class PlexPosterCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
-    final double progress = (item.viewOffset != null &&
-            item.duration != null &&
-            item.duration! > 0)
-        ? item.viewOffset! / item.duration!
-        : 0;
+    final double progress =
+        (item.viewOffset != null && item.duration != null && item.duration! > 0)
+            ? item.viewOffset! / item.duration!
+            : 0;
     final bool isEpisode = item.grandparentTitle != null;
 
     return InkWell(
@@ -888,11 +889,10 @@ class PlexPosterCard extends ConsumerWidget {
                           padding: const EdgeInsets.all(Insets.sm),
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(6),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress.clamp(0, 1),
-                              minHeight: 6,
-                              backgroundColor:
-                                  Colors.black.withValues(alpha: 0.5),
+                              trackColor: Colors.black.withValues(alpha: 0.5),
                             ),
                           ),
                         ),
@@ -938,9 +938,8 @@ class PlexPosterCard extends ConsumerWidget {
   }
 
   Widget _poster(ThemeData theme) {
-    final bool isMusic = item.type == 'album' ||
-        item.type == 'artist' ||
-        item.type == 'track';
+    final bool isMusic =
+        item.type == 'album' || item.type == 'artist' || item.type == 'track';
     final Widget fallback = Container(
       color: theme.colorScheme.surfaceContainerHighest,
       child: Icon(

--- a/services/service_plex/lib/src/plex_season_screen.dart
+++ b/services/service_plex/lib/src/plex_season_screen.dart
@@ -3,6 +3,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/plex_models.dart';
 import 'plex_api.dart';
@@ -81,9 +82,9 @@ class PlexSeasonCard extends StatelessWidget {
                       const SizedBox(height: Insets.sm),
                       ClipRRect(
                         borderRadius: BorderRadius.circular(6),
-                        child: LinearProgressIndicator(
+                        child: LinearProgressIndicatorM3E(
+                          shape: ProgressM3EShape.flat,
                           value: progress,
-                          minHeight: 6,
                         ),
                       ),
                     ],
@@ -123,7 +124,8 @@ class PlexSeasonCard extends StatelessWidget {
 /// a trailing toggle that scrobbles/unscrobbles the episode on the server.
 /// Tapping a row opens the episode detail screen.
 class PlexEpisodeList extends ConsumerWidget {
-  const PlexEpisodeList({required this.instance, required this.season, super.key});
+  const PlexEpisodeList(
+      {required this.instance, required this.season, super.key,});
 
   final Instance instance;
   final PlexMetadata season;
@@ -137,8 +139,8 @@ class PlexEpisodeList extends ConsumerWidget {
     return Scaffold(
       appBar: AppBar(title: Text(season.title)),
       body: M3RefreshIndicator(
-        onRefresh: () async => ref
-            .invalidate(plexChildrenProvider((instance, season.ratingKey))),
+        onRefresh: () async =>
+            ref.invalidate(plexChildrenProvider((instance, season.ratingKey))),
         child: AsyncValueView<List<PlexMetadata>>(
           value: episodes,
           onRetry: () => ref
@@ -185,10 +187,9 @@ class _EpisodeTile extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final bool watched = episode.viewCount > 0;
-    final String label =
-        (episode.parentIndex != null && episode.index != null)
-            ? 'S${episode.parentIndex}E${episode.index} - ${episode.title}'
-            : episode.title;
+    final String label = (episode.parentIndex != null && episode.index != null)
+        ? 'S${episode.parentIndex}E${episode.index} - ${episode.title}'
+        : episode.title;
     final int minutes =
         episode.duration != null ? episode.duration! ~/ 60000 : 0;
 

--- a/services/service_plex/lib/src/plex_session_detail_screen.dart
+++ b/services/service_plex/lib/src/plex_session_detail_screen.dart
@@ -8,6 +8,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:palette_generator_plus/palette_generator_plus.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/plex_session.dart';
 import 'plex_api.dart';
@@ -313,7 +314,8 @@ class _PlexSessionDetailScreenState
                             child: Container(
                               clipBehavior: Clip.antiAlias,
                               decoration: BoxDecoration(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                                 borderRadius: Radii.card,
                                 boxShadow: <BoxShadow>[
                                   BoxShadow(
@@ -415,8 +417,7 @@ class _PlexSessionDetailScreenState
                             _isDragging = true;
                             _dragPct = v;
                           }),
-                          onChanged: (double v) =>
-                              setState(() => _dragPct = v),
+                          onChanged: (double v) => setState(() => _dragPct = v),
                           onChangeEnd: (double v) {
                             setState(() => _isDragging = false);
                             final int? duration = session.duration;
@@ -436,12 +437,11 @@ class _PlexSessionDetailScreenState
                             const EdgeInsets.symmetric(horizontal: Insets.md),
                         child: ClipRRect(
                           borderRadius: BorderRadius.circular(4),
-                          child: LinearProgressIndicator(
+                          child: LinearProgressIndicatorM3E(
+                            shape: ProgressM3EShape.flat,
                             value: session.progress,
-                            minHeight: 6,
-                            color: theme.colorScheme.primary,
-                            backgroundColor:
-                                Colors.white.withValues(alpha: 0.2),
+                            activeColor: theme.colorScheme.primary,
+                            trackColor: Colors.white.withValues(alpha: 0.2),
                           ),
                         ),
                       ),

--- a/services/service_plex/pubspec.yaml
+++ b/services/service_plex/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   json_annotation: ^4.9.0
   meta: ^1.16.0
   palette_generator_plus: ^1.0.0
+  progress_indicator_m3e:
   url_launcher: ^6.3.2
 
 dev_dependencies:

--- a/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
+++ b/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
@@ -5,6 +5,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'qbittorrent_client.dart';
 import 'qbittorrent_providers.dart';
@@ -150,7 +151,6 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
-
             if (_mode == AddTorrentMode.link)
               TextField(
                 controller: _links,
@@ -191,7 +191,9 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
                 ],
                 onChanged: (String? v) => setState(() => _category = v),
               ),
-              loading: () => const LinearProgressIndicator(),
+              loading: () => const LinearProgressIndicatorM3E(
+                shape: ProgressM3EShape.flat,
+              ),
               error: (_, __) => const SizedBox.shrink(),
             ),
             const SizedBox(height: Insets.sm),
@@ -225,8 +227,7 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
       ),
       actions: <Widget>[
         TextButton(
-          onPressed:
-              _busy ? null : () => Navigator.of(context).pop(false),
+          onPressed: _busy ? null : () => Navigator.of(context).pop(false),
           child: const Text('Cancel'),
         ),
         FilledButton.icon(

--- a/services/service_qbittorrent/lib/src/qbittorrent_home.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_home.dart
@@ -3,6 +3,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'add_torrent_sheet.dart';
 import 'models/qbit_torrent.dart';
@@ -38,7 +39,8 @@ class QbittorrentHome extends ConsumerWidget {
               onRefresh: () async => _refresh(ref),
               child: AsyncValueView<List<QbitTorrent>>(
                 value: torrents,
-                onRetry: () => ref.invalidate(qbitRawTorrentsProvider(instance)),
+                onRetry: () =>
+                    ref.invalidate(qbitRawTorrentsProvider(instance)),
                 data: (List<QbitTorrent> list) {
                   if (list.isEmpty) {
                     return const EmptyView(
@@ -145,7 +147,9 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
                     setState(() {
                       _isSearching = false;
                       _searchController.clear();
-                      ref.read(qbitSearchProvider(widget.instance).notifier).state = '';
+                      ref
+                          .read(qbitSearchProvider(widget.instance).notifier)
+                          .state = '';
                     });
                   },
                 ),
@@ -158,7 +162,9 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
                       border: InputBorder.none,
                     ),
                     onChanged: (String val) {
-                      ref.read(qbitSearchProvider(widget.instance).notifier).state = val;
+                      ref
+                          .read(qbitSearchProvider(widget.instance).notifier)
+                          .state = val;
                       // setState to show/hide the clear button
                       setState(() {});
                     },
@@ -169,7 +175,9 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
                     icon: const Icon(Icons.clear),
                     onPressed: () {
                       _searchController.clear();
-                      ref.read(qbitSearchProvider(widget.instance).notifier).state = '';
+                      ref
+                          .read(qbitSearchProvider(widget.instance).notifier)
+                          .state = '';
                       setState(() {});
                     },
                   ),
@@ -213,20 +221,22 @@ class _BottomControlBarState extends ConsumerState<_BottomControlBar> {
   }
 }
 
-
 class QbittorrentAppBarActions extends ConsumerWidget {
   const QbittorrentAppBarActions({required this.instance, super.key});
 
   final Instance instance;
 
-  Future<void> _run(WidgetRef ref, Future<void> Function(QbittorrentClient) action) async {
-    final QbittorrentClient client = await ref.read(qbittorrentClientProvider(instance).future);
+  Future<void> _run(
+      WidgetRef ref, Future<void> Function(QbittorrentClient) action,) async {
+    final QbittorrentClient client =
+        await ref.read(qbittorrentClientProvider(instance).future);
     await action(client);
     ref.invalidate(qbitRawTorrentsProvider(instance));
     ref.invalidate(qbitSelectionProvider(instance));
   }
 
-  Future<void> _confirmDelete(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _confirmDelete(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
     bool deleteFiles = false;
     final bool? ok = await showDialog<bool>(
       context: context,
@@ -236,13 +246,15 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           content: Column(
             mainAxisSize: MainAxisSize.min,
             children: <Widget>[
-              Text('Are you sure to delete the selected ${selectedHashes.length} torrents?'),
+              Text(
+                  'Are you sure to delete the selected ${selectedHashes.length} torrents?',),
               const SizedBox(height: Insets.md),
               CheckboxListTile(
                 contentPadding: EdgeInsets.zero,
                 title: const Text('Delete files'),
                 value: deleteFiles,
-                onChanged: (bool? v) => setState(() => deleteFiles = v ?? false),
+                onChanged: (bool? v) =>
+                    setState(() => deleteFiles = v ?? false),
               ),
             ],
           ),
@@ -268,8 +280,10 @@ class QbittorrentAppBarActions extends ConsumerWidget {
     }
   }
 
-  Future<void> _editCategory(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
-    final List<String> cats = await ref.read(qbitCategoriesProvider(instance).future);
+  Future<void> _editCategory(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
+    final List<String> cats =
+        await ref.read(qbitCategoriesProvider(instance).future);
     if (!context.mounted) return;
     final String? chosen = await showDialog<String>(
       context: context,
@@ -289,11 +303,15 @@ class QbittorrentAppBarActions extends ConsumerWidget {
       ),
     );
     if (chosen != null) {
-      await _run(ref, (QbittorrentClient c) => c.setCategory(selectedHashes.toList(), chosen));
+      await _run(
+          ref,
+          (QbittorrentClient c) =>
+              c.setCategory(selectedHashes.toList(), chosen),);
     }
   }
 
-  Future<void> _editTags(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _editTags(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
     final TextEditingController ctrl = TextEditingController();
     final String? chosen = await showDialog<String>(
       context: context,
@@ -304,17 +322,23 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           decoration: const InputDecoration(hintText: 'tag1, tag2'),
         ),
         actions: <Widget>[
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.of(context).pop(ctrl.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(ctrl.text),
+              child: const Text('Save'),),
         ],
       ),
     );
     if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref, (QbittorrentClient c) => c.addTags(selectedHashes.toList(), chosen));
+      await _run(ref,
+          (QbittorrentClient c) => c.addTags(selectedHashes.toList(), chosen),);
     }
   }
 
-  Future<void> _editSavePath(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _editSavePath(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
     final TextEditingController ctrl = TextEditingController();
     final String? chosen = await showDialog<String>(
       context: context,
@@ -325,17 +349,25 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           decoration: const InputDecoration(hintText: '/downloads/new_path'),
         ),
         actions: <Widget>[
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.of(context).pop(ctrl.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(ctrl.text),
+              child: const Text('Save'),),
         ],
       ),
     );
     if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref, (QbittorrentClient c) => c.setLocation(selectedHashes.toList(), chosen));
+      await _run(
+          ref,
+          (QbittorrentClient c) =>
+              c.setLocation(selectedHashes.toList(), chosen),);
     }
   }
 
-  Future<void> _rename(BuildContext context, WidgetRef ref, Set<String> selectedHashes) async {
+  Future<void> _rename(
+      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
     final TextEditingController ctrl = TextEditingController();
     final String? chosen = await showDialog<String>(
       context: context,
@@ -346,13 +378,18 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           decoration: const InputDecoration(hintText: 'New name'),
         ),
         actions: <Widget>[
-          TextButton(onPressed: () => Navigator.of(context).pop(), child: const Text('Cancel')),
-          FilledButton(onPressed: () => Navigator.of(context).pop(ctrl.text), child: const Text('Save')),
+          TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),),
+          FilledButton(
+              onPressed: () => Navigator.of(context).pop(ctrl.text),
+              child: const Text('Save'),),
         ],
       ),
     );
     if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref, (QbittorrentClient c) => c.rename(selectedHashes.first, chosen));
+      await _run(
+          ref, (QbittorrentClient c) => c.rename(selectedHashes.first, chosen),);
     }
   }
 
@@ -368,19 +405,24 @@ class QbittorrentAppBarActions extends ConsumerWidget {
               padding: const EdgeInsets.symmetric(vertical: Insets.md),
               children: <Widget>[
                 ListTile(
-                  leading: Icon(config.ascending ? Icons.arrow_upward : Icons.arrow_downward),
+                  leading: Icon(config.ascending
+                      ? Icons.arrow_upward
+                      : Icons.arrow_downward,),
                   title: Text(config.ascending ? 'Ascending' : 'Descending'),
                   onTap: () {
-                    ref.read(qbitSortProvider(instance).notifier).state = config.copyWith(ascending: !config.ascending);
+                    ref.read(qbitSortProvider(instance).notifier).state =
+                        config.copyWith(ascending: !config.ascending);
                   },
                 ),
                 const Divider(),
                 for (final QbitSortField field in QbitSortField.values)
                   ListTile(
                     title: Text(field.displayName),
-                    trailing: config.field == field ? const Icon(Icons.check) : null,
+                    trailing:
+                        config.field == field ? const Icon(Icons.check) : null,
                     onTap: () {
-                      ref.read(qbitSortProvider(instance).notifier).state = config.copyWith(field: field);
+                      ref.read(qbitSortProvider(instance).notifier).state =
+                          config.copyWith(field: field);
                       Navigator.of(context).pop();
                     },
                   ),
@@ -394,7 +436,8 @@ class QbittorrentAppBarActions extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final Set<String> selectedHashes = ref.watch(qbitSelectionProvider(instance));
+    final Set<String> selectedHashes =
+        ref.watch(qbitSelectionProvider(instance));
 
     if (selectedHashes.isEmpty) {
       return Row(
@@ -429,7 +472,8 @@ class QbittorrentAppBarActions extends ConsumerWidget {
           tooltip: 'Select All',
           icon: const Icon(Icons.select_all),
           onPressed: () {
-            final List<QbitTorrent>? torrents = ref.read(qbitTorrentsProvider(instance)).value;
+            final List<QbitTorrent>? torrents =
+                ref.read(qbitTorrentsProvider(instance)).value;
             if (torrents != null) {
               ref.read(qbitSelectionProvider(instance).notifier).state =
                   torrents.map((QbitTorrent t) => t.hash).toSet();
@@ -458,14 +502,18 @@ class QbittorrentAppBarActions extends ConsumerWidget {
               case 'copy':
                 await Clipboard.setData(ClipboardData(text: hashes.join('\n')));
                 if (context.mounted) {
-                  ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Hashes copied')));
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Hashes copied')),);
                 }
               case 'recheck':
                 await _run(ref, (QbittorrentClient c) => c.recheck(hashes));
               case 'reannounce':
                 await _run(ref, (QbittorrentClient c) => c.reannounce(hashes));
               case 'forcestart':
-                await _run(ref, (QbittorrentClient c) => c.setForceStart(hashes, value: true));
+                await _run(
+                    ref,
+                    (QbittorrentClient c) =>
+                        c.setForceStart(hashes, value: true),);
               case 'rename':
                 await _rename(context, ref, selectedHashes);
               case 'savepath':
@@ -476,14 +524,17 @@ class QbittorrentAppBarActions extends ConsumerWidget {
                 await _editTags(context, ref, selectedHashes);
               case 'export':
                 try {
-                  final QbittorrentClient client = await ref.read(qbittorrentClientProvider(instance).future);
+                  final QbittorrentClient client = await ref
+                      .read(qbittorrentClientProvider(instance).future);
                   await client.exportTorrent(hashes.first);
                   if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Torrent exported successfully')));
+                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                        content: Text('Torrent exported successfully'),),);
                   }
                 } catch (e) {
                   if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text('Export failed: $e')));
+                    ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(content: Text('Export failed: $e')),);
                   }
                 }
             }
@@ -492,16 +543,21 @@ class QbittorrentAppBarActions extends ConsumerWidget {
             const PopupMenuItem<String>(value: 'pause', child: Text('Pause')),
             const PopupMenuItem<String>(value: 'resume', child: Text('Resume')),
             const PopupMenuItem<String>(value: 'copy', child: Text('Copy')),
-            const PopupMenuItem<String>(value: 'recheck', child: Text('Force Recheck')),
-            const PopupMenuItem<String>(value: 'reannounce', child: Text('Force Reannounce')),
-            const PopupMenuItem<String>(value: 'forcestart', child: Text('Force Start')),
+            const PopupMenuItem<String>(
+                value: 'recheck', child: Text('Force Recheck'),),
+            const PopupMenuItem<String>(
+                value: 'reannounce', child: Text('Force Reannounce'),),
+            const PopupMenuItem<String>(
+                value: 'forcestart', child: Text('Force Start'),),
             PopupMenuItem<String>(
               value: 'rename',
               enabled: selectedHashes.length == 1,
               child: const Text('Rename'),
             ),
-            const PopupMenuItem<String>(value: 'savepath', child: Text('Set SavePath')),
-            const PopupMenuItem<String>(value: 'category', child: Text('Set Category')),
+            const PopupMenuItem<String>(
+                value: 'savepath', child: Text('Set SavePath'),),
+            const PopupMenuItem<String>(
+                value: 'category', child: Text('Set Category'),),
             const PopupMenuItem<String>(value: 'tags', child: Text('Set Tags')),
             PopupMenuItem<String>(
               value: 'export',
@@ -544,9 +600,10 @@ class _TorrentTile extends ConsumerWidget {
     final bool complete = progress >= 1.0;
     final bool dlActive = torrent.dlspeed > 0;
     final bool upActive = torrent.upspeed > 0;
-    
+
     return Padding(
-      padding: const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
+      padding:
+          const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
       child: Material(
         color: isSelected ? cs.primaryContainer : cs.surfaceContainerHigh,
         borderRadius: BorderRadius.circular(20),
@@ -561,7 +618,8 @@ class _TorrentTile extends ConsumerWidget {
           },
           onTap: () {
             if (selectionMode) {
-              ref.read(qbitSelectionProvider(instance).notifier)
+              ref
+                  .read(qbitSelectionProvider(instance).notifier)
                   .update((Set<String> s) {
                 final Set<String> next = Set<String>.of(s);
                 if (next.contains(torrent.hash)) {
@@ -655,11 +713,11 @@ class _TorrentTile extends ConsumerWidget {
                     Expanded(
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(8),
-                        child: LinearProgressIndicator(
+                        child: LinearProgressIndicatorM3E(
+                          shape: ProgressM3EShape.flat,
                           value: progress,
-                          minHeight: 8,
-                          color: complete ? cs.tertiary : v.color,
-                          backgroundColor: isSelected
+                          activeColor: complete ? cs.tertiary : v.color,
+                          trackColor: isSelected
                               ? cs.onPrimaryContainer.withValues(alpha: 0.15)
                               : cs.surfaceContainerHighest,
                         ),
@@ -701,7 +759,8 @@ class _TorrentTile extends ConsumerWidget {
                     ),
                     if (!complete) ...<Widget>[
                       const SizedBox(width: Insets.sm),
-                      Icon(Icons.schedule, size: 14, color: cs.onSurfaceVariant),
+                      Icon(Icons.schedule,
+                          size: 14, color: cs.onSurfaceVariant,),
                       const SizedBox(width: 2),
                       Text(
                         _formatEta(torrent.eta),

--- a/services/service_qbittorrent/lib/src/torrent_detail_screen.dart
+++ b/services/service_qbittorrent/lib/src/torrent_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/qbit_detail.dart';
 import 'models/qbit_torrent.dart';
@@ -100,15 +101,22 @@ class TorrentDetailScreen extends ConsumerWidget {
                 }
               },
               itemBuilder: (BuildContext context) => <PopupMenuEntry<String>>[
-                const PopupMenuItem<String>(value: 'pause', child: Text('Pause')),
-                const PopupMenuItem<String>(value: 'resume', child: Text('Resume')),
-                const PopupMenuItem<String>(value: 'forcestart', child: Text('Force Start')),
+                const PopupMenuItem<String>(
+                    value: 'pause', child: Text('Pause'),),
+                const PopupMenuItem<String>(
+                    value: 'resume', child: Text('Resume'),),
+                const PopupMenuItem<String>(
+                    value: 'forcestart', child: Text('Force Start'),),
                 const PopupMenuDivider(),
-                const PopupMenuItem<String>(value: 'copy_magnet', child: Text('Copy Magnet Link')),
-                const PopupMenuItem<String>(value: 'copy_hash', child: Text('Copy Hash')),
+                const PopupMenuItem<String>(
+                    value: 'copy_magnet', child: Text('Copy Magnet Link'),),
+                const PopupMenuItem<String>(
+                    value: 'copy_hash', child: Text('Copy Hash'),),
                 const PopupMenuDivider(),
-                const PopupMenuItem<String>(value: 'recheck', child: Text('Force Recheck')),
-                const PopupMenuItem<String>(value: 'reannounce', child: Text('Force Reannounce')),
+                const PopupMenuItem<String>(
+                    value: 'recheck', child: Text('Force Recheck'),),
+                const PopupMenuItem<String>(
+                    value: 'reannounce', child: Text('Force Reannounce'),),
               ],
             ),
           ],
@@ -213,7 +221,8 @@ class _OverviewTab extends ConsumerWidget {
         ref.watch(qbitPropertiesProvider((instance, torrent.hash)));
     final Color accent = _accent(torrent.state, cs);
     final Color actionColor = accent == cs.outline ? cs.primary : accent;
-    final bool isPaused = torrent.state.contains('paused') || torrent.state.contains('stopped');
+    final bool isPaused =
+        torrent.state.contains('paused') || torrent.state.contains('stopped');
     final double progress = torrent.progress.clamp(0, 1).toDouble();
 
     return M3RefreshIndicator(
@@ -279,11 +288,11 @@ class _OverviewTab extends ConsumerWidget {
                         Expanded(
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(8),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress,
-                              minHeight: 8,
-                              color: accent,
-                              backgroundColor: cs.surfaceContainerHighest,
+                              activeColor: accent,
+                              trackColor: cs.surfaceContainerHighest,
                             ),
                           ),
                         ),
@@ -313,7 +322,8 @@ class _OverviewTab extends ConsumerWidget {
                         ),
                         const Spacer(),
                         if (progress < 1.0) ...<Widget>[
-                          Icon(Icons.schedule, size: 14, color: cs.onSurfaceVariant),
+                          Icon(Icons.schedule,
+                              size: 14, color: cs.onSurfaceVariant,),
                           const SizedBox(width: 2),
                           Text(
                             _fmtEta(torrent.eta),
@@ -326,186 +336,217 @@ class _OverviewTab extends ConsumerWidget {
                     const SizedBox(height: Insets.lg),
                     Center(
                       child: Wrap(
-                      spacing: 8.0,
-                      runSpacing: 8.0,
-                      alignment: WrapAlignment.center,
-                      children: <Widget>[
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: actionColor.withValues(alpha: 0.15),
-                            foregroundColor: actionColor,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          ),
-                          icon: Icon(isPaused ? Icons.play_arrow : Icons.pause, size: 18),
-                          label: Text(isPaused ? 'Resume' : 'Pause'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            try {
-                              final QbittorrentClient client = await ref.read(
-                                qbittorrentClientProvider(instance).future,
-                              );
-                              if (isPaused) {
-                                await client.resume(<String>[torrent.hash]);
-                              } else {
-                                await client.pause(<String>[torrent.hash]);
+                        spacing: 8.0,
+                        runSpacing: 8.0,
+                        alignment: WrapAlignment.center,
+                        children: <Widget>[
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor:
+                                  actionColor.withValues(alpha: 0.15),
+                              foregroundColor: actionColor,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8,),
+                            ),
+                            icon: Icon(
+                                isPaused ? Icons.play_arrow : Icons.pause,
+                                size: 18,),
+                            label: Text(isPaused ? 'Resume' : 'Pause'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final QbittorrentClient client = await ref.read(
+                                  qbittorrentClientProvider(instance).future,
+                                );
+                                if (isPaused) {
+                                  await client.resume(<String>[torrent.hash]);
+                                } else {
+                                  await client.pause(<String>[torrent.hash]);
+                                }
+                                if (!context.mounted) return;
+                                ref.invalidate(
+                                    qbitRawTorrentsProvider(instance),);
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Action failed'),),
+                                );
                               }
-                              if (!context.mounted) return;
-                              ref.invalidate(qbitRawTorrentsProvider(instance));
-                            } catch (_) {
+                            },
+                          ),
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor:
+                                  actionColor.withValues(alpha: 0.15),
+                              foregroundColor: actionColor,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8,),
+                            ),
+                            icon: const Icon(Icons.fast_forward, size: 18),
+                            label: const Text('Force Start'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final QbittorrentClient client = await ref.read(
+                                  qbittorrentClientProvider(instance).future,
+                                );
+                                await client.setForceStart(
+                                  <String>[torrent.hash],
+                                  value: true,
+                                );
+                                if (!context.mounted) return;
+                                ref.invalidate(
+                                    qbitRawTorrentsProvider(instance),);
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Action failed'),),
+                                );
+                              }
+                            },
+                          ),
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor: cs.surfaceContainerHighest,
+                              foregroundColor: cs.onSurfaceVariant,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8,),
+                            ),
+                            icon: const Icon(Icons.link, size: 18),
+                            label: const Text('Magnet'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              final String magnet = torrent.magnetUri.isNotEmpty
+                                  ? torrent.magnetUri
+                                  : 'magnet:?xt=urn:btih:${torrent.hash}&dn=${Uri.encodeComponent(torrent.name)}';
+                              await Clipboard.setData(
+                                  ClipboardData(text: magnet),);
                               messenger.showSnackBar(
-                                const SnackBar(content: Text('Action failed')),
+                                const SnackBar(
+                                  content: Text('Magnet link copied'),
+                                ),
                               );
-                            }
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: actionColor.withValues(alpha: 0.15),
-                            foregroundColor: actionColor,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                            },
                           ),
-                          icon: const Icon(Icons.fast_forward, size: 18),
-                          label: const Text('Force Start'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            try {
-                              final QbittorrentClient client = await ref.read(
-                                qbittorrentClientProvider(instance).future,
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor: cs.surfaceContainerHighest,
+                              foregroundColor: cs.onSurfaceVariant,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8,),
+                            ),
+                            icon: const Icon(Icons.tag, size: 18),
+                            label: const Text('Hash'),
+                            onPressed: () async {
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              await Clipboard.setData(
+                                ClipboardData(text: torrent.hash),
                               );
-                              await client.setForceStart(
-                                <String>[torrent.hash],
-                                value: true,
-                              );
-                              if (!context.mounted) return;
-                              ref.invalidate(qbitRawTorrentsProvider(instance));
-                            } catch (_) {
                               messenger.showSnackBar(
-                                const SnackBar(content: Text('Action failed')),
+                                const SnackBar(
+                                  content: Text('Torrent hash copied'),
+                                ),
                               );
-                            }
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: cs.surfaceContainerHighest,
-                            foregroundColor: cs.onSurfaceVariant,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                            },
                           ),
-                          icon: const Icon(Icons.link, size: 18),
-                          label: const Text('Magnet'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            final String magnet = torrent.magnetUri.isNotEmpty
-                                ? torrent.magnetUri
-                                : 'magnet:?xt=urn:btih:${torrent.hash}&dn=${Uri.encodeComponent(torrent.name)}';
-                            await Clipboard.setData(ClipboardData(text: magnet));
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text('Magnet link copied'),
-                              ),
-                            );
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: cs.surfaceContainerHighest,
-                            foregroundColor: cs.onSurfaceVariant,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          ),
-                          icon: const Icon(Icons.tag, size: 18),
-                          label: const Text('Hash'),
-                          onPressed: () async {
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            await Clipboard.setData(
-                              ClipboardData(text: torrent.hash),
-                            );
-                            messenger.showSnackBar(
-                              const SnackBar(
-                                content: Text('Torrent hash copied'),
-                              ),
-                            );
-                          },
-                        ),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
-                            backgroundColor: cs.surfaceContainerHighest,
-                            foregroundColor: cs.onSurfaceVariant,
-                            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                          ),
-                          icon: const Icon(Icons.delete, size: 18),
-                          label: const Text('Delete'),
-                          onPressed: () async {
-                            final bool? shouldDeleteFiles = await showDialog<bool>(
-                              context: context,
-                              builder: (BuildContext context) {
-                                bool deleteFiles = false;
-                                return StatefulBuilder(
-                                  builder: (BuildContext context, StateSetter setState) {
-                                    return AlertDialog(
-                                      title: const Text('Delete Torrent'),
-                                      content: Column(
-                                        mainAxisSize: MainAxisSize.min,
-                                        crossAxisAlignment: CrossAxisAlignment.start,
-                                        children: <Widget>[
-                                          const Text('Are you sure you want to delete this torrent?'),
-                                          const SizedBox(height: 16),
-                                          CheckboxListTile(
-                                            value: deleteFiles,
-                                            onChanged: (bool? val) {
-                                              if (val != null) {
-                                                setState(() => deleteFiles = val);
-                                              }
-                                            },
-                                            title: const Text('Also delete files'),
-                                            contentPadding: EdgeInsets.zero,
-                                            controlAffinity: ListTileControlAffinity.leading,
+                          TextButton.icon(
+                            style: TextButton.styleFrom(
+                              backgroundColor: cs.surfaceContainerHighest,
+                              foregroundColor: cs.onSurfaceVariant,
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 16, vertical: 8,),
+                            ),
+                            icon: const Icon(Icons.delete, size: 18),
+                            label: const Text('Delete'),
+                            onPressed: () async {
+                              final bool? shouldDeleteFiles =
+                                  await showDialog<bool>(
+                                context: context,
+                                builder: (BuildContext context) {
+                                  bool deleteFiles = false;
+                                  return StatefulBuilder(
+                                    builder: (BuildContext context,
+                                        StateSetter setState,) {
+                                      return AlertDialog(
+                                        title: const Text('Delete Torrent'),
+                                        content: Column(
+                                          mainAxisSize: MainAxisSize.min,
+                                          crossAxisAlignment:
+                                              CrossAxisAlignment.start,
+                                          children: <Widget>[
+                                            const Text(
+                                                'Are you sure you want to delete this torrent?',),
+                                            const SizedBox(height: 16),
+                                            CheckboxListTile(
+                                              value: deleteFiles,
+                                              onChanged: (bool? val) {
+                                                if (val != null) {
+                                                  setState(
+                                                      () => deleteFiles = val,);
+                                                }
+                                              },
+                                              title: const Text(
+                                                  'Also delete files',),
+                                              contentPadding: EdgeInsets.zero,
+                                              controlAffinity:
+                                                  ListTileControlAffinity
+                                                      .leading,
+                                            ),
+                                          ],
+                                        ),
+                                        actions: <Widget>[
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.of(context).pop(),
+                                            child: const Text('Cancel'),
+                                          ),
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.of(context)
+                                                    .pop(deleteFiles),
+                                            style: TextButton.styleFrom(
+                                                foregroundColor:
+                                                    Theme.of(context)
+                                                        .colorScheme
+                                                        .error,),
+                                            child: const Text('Delete'),
                                           ),
                                         ],
-                                      ),
-                                      actions: <Widget>[
-                                        TextButton(
-                                          onPressed: () => Navigator.of(context).pop(),
-                                          child: const Text('Cancel'),
-                                        ),
-                                        TextButton(
-                                          onPressed: () => Navigator.of(context).pop(deleteFiles),
-                                          style: TextButton.styleFrom(foregroundColor: Theme.of(context).colorScheme.error),
-                                          child: const Text('Delete'),
-                                        ),
-                                      ],
-                                    );
-                                  },
-                                );
-                              },
-                            );
-                            if (shouldDeleteFiles == null) return;
-                            if (!context.mounted) return;
-                            final ScaffoldMessengerState messenger =
-                                ScaffoldMessenger.of(context);
-                            try {
-                              final QbittorrentClient client = await ref.read(
-                                qbittorrentClientProvider(instance).future,
+                                      );
+                                    },
+                                  );
+                                },
                               );
-                              await client.delete(
-                                <String>[torrent.hash],
-                                deleteFiles: shouldDeleteFiles,
-                              );
+                              if (shouldDeleteFiles == null) return;
                               if (!context.mounted) return;
-                              ref.invalidate(qbitRawTorrentsProvider(instance));
-                              Navigator.of(context).pop();
-                            } catch (_) {
-                              messenger.showSnackBar(
-                                const SnackBar(content: Text('Action failed')),
-                              );
-                            }
-                          },
-                        ),
-                      ],
-                    ),
+                              final ScaffoldMessengerState messenger =
+                                  ScaffoldMessenger.of(context);
+                              try {
+                                final QbittorrentClient client = await ref.read(
+                                  qbittorrentClientProvider(instance).future,
+                                );
+                                await client.delete(
+                                  <String>[torrent.hash],
+                                  deleteFiles: shouldDeleteFiles,
+                                );
+                                if (!context.mounted) return;
+                                ref.invalidate(
+                                    qbitRawTorrentsProvider(instance),);
+                                Navigator.of(context).pop();
+                              } catch (_) {
+                                messenger.showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Action failed'),),
+                                );
+                              }
+                            },
+                          ),
+                        ],
+                      ),
                     ),
                   ],
                 ),
@@ -532,7 +573,8 @@ class _OverviewTab extends ConsumerWidget {
                   ('Save path', p.savePath),
                   ('Added', date(p.additionDate)),
                   ('Completed', date(p.completionDate)),
-                  if (torrent.category.isNotEmpty) ('Category', torrent.category),
+                  if (torrent.category.isNotEmpty)
+                    ('Category', torrent.category),
                   if (p.comment.isNotEmpty) ('Comment', p.comment),
                 ],
               ),
@@ -604,8 +646,8 @@ class _SectionCard extends StatelessWidget {
         children: <Widget>[
           Text(
             title,
-            style:
-                theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            style: theme.textTheme.titleMedium
+                ?.copyWith(fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: Insets.sm),
           for (final (String label, String value) in rows)
@@ -688,7 +730,8 @@ class _FileNode {
   final bool isCollapsed;
 }
 
-List<_FileNode> _buildFileTree(List<QbitFile> files, Set<String> collapsedPaths) {
+List<_FileNode> _buildFileTree(
+    List<QbitFile> files, Set<String> collapsedPaths,) {
   final _BuilderNode root = _BuilderNode('', '', -1, false);
 
   for (final QbitFile f in files) {
@@ -701,7 +744,8 @@ List<_FileNode> _buildFileTree(List<QbitFile> files, Set<String> collapsedPaths)
       currentPath = currentPath.isEmpty ? part : '$currentPath/$part';
 
       final bool isFile = i == parts.length - 1;
-      current = current.children.putIfAbsent(part, () => _BuilderNode(part, currentPath, i, isFile));
+      current = current.children
+          .putIfAbsent(part, () => _BuilderNode(part, currentPath, i, isFile));
 
       current.size += f.size;
       current.downloaded += f.size * f.progress;
@@ -739,7 +783,8 @@ class _FilesTab extends ConsumerStatefulWidget {
   ConsumerState<_FilesTab> createState() => _FilesTabState();
 }
 
-class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveClientMixin {
+class _FilesTabState extends ConsumerState<_FilesTab>
+    with AutomaticKeepAliveClientMixin {
   final Set<String> _collapsedPaths = <String>{};
 
   @override
@@ -758,7 +803,8 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
           ref.invalidate(qbitFilesProvider((widget.instance, widget.hash))),
       child: AsyncValueView<List<QbitFile>>(
         value: files,
-        onRetry: () => ref.invalidate(qbitFilesProvider((widget.instance, widget.hash))),
+        onRetry: () =>
+            ref.invalidate(qbitFilesProvider((widget.instance, widget.hash))),
         data: (List<QbitFile> list) {
           if (list.isEmpty) {
             return const EmptyView(
@@ -776,15 +822,17 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
               final _FileNode f = nodes[index];
               final Color barColor = f.isWanted ? cs.primary : cs.outline;
               return InkWell(
-                onTap: f.isFile ? null : () {
-                  setState(() {
-                    if (f.isCollapsed) {
-                      _collapsedPaths.remove(f.fullPath);
-                    } else {
-                      _collapsedPaths.add(f.fullPath);
-                    }
-                  });
-                },
+                onTap: f.isFile
+                    ? null
+                    : () {
+                        setState(() {
+                          if (f.isCollapsed) {
+                            _collapsedPaths.remove(f.fullPath);
+                          } else {
+                            _collapsedPaths.add(f.fullPath);
+                          }
+                        });
+                      },
                 child: Padding(
                   padding: EdgeInsets.fromLTRB(
                     Insets.md + f.depth * 16.0,
@@ -796,7 +844,9 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                     children: <Widget>[
                       if (!f.isFile)
                         Icon(
-                          f.isCollapsed ? Icons.keyboard_arrow_right : Icons.keyboard_arrow_down,
+                          f.isCollapsed
+                              ? Icons.keyboard_arrow_right
+                              : Icons.keyboard_arrow_down,
                           size: 20,
                           color: cs.onSurfaceVariant,
                         )
@@ -814,7 +864,9 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                         child: Icon(
                           f.isFile
                               ? Icons.insert_drive_file_outlined
-                              : (f.isCollapsed ? Icons.folder_outlined : Icons.folder_open_outlined),
+                              : (f.isCollapsed
+                                  ? Icons.folder_outlined
+                                  : Icons.folder_open_outlined),
                           size: 18,
                           color: cs.onSurfaceVariant,
                         ),
@@ -833,11 +885,11 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                             const SizedBox(height: 4),
                             ClipRRect(
                               borderRadius: BorderRadius.circular(6),
-                              child: LinearProgressIndicator(
+                              child: LinearProgressIndicatorM3E(
+                                shape: ProgressM3EShape.flat,
                                 value: f.progress.clamp(0, 1).toDouble(),
-                                minHeight: 5,
-                                color: barColor,
-                                backgroundColor: cs.surfaceContainerHighest,
+                                activeColor: barColor,
+                                trackColor: cs.surfaceContainerHighest,
                               ),
                             ),
                             const SizedBox(height: 2),
@@ -853,14 +905,16 @@ class _FilesTabState extends ConsumerState<_FilesTab> with AutomaticKeepAliveCli
                       Checkbox(
                         value: f.isWanted,
                         onChanged: (bool? v) async {
-                          final QbittorrentClient client = await ref
-                              .read(qbittorrentClientProvider(widget.instance).future);
+                          final QbittorrentClient client = await ref.read(
+                              qbittorrentClientProvider(widget.instance)
+                                  .future,);
                           await client.setFilePriority(
                             widget.hash,
                             f.fileIndices,
                             (v ?? false) ? 1 : 0,
                           );
-                          ref.invalidate(qbitFilesProvider((widget.instance, widget.hash)));
+                          ref.invalidate(qbitFilesProvider(
+                              (widget.instance, widget.hash),),);
                         },
                       ),
                     ],
@@ -896,9 +950,8 @@ class _TrackersTab extends ConsumerWidget {
         onRetry: () => ref.invalidate(qbitTrackersProvider((instance, hash))),
         data: (List<QbitTracker> list) {
           // Hide qBittorrent's synthetic DHT/PeX/LSD pseudo-trackers.
-          final List<QbitTracker> real = list
-              .where((QbitTracker t) => !t.url.startsWith('** '))
-              .toList();
+          final List<QbitTracker> real =
+              list.where((QbitTracker t) => !t.url.startsWith('** ')).toList();
           if (real.isEmpty) {
             return const EmptyView(
               icon: Icons.dns_outlined,
@@ -916,7 +969,11 @@ class _TrackersTab extends ConsumerWidget {
                 2 => (cs.tertiary, Icons.check_circle, 'Working'),
                 3 => (cs.primary, Icons.sync, 'Updating'),
                 4 => (cs.error, Icons.error_outline, 'Not working'),
-                1 => (cs.outline, Icons.radio_button_unchecked, 'Not contacted'),
+                1 => (
+                    cs.outline,
+                    Icons.radio_button_unchecked,
+                    'Not contacted'
+                  ),
                 0 => (cs.outline, Icons.block, 'Disabled'),
                 _ => (cs.outline, Icons.help_outline, 'Unknown'),
               };
@@ -1053,11 +1110,11 @@ class _PeersTab extends ConsumerWidget {
                     const SizedBox(height: Insets.sm),
                     ClipRRect(
                       borderRadius: BorderRadius.circular(6),
-                      child: LinearProgressIndicator(
+                      child: LinearProgressIndicatorM3E(
+                        shape: ProgressM3EShape.flat,
                         value: p.progress.clamp(0, 1).toDouble(),
-                        minHeight: 5,
-                        color: cs.primary,
-                        backgroundColor: cs.surfaceContainerHighest,
+                        activeColor: cs.primary,
+                        trackColor: cs.surfaceContainerHighest,
                       ),
                     ),
                     const SizedBox(height: Insets.sm),

--- a/services/service_qbittorrent/pubspec.yaml
+++ b/services/service_qbittorrent/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
+  progress_indicator_m3e:
 
 dev_dependencies:
   build_runner: ^2.4.13

--- a/services/service_radarr/lib/src/home/activity_tab.dart
+++ b/services/service_radarr/lib/src/home/activity_tab.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:math';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
@@ -7,6 +8,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import '../../service_radarr.dart';
 
@@ -41,8 +43,11 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
     _tabController = TabController(length: 3, vsync: this);
     _tabController.addListener(() {
       if (_tabController.indexIsChanging) {
-        ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state = {};
-        ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+        ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state =
+            {};
+        ref
+            .read(radarrBlocklistSelectionProvider(widget.instance).notifier)
+            .state = {};
         setState(() {});
       }
     });
@@ -88,8 +93,10 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final grouped = ref.watch(radarrActivityGroupedProvider(widget.instance));
-    final queueSelection = ref.watch(radarrQueueSelectionProvider(widget.instance));
-    final blocklistSelection = ref.watch(radarrBlocklistSelectionProvider(widget.instance));
+    final queueSelection =
+        ref.watch(radarrQueueSelectionProvider(widget.instance));
+    final blocklistSelection =
+        ref.watch(radarrBlocklistSelectionProvider(widget.instance));
     final activeSelection = _tabController.index == 0
         ? queueSelection
         : _tabController.index == 2
@@ -116,13 +123,20 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
               selectedIds: activeSelection,
               isQueue: _tabController.index == 0,
               onClear: () {
-                ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                ref
+                    .read(
+                        radarrQueueSelectionProvider(widget.instance).notifier,)
+                    .state = {};
+                ref
+                    .read(radarrBlocklistSelectionProvider(widget.instance)
+                        .notifier,)
+                    .state = {};
               },
             )
           : null,
       body: NestedScrollView(
-        headerSliverBuilder: (BuildContext innerContext, bool innerBoxIsScrolled) {
+        headerSliverBuilder:
+            (BuildContext innerContext, bool innerBoxIsScrolled) {
           return <Widget>[
             SliverAppBar(
               floating: true,
@@ -138,8 +152,15 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                   ? IconButton(
                       icon: const Icon(Icons.close),
                       onPressed: () {
-                        ref.read(radarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                        ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                        ref
+                            .read(radarrQueueSelectionProvider(widget.instance)
+                                .notifier,)
+                            .state = {};
+                        ref
+                            .read(radarrBlocklistSelectionProvider(
+                                    widget.instance,)
+                                .notifier,)
+                            .state = {};
                       },
                     )
                   : IconButton(
@@ -156,55 +177,59 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                       ),
                     )
                   : SearchBar(
-                focusNode: _searchFocusNode,
-                controller: _searchController,
-                hintText: 'Search activity...',
-                onTapOutside: (event) {
-                  if (_searchFocusNode.hasFocus) {
-                    _searchFocusNode.unfocus();
-                  }
-                },
-                elevation: const WidgetStatePropertyAll<double>(0),
-                backgroundColor: WidgetStatePropertyAll<Color>(
-                  theme.colorScheme.surfaceContainerHigh,
-                ),
-                trailing: <Widget>[
-                  if (_searchController.text.isNotEmpty)
-                    IconButton(
-                      icon: const Icon(Icons.clear),
-                      onPressed: () {
-                        setState(() {
-                          _searchController.clear();
-                        });
+                      focusNode: _searchFocusNode,
+                      controller: _searchController,
+                      hintText: 'Search activity...',
+                      onTapOutside: (event) {
+                        if (_searchFocusNode.hasFocus) {
+                          _searchFocusNode.unfocus();
+                        }
+                      },
+                      elevation: const WidgetStatePropertyAll<double>(0),
+                      backgroundColor: WidgetStatePropertyAll<Color>(
+                        theme.colorScheme.surfaceContainerHigh,
+                      ),
+                      trailing: <Widget>[
+                        if (_searchController.text.isNotEmpty)
+                          IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              setState(() {
+                                _searchController.clear();
+                              });
+                              ref
+                                  .read(
+                                    radarrActivitySearchQueryProvider(
+                                      widget.instance,
+                                    ).notifier,
+                                  )
+                                  .state = '';
+                              _updateSearchActiveState();
+                            },
+                          ),
+                      ],
+                      onChanged: (String value) {
+                        setState(() {});
                         ref
                             .read(
-                              radarrActivitySearchQueryProvider(
-                                widget.instance,
-                              ).notifier,
+                              radarrActivitySearchQueryProvider(widget.instance)
+                                  .notifier,
                             )
-                            .state = '';
+                            .state = value;
                         _updateSearchActiveState();
                       },
                     ),
-                ],
-                onChanged: (String value) {
-                  setState(() {});
-                  ref
-                      .read(
-                        radarrActivitySearchQueryProvider(widget.instance)
-                            .notifier,
-                      )
-                      .state = value;
-                  _updateSearchActiveState();
-                },
-              ),
               actions: <Widget>[
                 if (!isSelecting) ...[
                   IconButton(
                     icon: Icon(
-                      grouped ? Icons.format_list_bulleted : Icons.group_work_outlined,
+                      grouped
+                          ? Icons.format_list_bulleted
+                          : Icons.group_work_outlined,
                     ),
-                    tooltip: grouped ? 'Switch to plain list' : 'Switch to grouped view',
+                    tooltip: grouped
+                        ? 'Switch to plain list'
+                        : 'Switch to grouped view',
                     onPressed: () {
                       ref
                           .read(
@@ -259,14 +284,17 @@ class _QueueView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final queueAsync = ref.watch(radarrQueueProvider(instance));
-    final searchQuery = ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return queueAsync.when(
       data: (List<RadarrQueueItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.title?.toLowerCase().contains(searchQuery) ?? false;
-          final movieMatch = item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.title?.toLowerCase().contains(searchQuery) ?? false;
+          final movieMatch =
+              item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || movieMatch;
         }).toList();
 
@@ -336,7 +364,8 @@ class _QueueCard extends ConsumerWidget {
 
     String? posterUrl;
     if (item.movie?.images != null && api != null) {
-      final img = item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -360,7 +389,8 @@ class _QueueCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(16),
         onTap: () {
           if (selection.isNotEmpty) {
-            final notifier = ref.read(radarrQueueSelectionProvider(instance).notifier);
+            final notifier =
+                ref.read(radarrQueueSelectionProvider(instance).notifier);
             if (isSelected) {
               notifier.state = selection.where((id) => id != item.id).toSet();
             } else {
@@ -371,7 +401,8 @@ class _QueueCard extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          final notifier = ref.read(radarrQueueSelectionProvider(instance).notifier);
+          final notifier =
+              ref.read(radarrQueueSelectionProvider(instance).notifier);
           if (isSelected) {
             notifier.state = selection.where((id) => id != item.id).toSet();
           } else {
@@ -433,10 +464,12 @@ class _QueueCard extends ConsumerWidget {
                         Expanded(
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress,
-                              backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                              color: item.status == 'warning'
+                              trackColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                              activeColor: item.status == 'warning'
                                   ? theme.colorScheme.error
                                   : theme.colorScheme.primary,
                             ),
@@ -461,7 +494,8 @@ class _QueueCard extends ConsumerWidget {
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
                         ),
-                        if (item.timeleft != null && item.timeleft != '00:00:00')
+                        if (item.timeleft != null &&
+                            item.timeleft != '00:00:00')
                           Text(
                             'ETA: ${item.timeleft}',
                             style: theme.textTheme.bodySmall?.copyWith(
@@ -546,10 +580,12 @@ class _QueueCard extends ConsumerWidget {
       context: context,
       builder: (context) {
         return AlertDialog(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
           title: Text(
             'Queue Details',
-            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            style: theme.textTheme.titleLarge
+                ?.copyWith(fontWeight: FontWeight.bold),
           ),
           content: SingleChildScrollView(
             child: Column(
@@ -559,11 +595,17 @@ class _QueueCard extends ConsumerWidget {
                 _DetailRow(label: 'Title', value: i.title ?? 'No title'),
                 _DetailRow(label: 'Movie', value: i.movie?.title ?? 'Unknown'),
                 _DetailRow(label: 'Status', value: i.status ?? 'Unknown'),
-                _DetailRow(label: 'Tracked State', value: i.trackedDownloadState ?? 'None'),
-                _DetailRow(label: 'Download Client', value: i.downloadClient ?? 'Unknown'),
-                _DetailRow(label: 'Download ID', value: i.downloadId ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Tracked State',
+                    value: i.trackedDownloadState ?? 'None',),
+                _DetailRow(
+                    label: 'Download Client',
+                    value: i.downloadClient ?? 'Unknown',),
+                _DetailRow(
+                    label: 'Download ID', value: i.downloadId ?? 'Unknown',),
                 _DetailRow(label: 'Indexer', value: i.indexer ?? 'Unknown'),
-                _DetailRow(label: 'Output Path', value: i.outputPath ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Output Path', value: i.outputPath ?? 'Unknown',),
               ],
             ),
           ),
@@ -671,14 +713,17 @@ class _HistoryView extends ConsumerWidget {
     final theme = Theme.of(context);
     final historyAsync = ref.watch(radarrHistoryProvider(instance));
     final grouped = ref.watch(radarrActivityGroupedProvider(instance));
-    final searchQuery = ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return historyAsync.when(
       data: (List<RadarrHistoryItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final movieMatch = item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final movieMatch =
+              item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || movieMatch;
         }).toList();
 
@@ -705,7 +750,8 @@ class _HistoryView extends ConsumerWidget {
         }
 
         if (grouped) {
-          final groupedMap = groupBy(filteredItems, (RadarrHistoryItem item) => item.movie?.id ?? 0);
+          final groupedMap = groupBy(
+              filteredItems, (RadarrHistoryItem item) => item.movie?.id ?? 0,);
           final keys = groupedMap.keys.toList();
           return ListView.builder(
             padding: const EdgeInsets.all(Insets.md),
@@ -796,35 +842,38 @@ void _showHistoryDetails(
 
   void addRow(List<Widget> rows, String label, String? value) {
     if (value == null || value.isEmpty) return;
-    rows.add(Padding(
-      padding: const EdgeInsets.symmetric(vertical: 4),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          SizedBox(
-            width: 140,
-            child: Text(
-              label,
-              style: theme.textTheme.bodySmall?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
+    rows.add(
+      Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(
+              width: 140,
+              child: Text(
+                label,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
               ),
             ),
-          ),
-          Expanded(
-            child: Text(
-              value,
-              style: theme.textTheme.bodySmall?.copyWith(
-                fontWeight: FontWeight.w500,
+            Expanded(
+              child: Text(
+                value,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  fontWeight: FontWeight.w500,
+                ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
-    ),);
+    );
   }
 
   final date = DateTime.tryParse(item.date ?? '')?.toLocal();
-  final formattedDate = date != null ? DateFormat.yMMMd().add_jm().format(date) : null;
+  final formattedDate =
+      date != null ? DateFormat.yMMMd().add_jm().format(date) : null;
 
   final rows = <Widget>[];
   addRow(rows, 'Movie', item.movie?.title);
@@ -840,8 +889,7 @@ void _showHistoryDetails(
     });
   }
 
-  final bool canMarkFailed =
-      (item.eventType ?? '').toLowerCase() == 'grabbed';
+  final bool canMarkFailed = (item.eventType ?? '').toLowerCase() == 'grabbed';
 
   showModalBottomSheet<void>(
     context: context,
@@ -871,7 +919,8 @@ void _showHistoryDetails(
             padding: const EdgeInsets.symmetric(horizontal: 20),
             child: Text(
               'History Details',
-              style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+              style: theme.textTheme.titleLarge
+                  ?.copyWith(fontWeight: FontWeight.bold),
             ),
           ),
           const SizedBox(height: 12),
@@ -894,8 +943,8 @@ void _showHistoryDetails(
                           ScaffoldMessenger.of(context);
                       Navigator.of(ctx).pop();
                       try {
-                        final api = await ref
-                            .read(radarrApiProvider(instance).future);
+                        final api =
+                            await ref.read(radarrApiProvider(instance).future);
                         await api.failHistoryItem(item.id);
                         if (!context.mounted) return;
                         ref.invalidate(radarrHistoryProvider(instance));
@@ -937,7 +986,8 @@ Future<void> _confirmDeleteBlocklistItem(
     context: context,
     builder: (context) => AlertDialog(
       title: const Text('Delete from Blocklist?'),
-      content: const Text('Are you sure you want to remove this entry from your blocklist?'),
+      content: const Text(
+          'Are you sure you want to remove this entry from your blocklist?',),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context, false),
@@ -984,14 +1034,16 @@ class _HistoryCard extends ConsumerWidget {
 
     String? posterUrl;
     if (item.movie?.images != null && api != null) {
-      final img = item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
     }
 
     final date = DateTime.tryParse(item.date ?? '')?.toLocal();
-    final String formattedDate = date != null ? DateFormat.yMMMd().add_jm().format(date) : '';
+    final String formattedDate =
+        date != null ? DateFormat.yMMMd().add_jm().format(date) : '';
 
     return Card(
       elevation: 0,
@@ -1133,7 +1185,8 @@ class _GroupedHistoryCard extends ConsumerStatefulWidget {
   final List<RadarrHistoryItem> items;
 
   @override
-  ConsumerState<_GroupedHistoryCard> createState() => _GroupedHistoryCardState();
+  ConsumerState<_GroupedHistoryCard> createState() =>
+      _GroupedHistoryCardState();
 }
 
 class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
@@ -1146,7 +1199,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
 
     String? posterUrl;
     if (widget.movie?.images != null && api != null) {
-      final img = widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -1187,11 +1241,14 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                               ),
                               errorWidget: (context, url, err) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
-                                child: const Icon(Icons.movie_outlined, size: 18),
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                                child:
+                                    const Icon(Icons.movie_outlined, size: 18),
                               ),
                             )
                           : Container(
@@ -1225,7 +1282,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1258,7 +1316,9 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                 itemBuilder: (context, index) {
                   final item = widget.items[index];
                   final date = DateTime.tryParse(item.date ?? '')?.toLocal();
-                  final String formattedDate = date != null ? DateFormat.yMMMd().add_jm().format(date) : '';
+                  final String formattedDate = date != null
+                      ? DateFormat.yMMMd().add_jm().format(date)
+                      : '';
                   return Padding(
                     padding: const EdgeInsets.symmetric(vertical: 6),
                     child: Row(
@@ -1290,7 +1350,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                         ),
                         IconButton(
                           icon: const Icon(Icons.info_outline, size: 20),
-                          onPressed: () => _showHistoryDetails(context, ref, widget.instance, item),
+                          onPressed: () => _showHistoryDetails(
+                              context, ref, widget.instance, item,),
                         ),
                       ],
                     ),
@@ -1315,14 +1376,17 @@ class _BlocklistView extends ConsumerWidget {
     final theme = Theme.of(context);
     final blocklistAsync = ref.watch(radarrBlocklistProvider(instance));
     final grouped = ref.watch(radarrActivityGroupedProvider(instance));
-    final searchQuery = ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(radarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return blocklistAsync.when(
       data: (List<RadarrBlocklistItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final movieMatch = item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final movieMatch =
+              item.movie?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || movieMatch;
         }).toList();
 
@@ -1349,7 +1413,8 @@ class _BlocklistView extends ConsumerWidget {
         }
 
         if (grouped) {
-          final groupedMap = groupBy(filteredItems, (RadarrBlocklistItem item) => item.movie?.id ?? 0);
+          final groupedMap = groupBy(
+              filteredItems, (RadarrBlocklistItem item) => item.movie?.id ?? 0,);
           final keys = groupedMap.keys.toList();
           return ListView.builder(
             padding: const EdgeInsets.all(Insets.md),
@@ -1406,7 +1471,8 @@ class _BlocklistCard extends ConsumerWidget {
 
     String? posterUrl;
     if (item.movie?.images != null && api != null) {
-      final img = item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          item.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -1430,7 +1496,8 @@ class _BlocklistCard extends ConsumerWidget {
         borderRadius: BorderRadius.circular(16),
         onTap: () {
           if (selection.isNotEmpty) {
-            final notifier = ref.read(radarrBlocklistSelectionProvider(instance).notifier);
+            final notifier =
+                ref.read(radarrBlocklistSelectionProvider(instance).notifier);
             if (isSelected) {
               notifier.state = selection.where((id) => id != item.id).toSet();
             } else {
@@ -1439,7 +1506,8 @@ class _BlocklistCard extends ConsumerWidget {
           }
         },
         onLongPress: () {
-          final notifier = ref.read(radarrBlocklistSelectionProvider(instance).notifier);
+          final notifier =
+              ref.read(radarrBlocklistSelectionProvider(instance).notifier);
           if (isSelected) {
             notifier.state = selection.where((id) => id != item.id).toSet();
           } else {
@@ -1532,7 +1600,8 @@ class _BlocklistCard extends ConsumerWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Delete from Blocklist?'),
-        content: const Text('Are you sure you want to remove this entry from your blocklist?'),
+        content: const Text(
+            'Are you sure you want to remove this entry from your blocklist?',),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -1572,7 +1641,8 @@ class _GroupedBlocklistCard extends ConsumerStatefulWidget {
   final List<RadarrBlocklistItem> items;
 
   @override
-  ConsumerState<_GroupedBlocklistCard> createState() => _GroupedBlocklistCardState();
+  ConsumerState<_GroupedBlocklistCard> createState() =>
+      _GroupedBlocklistCardState();
 }
 
 class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
@@ -1582,15 +1652,18 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final api = ref.watch(radarrApiProvider(widget.instance)).value;
-    final selection = ref.watch(radarrBlocklistSelectionProvider(widget.instance));
+    final selection =
+        ref.watch(radarrBlocklistSelectionProvider(widget.instance));
     final isSelecting = selection.isNotEmpty;
     final groupIds = widget.items.map((i) => i.id).toList();
     final isGroupSelected = groupIds.every(selection.contains);
 
     void toggleGroupSelection() {
-      final notifier = ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier);
+      final notifier =
+          ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier);
       if (isGroupSelected) {
-        notifier.state = selection.where((id) => !groupIds.contains(id)).toSet();
+        notifier.state =
+            selection.where((id) => !groupIds.contains(id)).toSet();
       } else {
         notifier.state = {...selection, ...groupIds};
       }
@@ -1598,7 +1671,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
 
     String? posterUrl;
     if (widget.movie?.images != null && api != null) {
-      final img = widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
+      final img =
+          widget.movie!.images.firstWhereOrNull((i) => i.coverType == 'poster');
       if (img != null) {
         posterUrl = api.posterUrl(img);
       }
@@ -1649,20 +1723,26 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   placeholder: (context, url) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
                                   ),
                                   errorWidget: (context, url, err) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
-                                    child: const Icon(Icons.movie_outlined, size: 18),
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
+                                    child: const Icon(Icons.movie_outlined,
+                                        size: 18,),
                                   ),
                                 )
                               : Container(
-                                  color: theme.colorScheme.surfaceContainerHighest,
-                                  child: const Icon(Icons.movie_outlined, size: 18),
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
+                                  child: const Icon(Icons.movie_outlined,
+                                      size: 18,),
                                 ),
                           if (isGroupSelected)
                             Container(
-                              color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                              color: theme.colorScheme.primary
+                                  .withValues(alpha: 0.25),
                               child: Center(
                                 child: Container(
                                   padding: const EdgeInsets.all(3),
@@ -1707,7 +1787,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.errorContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1742,9 +1823,12 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   final isItemSelected = selection.contains(item.id);
 
                   void toggleItemSelection() {
-                    final notifier = ref.read(radarrBlocklistSelectionProvider(widget.instance).notifier);
+                    final notifier = ref.read(
+                        radarrBlocklistSelectionProvider(widget.instance)
+                            .notifier,);
                     if (isItemSelected) {
-                      notifier.state = selection.where((id) => id != item.id).toSet();
+                      notifier.state =
+                          selection.where((id) => id != item.id).toSet();
                     } else {
                       notifier.state = {...selection, item.id};
                     }
@@ -1780,7 +1864,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                 maxLines: 2,
                                 overflow: TextOverflow.ellipsis,
                               ),
-                              if (item.message != null && item.message!.isNotEmpty) ...[
+                              if (item.message != null &&
+                                  item.message!.isNotEmpty) ...[
                                 const SizedBox(height: 2),
                                 Text(
                                   item.message!,
@@ -1802,7 +1887,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                               color: theme.colorScheme.error,
                               size: 20,
                             ),
-                            onPressed: () => _confirmDeleteBlocklistItem(context, ref, widget.instance, item),
+                            onPressed: () => _confirmDeleteBlocklistItem(
+                                context, ref, widget.instance, item,),
                           ),
                       ],
                     ),
@@ -1908,7 +1994,8 @@ class _ActivityBulkActionsBar extends StatelessWidget {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              const Text('Are you sure you want to cancel the selected downloads?'),
+              const Text(
+                  'Are you sure you want to cancel the selected downloads?',),
               CheckboxListTile(
                 title: const Text('Add releases to blocklist'),
                 value: blocklist,
@@ -1953,7 +2040,8 @@ class _ActivityBulkActionsBar extends StatelessWidget {
       context: context,
       builder: (context) => AlertDialog(
         title: Text('Remove ${selectedIds.length} Entries?'),
-        content: const Text('Are you sure you want to remove the selected entries from the blocklist?'),
+        content: const Text(
+            'Are you sure you want to remove the selected entries from the blocklist?',),
         actions: [
           TextButton(
             onPressed: () => Navigator.pop(context, false),
@@ -2042,7 +2130,8 @@ class _QueueBulkGrabDialog extends ConsumerWidget {
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Forced grab successfully triggered')),
+              const SnackBar(
+                  content: Text('Forced grab successfully triggered'),),
             );
           },
           child: const Text('Force Grab'),

--- a/services/service_radarr/lib/src/home/system_tab.dart
+++ b/services/service_radarr/lib/src/home/system_tab.dart
@@ -4,6 +4,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../radarr_api.dart';
@@ -242,10 +243,8 @@ class _StatusTab extends ConsumerWidget {
               );
             },
           ),
-
           statusAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
             error: (Object err, _) => _sectionError('Status', err),
             data: (Map<String, dynamic> s) {
               final String version = s['version'] as String? ?? 'Unknown';
@@ -253,7 +252,8 @@ class _StatusTab extends ConsumerWidget {
               final String osName = s['osName'] as String? ?? 'Unknown';
               final String osVersion = s['osVersion'] as String? ?? '';
               final String runtimeName = s['runtimeName'] as String? ?? '';
-              final String runtimeVersion = s['runtimeVersion'] as String? ?? '';
+              final String runtimeVersion =
+                  s['runtimeVersion'] as String? ?? '';
               final bool isDocker = s['isDocker'] as bool? ?? false;
               final String packageAuthor = s['packageAuthor'] as String? ?? '';
               final String dbType = s['databaseType'] as String? ?? '';
@@ -272,8 +272,7 @@ class _StatusTab extends ConsumerWidget {
                   uptimeText =
                       '${uptime.inDays}d ${uptime.inHours % 24}h ${uptime.inMinutes % 60}m';
                 } else if (uptime.inHours > 0) {
-                  uptimeText =
-                      '${uptime.inHours}h ${uptime.inMinutes % 60}m';
+                  uptimeText = '${uptime.inHours}h ${uptime.inMinutes % 60}m';
                 } else {
                   uptimeText = '${uptime.inMinutes}m';
                 }
@@ -354,7 +353,6 @@ class _StatusTab extends ConsumerWidget {
               );
             },
           ),
-
           diskAsync.when(
             loading: () => const SizedBox.shrink(),
             error: (Object err, _) => _sectionError('Disk Space', err),
@@ -365,8 +363,7 @@ class _StatusTab extends ConsumerWidget {
                 children: <Widget>[
                   _sectionHeader(theme, 'Disk Space'),
                   ...disks.map(
-                    (Map<String, dynamic> d) =>
-                        _DiskSpaceCard(disk: d),
+                    (Map<String, dynamic> d) => _DiskSpaceCard(disk: d),
                   ),
                 ],
               );
@@ -526,8 +523,7 @@ class _DiskSpaceCard extends StatelessWidget {
     final int freeSpace = disk['freeSpace'] as int? ?? 0;
     final int totalSpace = disk['totalSpace'] as int? ?? 1;
     final int usedSpace = totalSpace - freeSpace;
-    final double usedPercent =
-        totalSpace > 0 ? usedSpace / totalSpace : 0.0;
+    final double usedPercent = totalSpace > 0 ? usedSpace / totalSpace : 0.0;
 
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -571,17 +567,13 @@ class _DiskSpaceCard extends StatelessWidget {
             const SizedBox(height: Insets.sm),
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
-                value: usedPercent,
-                minHeight: 8,
-                backgroundColor:
-                    theme.colorScheme.surfaceContainerHighest,
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  usedPercent > 0.9
+              child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
+                  value: usedPercent,
+                  trackColor: theme.colorScheme.surfaceContainerHighest,
+                  activeColor: usedPercent > 0.9
                       ? theme.colorScheme.error
-                      : theme.colorScheme.primary,
-                ),
-              ),
+                      : theme.colorScheme.primary,),
             ),
             const SizedBox(height: Insets.xs),
             Text(
@@ -619,8 +611,7 @@ class _TasksTab extends ConsumerWidget {
     String taskName,
   ) async {
     try {
-      final RadarrApi api =
-          await ref.read(radarrApiProvider(instance).future);
+      final RadarrApi api = await ref.read(radarrApiProvider(instance).future);
       await api.runCommand(<String, dynamic>{'name': taskName});
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -649,10 +640,8 @@ class _TasksTab extends ConsumerWidget {
         await ref.read(radarrTasksProvider(instance).future);
       },
       child: tasksAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> tasks) {
           if (tasks.isEmpty) {
             return const Center(child: Text('No scheduled tasks.'));
@@ -663,24 +652,16 @@ class _TasksTab extends ConsumerWidget {
             itemCount: tasks.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> task = tasks[index];
-              final String name =
-                  task['name'] as String? ?? 'Task';
-              final String taskName =
-                  task['taskName'] as String? ?? '';
-              final int interval =
-                  task['interval'] as int? ?? 0;
-              final String lastExecStr =
-                  task['lastExecution'] as String? ?? '';
-              final String nextExecStr =
-                  task['nextExecution'] as String? ?? '';
-              final String lastDuration =
-                  task['lastDuration'] as String? ?? '';
+              final String name = task['name'] as String? ?? 'Task';
+              final String taskName = task['taskName'] as String? ?? '';
+              final int interval = task['interval'] as int? ?? 0;
+              final String lastExecStr = task['lastExecution'] as String? ?? '';
+              final String nextExecStr = task['nextExecution'] as String? ?? '';
+              final String lastDuration = task['lastDuration'] as String? ?? '';
 
               final String intervalText = _formatInterval(interval);
-              final String lastExecText =
-                  _formatRelativeTime(lastExecStr);
-              final String nextExecText =
-                  _formatRelativeTime(nextExecStr);
+              final String lastExecText = _formatRelativeTime(lastExecStr);
+              final String nextExecText = _formatRelativeTime(nextExecStr);
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -723,8 +704,7 @@ class _TasksTab extends ConsumerWidget {
                   trailing: IconButton(
                     icon: const Icon(Icons.play_arrow_outlined),
                     tooltip: 'Run now',
-                    onPressed: () =>
-                        _runTask(context, ref, taskName),
+                    onPressed: () => _runTask(context, ref, taskName),
                   ),
                 ),
               );
@@ -796,10 +776,8 @@ class _UpdatesTab extends ConsumerWidget {
         await ref.read(radarrUpdatesProvider(instance).future);
       },
       child: updatesAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> updates) {
           if (updates.isEmpty) {
             return const Center(
@@ -833,21 +811,18 @@ class _UpdateCard extends StatelessWidget {
     final String branch = update['branch'] as String? ?? '';
     final bool installed = update['installed'] as bool? ?? false;
     final bool latest = update['latest'] as bool? ?? false;
-    final String releaseDateStr =
-        update['releaseDate'] as String? ?? '';
+    final String releaseDateStr = update['releaseDate'] as String? ?? '';
     final Map<String, dynamic>? changes =
         update['changes'] as Map<String, dynamic>?;
 
-    final List<String> newItems =
-        (changes?['new'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
-    final List<String> fixedItems =
-        (changes?['fixed'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
+    final List<String> newItems = (changes?['new'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
+    final List<String> fixedItems = (changes?['fixed'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
 
     String releaseDateText = '';
     if (releaseDateStr.isNotEmpty) {
@@ -861,9 +836,8 @@ class _UpdateCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.md),
       elevation: 0,
-      color: installed
-          ? theme.colorScheme.primaryContainer.withAlpha(50)
-          : null,
+      color:
+          installed ? theme.colorScheme.primaryContainer.withAlpha(50) : null,
       shape: RoundedRectangleBorder(
         side: BorderSide(
           color: installed
@@ -895,23 +869,19 @@ class _UpdateCard extends StatelessWidget {
                       color: theme.colorScheme.onPrimaryContainer,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
                 if (latest && !installed)
                   Chip(
                     label: const Text('Latest'),
-                    backgroundColor:
-                        theme.colorScheme.tertiary.withAlpha(30),
-                    labelStyle:
-                        theme.textTheme.labelSmall?.copyWith(
+                    backgroundColor: theme.colorScheme.tertiary.withAlpha(30),
+                    labelStyle: theme.textTheme.labelSmall?.copyWith(
                       color: theme.colorScheme.tertiary,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
@@ -1029,12 +999,14 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final logsAsync = ref.watch(
-      radarrLogsProvider((
-        widget.instance,
-        page: _currentPage,
-        pageSize: _pageSize,
-        level: _levelFilter,
-      ),),
+      radarrLogsProvider(
+        (
+          widget.instance,
+          page: _currentPage,
+          pageSize: _pageSize,
+          level: _levelFilter,
+        ),
+      ),
     );
 
     return Column(
@@ -1085,18 +1057,14 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
             ],
           ),
         ),
-
         Expanded(
           child: logsAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
-            error: (Object err, _) =>
-                Center(child: Text('Error: $err')),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
+            error: (Object err, _) => Center(child: Text('Error: $err')),
             data: (Map<String, dynamic> data) {
               final List<dynamic> records =
                   data['records'] as List<dynamic>? ?? <dynamic>[];
-              final int totalRecords =
-                  data['totalRecords'] as int? ?? 0;
+              final int totalRecords = data['totalRecords'] as int? ?? 0;
               final int totalPages =
                   (totalRecords / _pageSize).ceil().clamp(1, 9999);
 
@@ -1109,19 +1077,22 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                   Expanded(
                     child: M3RefreshIndicator(
                       onRefresh: () async {
-                        ref.invalidate(radarrLogsProvider((
-                          widget.instance,
-                          page: _currentPage,
-                          pageSize: _pageSize,
-                          level: _levelFilter,
-                        ),),);
+                        ref.invalidate(
+                          radarrLogsProvider(
+                            (
+                              widget.instance,
+                              page: _currentPage,
+                              pageSize: _pageSize,
+                              level: _levelFilter,
+                            ),
+                          ),
+                        );
                       },
                       child: ListView.builder(
                         padding:
                             const EdgeInsets.symmetric(horizontal: Insets.md),
                         itemCount: records.length,
-                        itemBuilder:
-                            (BuildContext context, int index) {
+                        itemBuilder: (BuildContext context, int index) {
                           final Map<String, dynamic> log =
                               records[index] as Map<String, dynamic>;
                           return _LogEntryTile(log: log);
@@ -1129,7 +1100,6 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                       ),
                     ),
                   ),
-
                   Padding(
                     padding: const EdgeInsets.all(Insets.sm),
                     child: Row(
@@ -1138,8 +1108,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_left),
                           onPressed: _currentPage > 1
-                              ? () =>
-                                  setState(() => _currentPage--)
+                              ? () => setState(() => _currentPage--)
                               : null,
                         ),
                         Text(
@@ -1149,8 +1118,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_right),
                           onPressed: _currentPage < totalPages
-                              ? () =>
-                                  setState(() => _currentPage++)
+                              ? () => setState(() => _currentPage++)
                               : null,
                         ),
                       ],
@@ -1282,8 +1250,7 @@ class _LogEntryTile extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 4),
                         child: Text(
                           exception,
-                          style:
-                              theme.textTheme.bodySmall?.copyWith(
+                          style: theme.textTheme.bodySmall?.copyWith(
                             color: theme.colorScheme.error,
                             fontFamily: 'monospace',
                             fontSize: 11,
@@ -1371,10 +1338,8 @@ class _BackupsTab extends ConsumerWidget {
         await ref.read(radarrBackupsProvider(instance).future);
       },
       child: backupsAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> backups) {
           if (backups.isEmpty) {
             return const Center(child: Text('No backups found.'));
@@ -1385,14 +1350,11 @@ class _BackupsTab extends ConsumerWidget {
             itemCount: backups.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> backup = backups[index];
-              final String name =
-                  backup['name'] as String? ?? 'Backup';
-              final String type =
-                  backup['type'] as String? ?? 'unknown';
+              final String name = backup['name'] as String? ?? 'Backup';
+              final String type = backup['type'] as String? ?? 'unknown';
               final int size = backup['size'] as int? ?? 0;
               final int id = backup['id'] as int? ?? 0;
-              final String timeStr =
-                  backup['time'] as String? ?? '';
+              final String timeStr = backup['time'] as String? ?? '';
 
               String dateText = '';
               if (timeStr.isNotEmpty) {
@@ -1427,8 +1389,7 @@ class _BackupsTab extends ConsumerWidget {
                 ),
                 child: ListTile(
                   leading: CircleAvatar(
-                    backgroundColor:
-                        theme.colorScheme.surfaceContainerHighest,
+                    backgroundColor: theme.colorScheme.surfaceContainerHighest,
                     child: Icon(
                       typeIcon,
                       color: theme.colorScheme.onSurfaceVariant,
@@ -1453,8 +1414,7 @@ class _BackupsTab extends ConsumerWidget {
                       Icons.delete_outline,
                       color: theme.colorScheme.error,
                     ),
-                    onPressed: () =>
-                        _deleteBackup(context, ref, id, name),
+                    onPressed: () => _deleteBackup(context, ref, id, name),
                   ),
                 ),
               );

--- a/services/service_radarr/pubspec.yaml
+++ b/services/service_radarr/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
+  progress_indicator_m3e:
   url_launcher: ^6.3.2
 
 dev_dependencies:

--- a/services/service_sabnzbd/lib/src/sabnzbd_home.dart
+++ b/services/service_sabnzbd/lib/src/sabnzbd_home.dart
@@ -2,6 +2,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/sab_history.dart';
 import 'models/sab_queue.dart';
@@ -144,8 +145,8 @@ class _QueueSummary extends ConsumerWidget {
                   children: <Widget>[
                     Text(
                       speed,
-                      style: theme.textTheme.titleLarge
-                          ?.copyWith(fontWeight: FontWeight.w700, color: accent),
+                      style: theme.textTheme.titleLarge?.copyWith(
+                          fontWeight: FontWeight.w700, color: accent,),
                     ),
                     Text(
                       _isPaused
@@ -182,7 +183,8 @@ class _QueueSummary extends ConsumerWidget {
             children: <Widget>[
               _StatPill(
                 icon: Icons.speed,
-                label: 'Limit ${queue.speedlimit.isEmpty ? "100" : queue.speedlimit}%',
+                label:
+                    'Limit ${queue.speedlimit.isEmpty ? "100" : queue.speedlimit}%',
                 color: cs.tertiary,
               ),
               if (queue.diskspace1.isNotEmpty) ...<Widget>[
@@ -244,11 +246,11 @@ class _SlotCard extends ConsumerWidget {
             const SizedBox(height: Insets.sm),
             ClipRRect(
               borderRadius: BorderRadius.circular(8),
-              child: LinearProgressIndicator(
+              child: LinearProgressIndicatorM3E(
+                shape: ProgressM3EShape.flat,
                 value: pct.clamp(0, 1),
-                minHeight: 6,
-                color: color,
-                backgroundColor: cs.surfaceContainerHighest,
+                activeColor: color,
+                trackColor: cs.surfaceContainerHighest,
               ),
             ),
             const SizedBox(height: Insets.sm),
@@ -265,7 +267,8 @@ class _SlotCard extends ConsumerWidget {
                     <String>[
                       slot.status,
                       if (slot.mb.isNotEmpty) _mbToHuman(slot.mb),
-                      if (slot.timeleft.isNotEmpty && slot.timeleft != '0:00:00')
+                      if (slot.timeleft.isNotEmpty &&
+                          slot.timeleft != '0:00:00')
                         slot.timeleft,
                     ].join(' • '),
                     maxLines: 1,
@@ -316,7 +319,8 @@ class _HistoryTab extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<SabHistory> history = ref.watch(sabHistoryProvider(instance));
+    final AsyncValue<SabHistory> history =
+        ref.watch(sabHistoryProvider(instance));
     return M3RefreshIndicator(
       onRefresh: () async => ref.invalidate(sabHistoryProvider(instance)),
       child: AsyncValueView<SabHistory>(
@@ -463,8 +467,7 @@ class _ServerTab extends ConsumerWidget {
     final AsyncValue<SabServerStats> stats =
         ref.watch(sabServerStatsProvider(instance));
     final SabQueue? queue = ref.watch(sabQueueProvider(instance)).value;
-    final String version =
-        ref.watch(sabVersionProvider(instance)).value ?? '';
+    final String version = ref.watch(sabVersionProvider(instance)).value ?? '';
     final int currentLimit = int.tryParse(queue?.speedlimit ?? '') ?? 100;
 
     return M3RefreshIndicator(
@@ -481,10 +484,18 @@ class _ServerTab extends ConsumerWidget {
             child: stats.when(
               data: (SabServerStats s) => Row(
                 children: <Widget>[
-                  Expanded(child: _StatTile(label: 'Today', value: _fmtBytes(s.day))),
-                  Expanded(child: _StatTile(label: 'Week', value: _fmtBytes(s.week))),
-                  Expanded(child: _StatTile(label: 'Month', value: _fmtBytes(s.month))),
-                  Expanded(child: _StatTile(label: 'Total', value: _fmtBytes(s.total))),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Today', value: _fmtBytes(s.day)),),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Week', value: _fmtBytes(s.week)),),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Month', value: _fmtBytes(s.month)),),
+                  Expanded(
+                      child:
+                          _StatTile(label: 'Total', value: _fmtBytes(s.total)),),
                 ],
               ),
               loading: () => const Padding(
@@ -535,7 +546,8 @@ class _ServerTab extends ConsumerWidget {
 }
 
 class _SpeedLimitControl extends ConsumerStatefulWidget {
-  const _SpeedLimitControl({required this.instance, required this.initialPercent});
+  const _SpeedLimitControl(
+      {required this.instance, required this.initialPercent,});
 
   final Instance instance;
   final int initialPercent;
@@ -585,7 +597,8 @@ class _SpeedLimitControlState extends ConsumerState<_SpeedLimitControl> {
 // Shared -------------------------------------------------------------------
 
 class _StatPill extends StatelessWidget {
-  const _StatPill({required this.icon, required this.label, required this.color});
+  const _StatPill(
+      {required this.icon, required this.label, required this.color,});
 
   final IconData icon;
   final String label;
@@ -638,8 +651,8 @@ class _SectionCard extends StatelessWidget {
         children: <Widget>[
           Text(
             title,
-            style:
-                theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700),
+            style: theme.textTheme.titleMedium
+                ?.copyWith(fontWeight: FontWeight.w700),
           ),
           const SizedBox(height: Insets.sm),
           child,
@@ -749,8 +762,9 @@ String _fmtBytes(int bytes) {
     value /= 1024;
     unit++;
   }
-  final String text =
-      value >= 100 || unit == 0 ? value.toStringAsFixed(0) : value.toStringAsFixed(1);
+  final String text = value >= 100 || unit == 0
+      ? value.toStringAsFixed(0)
+      : value.toStringAsFixed(1);
   return '$text ${units[unit]}';
 }
 

--- a/services/service_sabnzbd/pubspec.yaml
+++ b/services/service_sabnzbd/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
+  progress_indicator_m3e:
 
 dev_dependencies:
   build_runner: ^2.4.13

--- a/services/service_sonarr/lib/src/home/activity_tab.dart
+++ b/services/service_sonarr/lib/src/home/activity_tab.dart
@@ -3,6 +3,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import '../models/sonarr_blocklist_item.dart';
 import '../models/sonarr_history_item.dart';
@@ -44,8 +45,11 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
     _tabController = TabController(length: 3, vsync: this);
     _tabController.addListener(() {
       if (_tabController.indexIsChanging) {
-        ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state = {};
-        ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+        ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state =
+            {};
+        ref
+            .read(sonarrBlocklistSelectionProvider(widget.instance).notifier)
+            .state = {};
         setState(() {});
       }
     });
@@ -91,8 +95,10 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final grouped = ref.watch(sonarrActivityGroupedProvider(widget.instance));
-    final queueSelection = ref.watch(sonarrQueueSelectionProvider(widget.instance));
-    final blocklistSelection = ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
+    final queueSelection =
+        ref.watch(sonarrQueueSelectionProvider(widget.instance));
+    final blocklistSelection =
+        ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
     final activeSelection = _tabController.index == 0
         ? queueSelection
         : _tabController.index == 2
@@ -121,13 +127,20 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
               selectedIds: activeSelection,
               isQueue: _tabController.index == 0,
               onClear: () {
-                ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                ref
+                    .read(
+                        sonarrQueueSelectionProvider(widget.instance).notifier,)
+                    .state = {};
+                ref
+                    .read(sonarrBlocklistSelectionProvider(widget.instance)
+                        .notifier,)
+                    .state = {};
               },
             )
           : null,
       body: NestedScrollView(
-        headerSliverBuilder: (BuildContext innerContext, bool innerBoxIsScrolled) {
+        headerSliverBuilder:
+            (BuildContext innerContext, bool innerBoxIsScrolled) {
           return <Widget>[
             SliverAppBar(
               floating: true,
@@ -143,8 +156,15 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                   ? IconButton(
                       icon: const Icon(Icons.close),
                       onPressed: () {
-                        ref.read(sonarrQueueSelectionProvider(widget.instance).notifier).state = {};
-                        ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier).state = {};
+                        ref
+                            .read(sonarrQueueSelectionProvider(widget.instance)
+                                .notifier,)
+                            .state = {};
+                        ref
+                            .read(sonarrBlocklistSelectionProvider(
+                                    widget.instance,)
+                                .notifier,)
+                            .state = {};
                       },
                     )
                   : IconButton(
@@ -162,55 +182,59 @@ class _ActivityTabState extends ConsumerState<ActivityTab>
                       ),
                     )
                   : SearchBar(
-                focusNode: _searchFocusNode,
-                controller: _searchController,
-                hintText: 'Search activity...',
-                onTapOutside: (event) {
-                  if (_searchFocusNode.hasFocus) {
-                    _searchFocusNode.unfocus();
-                  }
-                },
-                elevation: const WidgetStatePropertyAll<double>(0),
-                backgroundColor: WidgetStatePropertyAll<Color>(
-                  theme.colorScheme.surfaceContainerHigh,
-                ),
-                trailing: <Widget>[
-                  if (_searchController.text.isNotEmpty)
-                    IconButton(
-                      icon: const Icon(Icons.clear),
-                      onPressed: () {
-                        setState(() {
-                          _searchController.clear();
-                        });
+                      focusNode: _searchFocusNode,
+                      controller: _searchController,
+                      hintText: 'Search activity...',
+                      onTapOutside: (event) {
+                        if (_searchFocusNode.hasFocus) {
+                          _searchFocusNode.unfocus();
+                        }
+                      },
+                      elevation: const WidgetStatePropertyAll<double>(0),
+                      backgroundColor: WidgetStatePropertyAll<Color>(
+                        theme.colorScheme.surfaceContainerHigh,
+                      ),
+                      trailing: <Widget>[
+                        if (_searchController.text.isNotEmpty)
+                          IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: () {
+                              setState(() {
+                                _searchController.clear();
+                              });
+                              ref
+                                  .read(
+                                    sonarrActivitySearchQueryProvider(
+                                      widget.instance,
+                                    ).notifier,
+                                  )
+                                  .state = '';
+                              _updateSearchActiveState();
+                            },
+                          ),
+                      ],
+                      onChanged: (String value) {
+                        setState(() {});
                         ref
                             .read(
-                              sonarrActivitySearchQueryProvider(
-                                widget.instance,
-                              ).notifier,
+                              sonarrActivitySearchQueryProvider(widget.instance)
+                                  .notifier,
                             )
-                            .state = '';
+                            .state = value;
                         _updateSearchActiveState();
                       },
                     ),
-                ],
-                onChanged: (String value) {
-                  setState(() {});
-                  ref
-                      .read(
-                        sonarrActivitySearchQueryProvider(widget.instance)
-                            .notifier,
-                      )
-                      .state = value;
-                  _updateSearchActiveState();
-                },
-              ),
               actions: <Widget>[
                 if (!isSelecting) ...[
                   IconButton(
                     icon: Icon(
-                      grouped ? Icons.format_list_bulleted : Icons.group_work_outlined,
+                      grouped
+                          ? Icons.format_list_bulleted
+                          : Icons.group_work_outlined,
                     ),
-                    tooltip: grouped ? 'Switch to plain list' : 'Switch to grouped view',
+                    tooltip: grouped
+                        ? 'Switch to plain list'
+                        : 'Switch to grouped view',
                     onPressed: () {
                       ref
                           .read(
@@ -265,14 +289,17 @@ class _QueueView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final queueAsync = ref.watch(sonarrQueueProvider(instance));
-    final searchQuery = ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
 
     return queueAsync.when(
       data: (List<SonarrQueueItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.title?.toLowerCase().contains(searchQuery) ?? false;
-          final seriesMatch = item.series?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.title?.toLowerCase().contains(searchQuery) ?? false;
+          final seriesMatch =
+              item.series?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || seriesMatch;
         }).toList();
 
@@ -305,7 +332,9 @@ class _QueueView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  searchQuery.isEmpty ? 'Queue is empty' : 'No items match search',
+                  searchQuery.isEmpty
+                      ? 'Queue is empty'
+                      : 'No items match search',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -353,7 +382,8 @@ class _QueueView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 FilledButton.tonal(
-                  onPressed: () => ref.invalidate(sonarrQueueProvider(instance)),
+                  onPressed: () =>
+                      ref.invalidate(sonarrQueueProvider(instance)),
                   child: const Text('Retry'),
                 ),
               ],
@@ -385,9 +415,11 @@ class _QueueItemCard extends ConsumerWidget {
     final isSelected = groupIds.every(selection.contains);
 
     void toggleSelection() {
-      final notifier = ref.read(sonarrQueueSelectionProvider(instance).notifier);
+      final notifier =
+          ref.read(sonarrQueueSelectionProvider(instance).notifier);
       if (isSelected) {
-        notifier.state = selection.where((id) => !groupIds.contains(id)).toSet();
+        notifier.state =
+            selection.where((id) => !groupIds.contains(id)).toSet();
       } else {
         notifier.state = {...selection, ...groupIds};
       }
@@ -401,23 +433,29 @@ class _QueueItemCard extends ConsumerWidget {
       totalSizeLeft += i.sizeleft ?? 0.0;
     }
 
-    final bool allSizesIdentical = group.every((i) => i.size == item.size && i.sizeleft == item.sizeleft);
-    final double displaySize = allSizesIdentical ? (item.size ?? 0.0) : totalSize;
-    final double displaySizeLeft = allSizesIdentical ? (item.sizeleft ?? 0.0) : totalSizeLeft;
-    final double progress = displaySize > 0 ? (displaySize - displaySizeLeft) / displaySize : 0.0;
+    final bool allSizesIdentical =
+        group.every((i) => i.size == item.size && i.sizeleft == item.sizeleft);
+    final double displaySize =
+        allSizesIdentical ? (item.size ?? 0.0) : totalSize;
+    final double displaySizeLeft =
+        allSizesIdentical ? (item.sizeleft ?? 0.0) : totalSizeLeft;
+    final double progress =
+        displaySize > 0 ? (displaySize - displaySizeLeft) / displaySize : 0.0;
 
     // Construct episodes display list (e.g. S01E01, S01E02)
     final List<String> episodeTexts = [];
     for (final i in group) {
       if (i.episode != null) {
-        final String seasonStr = i.seasonNumber != null ? 'S${i.seasonNumber.toString().padLeft(2, '0')}' : '';
-        final String epStr = 'E${i.episode!.episodeNumber.toString().padLeft(2, '0')}';
+        final String seasonStr = i.seasonNumber != null
+            ? 'S${i.seasonNumber.toString().padLeft(2, '0')}'
+            : '';
+        final String epStr =
+            'E${i.episode!.episodeNumber.toString().padLeft(2, '0')}';
         episodeTexts.add('$seasonStr$epStr');
       }
     }
-    final String episodesDisplay = episodeTexts.isNotEmpty
-        ? 'Episodes: ${episodeTexts.join(', ')}'
-        : '';
+    final String episodesDisplay =
+        episodeTexts.isNotEmpty ? 'Episodes: ${episodeTexts.join(', ')}' : '';
 
     String? posterUrl;
     if (item.series?.images != null && api != null) {
@@ -463,30 +501,33 @@ class _QueueItemCard extends ConsumerWidget {
                     fit: StackFit.expand,
                     children: [
                       posterUrl != null
-                        ? CachedNetworkImage(
-                            imageUrl: posterUrl,
-                            fit: BoxFit.cover,
-                            placeholder: (context, url) => Container(
-                              color: theme.colorScheme.surfaceContainerHighest,
-                            ),
-                            errorWidget: (context, url, err) => Container(
+                          ? CachedNetworkImage(
+                              imageUrl: posterUrl,
+                              fit: BoxFit.cover,
+                              placeholder: (context, url) => Container(
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                              ),
+                              errorWidget: (context, url, err) => Container(
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
+                                child: Icon(
+                                  Icons.live_tv,
+                                  color: theme.colorScheme.outline,
+                                ),
+                              ),
+                            )
+                          : Container(
                               color: theme.colorScheme.surfaceContainerHighest,
                               child: Icon(
                                 Icons.live_tv,
                                 color: theme.colorScheme.outline,
                               ),
                             ),
-                          )
-                        : Container(
-                            color: theme.colorScheme.surfaceContainerHighest,
-                            child: Icon(
-                              Icons.live_tv,
-                              color: theme.colorScheme.outline,
-                            ),
-                          ),
                       if (isSelected)
                         Container(
-                          color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                          color:
+                              theme.colorScheme.primary.withValues(alpha: 0.25),
                           child: Center(
                             child: Container(
                               padding: const EdgeInsets.all(4),
@@ -549,10 +590,12 @@ class _QueueItemCard extends ConsumerWidget {
                         Expanded(
                           child: ClipRRect(
                             borderRadius: BorderRadius.circular(4),
-                            child: LinearProgressIndicator(
+                            child: LinearProgressIndicatorM3E(
+                              shape: ProgressM3EShape.flat,
                               value: progress,
-                              backgroundColor: theme.colorScheme.surfaceContainerHighest,
-                              color: item.status == 'warning'
+                              trackColor:
+                                  theme.colorScheme.surfaceContainerHighest,
+                              activeColor: item.status == 'warning'
                                   ? theme.colorScheme.error
                                   : theme.colorScheme.primary,
                             ),
@@ -578,7 +621,8 @@ class _QueueItemCard extends ConsumerWidget {
                             color: theme.colorScheme.onSurfaceVariant,
                           ),
                         ),
-                        if (item.timeleft != null && item.timeleft != '00:00:00')
+                        if (item.timeleft != null &&
+                            item.timeleft != '00:00:00')
                           Text(
                             'ETA: ${item.timeleft}',
                             style: theme.textTheme.bodySmall?.copyWith(
@@ -667,20 +711,21 @@ class _QueueItemCard extends ConsumerWidget {
     final List<String> episodeTexts = [];
     for (final i in group) {
       if (i.episode != null) {
-        final String seasonStr = i.seasonNumber != null ? 'S${i.seasonNumber}' : '';
+        final String seasonStr =
+            i.seasonNumber != null ? 'S${i.seasonNumber}' : '';
         final String epStr = 'E${i.episode!.episodeNumber}';
         episodeTexts.add('$seasonStr$epStr');
       }
     }
-    final String episodesDisplay = episodeTexts.isNotEmpty
-        ? episodeTexts.join(', ')
-        : 'None';
+    final String episodesDisplay =
+        episodeTexts.isNotEmpty ? episodeTexts.join(', ') : 'None';
 
     showDialog<void>(
       context: context,
       builder: (BuildContext context) {
         return AlertDialog(
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+          shape:
+              RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
           title: Text(
             'Queue Item Details',
             style: theme.textTheme.titleLarge?.copyWith(
@@ -693,15 +738,24 @@ class _QueueItemCard extends ConsumerWidget {
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
                 _DetailRow(label: 'Title', value: item.title ?? 'No title'),
-                _DetailRow(label: 'Series', value: item.series?.title ?? 'Unknown Series'),
+                _DetailRow(
+                    label: 'Series',
+                    value: item.series?.title ?? 'Unknown Series',),
                 _DetailRow(label: 'Episodes', value: episodesDisplay),
                 _DetailRow(label: 'Status', value: item.status ?? 'Unknown'),
-                _DetailRow(label: 'Tracked State', value: item.trackedDownloadState ?? 'None'),
-                _DetailRow(label: 'Download Client', value: item.downloadClient ?? 'Unknown'),
-                _DetailRow(label: 'Download ID', value: item.downloadId ?? 'Unknown'),
+                _DetailRow(
+                    label: 'Tracked State',
+                    value: item.trackedDownloadState ?? 'None',),
+                _DetailRow(
+                    label: 'Download Client',
+                    value: item.downloadClient ?? 'Unknown',),
+                _DetailRow(
+                    label: 'Download ID', value: item.downloadId ?? 'Unknown',),
                 _DetailRow(label: 'Indexer', value: item.indexer ?? 'Unknown'),
-                _DetailRow(label: 'Output Path', value: item.outputPath ?? 'Unknown'),
-                if (item.errorMessage != null && item.errorMessage!.isNotEmpty) ...[
+                _DetailRow(
+                    label: 'Output Path', value: item.outputPath ?? 'Unknown',),
+                if (item.errorMessage != null &&
+                    item.errorMessage!.isNotEmpty) ...[
                   const SizedBox(height: 12),
                   Text(
                     'Error Message:',
@@ -715,9 +769,11 @@ class _QueueItemCard extends ConsumerWidget {
                     width: double.maxFinite,
                     padding: const EdgeInsets.all(12),
                     decoration: BoxDecoration(
-                      color: theme.colorScheme.errorContainer.withValues(alpha: 0.3),
+                      color: theme.colorScheme.errorContainer
+                          .withValues(alpha: 0.3),
                       borderRadius: BorderRadius.circular(8),
-                      border: Border.all(color: theme.colorScheme.errorContainer),
+                      border:
+                          Border.all(color: theme.colorScheme.errorContainer),
                     ),
                     child: Text(
                       item.errorMessage!,
@@ -756,7 +812,8 @@ class _QueueItemCard extends ConsumerWidget {
         return StatefulBuilder(
           builder: (BuildContext context, StateSetter setState) {
             return AlertDialog(
-              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
+              shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(28),),
               title: Text(
                 'Remove from Queue',
                 style: theme.textTheme.titleLarge?.copyWith(
@@ -787,7 +844,8 @@ class _QueueItemCard extends ConsumerWidget {
                   ),
                   CheckboxListTile(
                     title: const Text('Blocklist this release'),
-                    subtitle: const Text('Prevents Sonarr from grabbing this file again'),
+                    subtitle: const Text(
+                        'Prevents Sonarr from grabbing this file again',),
                     value: blocklist,
                     controlAffinity: ListTileControlAffinity.leading,
                     contentPadding: EdgeInsets.zero,
@@ -812,7 +870,8 @@ class _QueueItemCard extends ConsumerWidget {
                   onPressed: () async {
                     Navigator.of(context).pop();
                     try {
-                      final api = await ref.read(sonarrApiProvider(instance).future);
+                      final api =
+                          await ref.read(sonarrApiProvider(instance).future);
                       // Delete all items in the grouped torrent.
                       for (final i in group) {
                         await api.deleteQueueItem(
@@ -861,16 +920,20 @@ class _HistoryView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final historyAsync = ref.watch(sonarrHistoryProvider(instance));
-    final searchQuery = ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
     final grouped = ref.watch(sonarrActivityGroupedProvider(instance));
 
     return historyAsync.when(
       data: (List<SonarrHistoryItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final seriesMatch = item.series?.title.toLowerCase().contains(searchQuery) ?? false;
-          final episodeMatch = item.episode?.title.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final seriesMatch =
+              item.series?.title.toLowerCase().contains(searchQuery) ?? false;
+          final episodeMatch =
+              item.episode?.title.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || seriesMatch || episodeMatch;
         }).toList();
 
@@ -886,7 +949,9 @@ class _HistoryView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  searchQuery.isEmpty ? 'No history records' : 'No history matches search',
+                  searchQuery.isEmpty
+                      ? 'No history records'
+                      : 'No history matches search',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -929,7 +994,8 @@ class _HistoryView extends ConsumerWidget {
             },
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
-              itemCount: seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
+              itemCount:
+                  seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
               itemBuilder: (BuildContext context, int index) {
                 if (index < seriesList.length) {
                   final series = seriesList[index];
@@ -990,7 +1056,8 @@ class _HistoryView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 FilledButton.tonal(
-                  onPressed: () => ref.invalidate(sonarrHistoryProvider(instance)),
+                  onPressed: () =>
+                      ref.invalidate(sonarrHistoryProvider(instance)),
                   child: const Text('Retry'),
                 ),
               ],
@@ -1014,7 +1081,8 @@ class _GroupedHistoryCard extends ConsumerStatefulWidget {
   final List<SonarrHistoryItem> items;
 
   @override
-  ConsumerState<_GroupedHistoryCard> createState() => _GroupedHistoryCardState();
+  ConsumerState<_GroupedHistoryCard> createState() =>
+      _GroupedHistoryCardState();
 }
 
 class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
@@ -1028,7 +1096,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
     String? posterUrl;
     if (widget.series?.images != null && api != null) {
       try {
-        final img = widget.series!.images.firstWhere((i) => i.coverType == 'poster');
+        final img =
+            widget.series!.images.firstWhere((i) => i.coverType == 'poster');
         posterUrl = api.posterUrl(img);
       } catch (_) {}
     }
@@ -1073,10 +1142,12 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                               ),
                               errorWidget: (context, url, err) => Container(
-                                color: theme.colorScheme.surfaceContainerHighest,
+                                color:
+                                    theme.colorScheme.surfaceContainerHighest,
                                 child: Icon(
                                   Icons.live_tv,
                                   size: 18,
@@ -1119,7 +1190,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.primaryContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1184,7 +1256,8 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                         ),
                         IconButton(
                           icon: const Icon(Icons.info_outline, size: 20),
-                          onPressed: () => _showHistoryDetails(context, ref, widget.instance, item),
+                          onPressed: () => _showHistoryDetails(
+                              context, ref, widget.instance, item,),
                         ),
                       ],
                     ),
@@ -1272,16 +1345,20 @@ class _BlocklistView extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = Theme.of(context);
     final blocklistAsync = ref.watch(sonarrBlocklistProvider(instance));
-    final searchQuery = ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
+    final searchQuery =
+        ref.watch(sonarrActivitySearchQueryProvider(instance)).toLowerCase();
     final grouped = ref.watch(sonarrActivityGroupedProvider(instance));
 
     return blocklistAsync.when(
       data: (List<SonarrBlocklistItem> items) {
         final filteredItems = items.where((item) {
           if (searchQuery.isEmpty) return true;
-          final titleMatch = item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
-          final seriesMatch = item.series?.title.toLowerCase().contains(searchQuery) ?? false;
-          final messageMatch = item.message?.toLowerCase().contains(searchQuery) ?? false;
+          final titleMatch =
+              item.sourceTitle?.toLowerCase().contains(searchQuery) ?? false;
+          final seriesMatch =
+              item.series?.title.toLowerCase().contains(searchQuery) ?? false;
+          final messageMatch =
+              item.message?.toLowerCase().contains(searchQuery) ?? false;
           return titleMatch || seriesMatch || messageMatch;
         }).toList();
 
@@ -1297,7 +1374,9 @@ class _BlocklistView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 Text(
-                  searchQuery.isEmpty ? 'No blocklisted items' : 'No blocklist matches search',
+                  searchQuery.isEmpty
+                      ? 'No blocklisted items'
+                      : 'No blocklist matches search',
                   style: theme.textTheme.titleMedium?.copyWith(
                     color: theme.colorScheme.onSurfaceVariant,
                   ),
@@ -1340,7 +1419,8 @@ class _BlocklistView extends ConsumerWidget {
             },
             child: ListView.builder(
               padding: const EdgeInsets.all(16),
-              itemCount: seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
+              itemCount:
+                  seriesList.length + (unknownSeriesItems.isNotEmpty ? 1 : 0),
               itemBuilder: (BuildContext context, int index) {
                 if (index < seriesList.length) {
                   final series = seriesList[index];
@@ -1401,7 +1481,8 @@ class _BlocklistView extends ConsumerWidget {
                 ),
                 const SizedBox(height: 16),
                 FilledButton.tonal(
-                  onPressed: () => ref.invalidate(sonarrBlocklistProvider(instance)),
+                  onPressed: () =>
+                      ref.invalidate(sonarrBlocklistProvider(instance)),
                   child: const Text('Retry'),
                 ),
               ],
@@ -1425,7 +1506,8 @@ class _GroupedBlocklistCard extends ConsumerStatefulWidget {
   final List<SonarrBlocklistItem> items;
 
   @override
-  ConsumerState<_GroupedBlocklistCard> createState() => _GroupedBlocklistCardState();
+  ConsumerState<_GroupedBlocklistCard> createState() =>
+      _GroupedBlocklistCardState();
 }
 
 class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
@@ -1435,15 +1517,18 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final api = ref.watch(sonarrApiProvider(widget.instance)).value;
-    final selection = ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
+    final selection =
+        ref.watch(sonarrBlocklistSelectionProvider(widget.instance));
     final isSelecting = selection.isNotEmpty;
     final groupIds = widget.items.map((i) => i.id).toList();
     final isGroupSelected = groupIds.every(selection.contains);
 
     void toggleGroupSelection() {
-      final notifier = ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier);
+      final notifier =
+          ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier);
       if (isGroupSelected) {
-        notifier.state = selection.where((id) => !groupIds.contains(id)).toSet();
+        notifier.state =
+            selection.where((id) => !groupIds.contains(id)).toSet();
       } else {
         notifier.state = {...selection, ...groupIds};
       }
@@ -1452,7 +1537,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
     String? posterUrl;
     if (widget.series?.images != null && api != null) {
       try {
-        final img = widget.series!.images.firstWhere((i) => i.coverType == 'poster');
+        final img =
+            widget.series!.images.firstWhere((i) => i.coverType == 'poster');
         posterUrl = api.posterUrl(img);
       } catch (_) {}
     }
@@ -1505,10 +1591,12 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   placeholder: (context, url) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
                                   ),
                                   errorWidget: (context, url, err) => Container(
-                                    color: theme.colorScheme.surfaceContainerHighest,
+                                    color: theme
+                                        .colorScheme.surfaceContainerHighest,
                                     child: Icon(
                                       Icons.live_tv,
                                       size: 18,
@@ -1517,7 +1605,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   ),
                                 )
                               : Container(
-                                  color: theme.colorScheme.surfaceContainerHighest,
+                                  color:
+                                      theme.colorScheme.surfaceContainerHighest,
                                   child: Icon(
                                     Icons.live_tv,
                                     size: 18,
@@ -1526,7 +1615,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                 ),
                           if (isGroupSelected)
                             Container(
-                              color: theme.colorScheme.primary.withValues(alpha: 0.25),
+                              color: theme.colorScheme.primary
+                                  .withValues(alpha: 0.25),
                               child: Center(
                                 child: Container(
                                   padding: const EdgeInsets.all(3),
@@ -1571,7 +1661,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   ),
                   const SizedBox(width: 8),
                   Container(
-                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                     decoration: BoxDecoration(
                       color: theme.colorScheme.errorContainer,
                       borderRadius: BorderRadius.circular(10),
@@ -1606,9 +1697,12 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                   final isItemSelected = selection.contains(item.id);
 
                   void toggleItemSelection() {
-                    final notifier = ref.read(sonarrBlocklistSelectionProvider(widget.instance).notifier);
+                    final notifier = ref.read(
+                        sonarrBlocklistSelectionProvider(widget.instance)
+                            .notifier,);
                     if (isItemSelected) {
-                      notifier.state = selection.where((id) => id != item.id).toSet();
+                      notifier.state =
+                          selection.where((id) => id != item.id).toSet();
                     } else {
                       notifier.state = {...selection, item.id};
                     }
@@ -1647,12 +1741,14 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                   maxLines: 2,
                                   overflow: TextOverflow.ellipsis,
                                 ),
-                                if (item.message != null && item.message!.isNotEmpty)
+                                if (item.message != null &&
+                                    item.message!.isNotEmpty)
                                   Padding(
                                     padding: const EdgeInsets.only(top: 2),
                                     child: Text(
                                       item.message!,
-                                      style: theme.textTheme.bodySmall?.copyWith(
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
                                         color: theme.colorScheme.error,
                                         fontSize: 11,
                                       ),
@@ -1671,12 +1767,15 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                         ),
                                         margin: const EdgeInsets.only(right: 6),
                                         decoration: BoxDecoration(
-                                          color: theme.colorScheme.surfaceContainerHighest,
-                                          borderRadius: BorderRadius.circular(4),
+                                          color: theme.colorScheme
+                                              .surfaceContainerHighest,
+                                          borderRadius:
+                                              BorderRadius.circular(4),
                                         ),
                                         child: Text(
                                           item.indexer!,
-                                          style: theme.textTheme.bodySmall?.copyWith(
+                                          style: theme.textTheme.bodySmall
+                                              ?.copyWith(
                                             fontSize: 9,
                                             fontWeight: FontWeight.w500,
                                           ),
@@ -1684,7 +1783,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                       ),
                                     Text(
                                       _formatDateTime(item.date),
-                                      style: theme.textTheme.bodySmall?.copyWith(
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
                                         color: theme.colorScheme.outline,
                                         fontSize: 10,
                                       ),
@@ -1700,7 +1800,8 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                                 Icons.delete_outline,
                                 color: theme.colorScheme.error,
                               ),
-                              onPressed: () => _confirmDeleteBlocklistItem(context, ref, widget.instance, item),
+                              onPressed: () => _confirmDeleteBlocklistItem(
+                                  context, ref, widget.instance, item,),
                             ),
                         ],
                       ),
@@ -1733,7 +1834,8 @@ class _PlainBlocklistCard extends ConsumerWidget {
     final isSelected = selection.contains(item.id);
 
     void toggleSelection() {
-      final notifier = ref.read(sonarrBlocklistSelectionProvider(instance).notifier);
+      final notifier =
+          ref.read(sonarrBlocklistSelectionProvider(instance).notifier);
       if (isSelected) {
         notifier.state = selection.where((id) => id != item.id).toSet();
       } else {
@@ -1810,7 +1912,8 @@ class _PlainBlocklistCard extends ConsumerWidget {
                   Icons.delete_outline,
                   color: theme.colorScheme.error,
                 ),
-                onPressed: () => _confirmDeleteBlocklistItem(context, ref, instance, item),
+                onPressed: () =>
+                    _confirmDeleteBlocklistItem(context, ref, instance, item),
               ),
       ),
     );
@@ -1925,7 +2028,8 @@ void _showHistoryDetails(
             children: <Widget>[
               _DetailRow(label: 'Event Type', value: eventType.toUpperCase()),
               _DetailRow(label: 'Date', value: _formatDateTime(item.date)),
-              _DetailRow(label: 'Source Title', value: item.sourceTitle ?? 'None'),
+              _DetailRow(
+                  label: 'Source Title', value: item.sourceTitle ?? 'None',),
               if (item.downloadId != null)
                 _DetailRow(label: 'Download ID', value: item.downloadId!),
               if (item.data != null && item.data!.isNotEmpty) ...[
@@ -1964,11 +2068,13 @@ void _showHistoryDetails(
         actions: <Widget>[
           if (eventType.toLowerCase() == 'grabbed')
             TextButton(
-              style: TextButton.styleFrom(foregroundColor: theme.colorScheme.error),
+              style: TextButton.styleFrom(
+                  foregroundColor: theme.colorScheme.error,),
               onPressed: () async {
                 Navigator.of(context).pop();
                 try {
-                  final api = await ref.read(sonarrApiProvider(instance).future);
+                  final api =
+                      await ref.read(sonarrApiProvider(instance).future);
                   await api.failHistoryItem(item.id);
                   ref.invalidate(sonarrHistoryProvider(instance));
                   if (context.mounted) {
@@ -2041,7 +2147,8 @@ void _confirmDeleteBlocklistItem(
                 ref.invalidate(sonarrBlocklistProvider(instance));
                 if (context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Item removed from blocklist.')),
+                    const SnackBar(
+                        content: Text('Item removed from blocklist.'),),
                   );
                 }
               } catch (e) {
@@ -2081,6 +2188,7 @@ String _formatDateTime(String? isoDate) {
     return isoDate;
   }
 }
+
 class _ActivityBulkActionsBar extends StatelessWidget {
   const _ActivityBulkActionsBar({
     required this.instance,
@@ -2193,7 +2301,8 @@ class _QueueBulkGrabDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return AlertDialog(
       title: Text('Force Grab ${selectedIds.length} Releases?'),
-      content: const Text('Are you sure you want to force download the selected releases from the queue?'),
+      content: const Text(
+          'Are you sure you want to force download the selected releases from the queue?',),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
@@ -2234,7 +2343,8 @@ class _QueueBulkGrabDialog extends ConsumerWidget {
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Forced grab successfully triggered')),
+              const SnackBar(
+                  content: Text('Forced grab successfully triggered'),),
             );
           },
           child: const Text('Force Grab'),
@@ -2256,10 +2366,12 @@ class _QueueBulkDeleteDialog extends ConsumerStatefulWidget {
   final VoidCallback onClear;
 
   @override
-  ConsumerState<_QueueBulkDeleteDialog> createState() => _QueueBulkDeleteDialogState();
+  ConsumerState<_QueueBulkDeleteDialog> createState() =>
+      _QueueBulkDeleteDialogState();
 }
 
-class _QueueBulkDeleteDialogState extends ConsumerState<_QueueBulkDeleteDialog> {
+class _QueueBulkDeleteDialogState
+    extends ConsumerState<_QueueBulkDeleteDialog> {
   bool _blocklist = false;
 
   @override
@@ -2270,7 +2382,8 @@ class _QueueBulkDeleteDialogState extends ConsumerState<_QueueBulkDeleteDialog> 
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          const Text('Are you sure you want to remove these items from download client queue?'),
+          const Text(
+              'Are you sure you want to remove these items from download client queue?',),
           const SizedBox(height: 16),
           CheckboxListTile(
             title: const Text('Add items to blocklist'),
@@ -2306,7 +2419,8 @@ class _QueueBulkDeleteDialogState extends ConsumerState<_QueueBulkDeleteDialog> 
             try {
               final api =
                   await ref.read(sonarrApiProvider(widget.instance).future);
-              await api.bulkDeleteQueue(widget.selectedIds.toList(), blocklist: _blocklist);
+              await api.bulkDeleteQueue(widget.selectedIds.toList(),
+                  blocklist: _blocklist,);
             } catch (e) {
               error = e;
             } finally {
@@ -2350,7 +2464,8 @@ class _BlocklistBulkDeleteDialog extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return AlertDialog(
       title: Text('Remove ${selectedIds.length} items from Blocklist?'),
-      content: const Text('Are you sure you want to remove these items from blocklist? Sonarr will be able to search and grab these releases again.'),
+      content: const Text(
+          'Are you sure you want to remove these items from blocklist? Sonarr will be able to search and grab these releases again.',),
       actions: [
         TextButton(
           onPressed: () => Navigator.pop(context),
@@ -2395,7 +2510,8 @@ class _BlocklistBulkDeleteDialog extends ConsumerWidget {
             Navigator.pop(context); // pop dialog
 
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Successfully removed items from blocklist')),
+              const SnackBar(
+                  content: Text('Successfully removed items from blocklist'),),
             );
           },
           child: const Text('Remove'),
@@ -2404,4 +2520,3 @@ class _BlocklistBulkDeleteDialog extends ConsumerWidget {
     );
   }
 }
-

--- a/services/service_sonarr/lib/src/home/system_tab.dart
+++ b/services/service_sonarr/lib/src/home/system_tab.dart
@@ -4,6 +4,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 import '../sonarr_api.dart';
@@ -249,35 +250,23 @@ class _StatusTab extends ConsumerWidget {
 
           // ── About / Status ──
           statusAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
             error: (Object err, _) => _sectionError('Status', err),
             data: (Map<String, dynamic> s) {
-              final String version =
-                  s['version'] as String? ?? 'Unknown';
-              final String branch =
-                  s['branch'] as String? ?? 'Unknown';
-              final String osName =
-                  s['osName'] as String? ?? 'Unknown';
-              final String osVersion =
-                  s['osVersion'] as String? ?? '';
-              final String runtimeName =
-                  s['runtimeName'] as String? ?? '';
+              final String version = s['version'] as String? ?? 'Unknown';
+              final String branch = s['branch'] as String? ?? 'Unknown';
+              final String osName = s['osName'] as String? ?? 'Unknown';
+              final String osVersion = s['osVersion'] as String? ?? '';
+              final String runtimeName = s['runtimeName'] as String? ?? '';
               final String runtimeVersion =
                   s['runtimeVersion'] as String? ?? '';
               final bool isDocker = s['isDocker'] as bool? ?? false;
-              final String packageAuthor =
-                  s['packageAuthor'] as String? ?? '';
-              final String dbType =
-                  s['databaseType'] as String? ?? '';
-              final String dbVersion =
-                  s['databaseVersion'] as String? ?? '';
-              final String startTimeStr =
-                  s['startTime'] as String? ?? '';
-              final String appData =
-                  s['appData'] as String? ?? '';
-              final String startupPath =
-                  s['startupPath'] as String? ?? '';
+              final String packageAuthor = s['packageAuthor'] as String? ?? '';
+              final String dbType = s['databaseType'] as String? ?? '';
+              final String dbVersion = s['databaseVersion'] as String? ?? '';
+              final String startTimeStr = s['startTime'] as String? ?? '';
+              final String appData = s['appData'] as String? ?? '';
+              final String startupPath = s['startupPath'] as String? ?? '';
 
               String uptimeText = '';
               if (startTimeStr.isNotEmpty) {
@@ -289,8 +278,7 @@ class _StatusTab extends ConsumerWidget {
                   uptimeText =
                       '${uptime.inDays}d ${uptime.inHours % 24}h ${uptime.inMinutes % 60}m';
                 } else if (uptime.inHours > 0) {
-                  uptimeText =
-                      '${uptime.inHours}h ${uptime.inMinutes % 60}m';
+                  uptimeText = '${uptime.inHours}h ${uptime.inMinutes % 60}m';
                 } else {
                   uptimeText = '${uptime.inMinutes}m';
                 }
@@ -383,8 +371,7 @@ class _StatusTab extends ConsumerWidget {
                 children: <Widget>[
                   _sectionHeader(theme, 'Disk Space'),
                   ...disks.map(
-                    (Map<String, dynamic> d) =>
-                        _DiskSpaceCard(disk: d),
+                    (Map<String, dynamic> d) => _DiskSpaceCard(disk: d),
                   ),
                 ],
               );
@@ -547,8 +534,7 @@ class _DiskSpaceCard extends StatelessWidget {
     final int freeSpace = disk['freeSpace'] as int? ?? 0;
     final int totalSpace = disk['totalSpace'] as int? ?? 1;
     final int usedSpace = totalSpace - freeSpace;
-    final double usedPercent =
-        totalSpace > 0 ? usedSpace / totalSpace : 0.0;
+    final double usedPercent = totalSpace > 0 ? usedSpace / totalSpace : 0.0;
 
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -592,17 +578,13 @@ class _DiskSpaceCard extends StatelessWidget {
             const SizedBox(height: Insets.sm),
             ClipRRect(
               borderRadius: BorderRadius.circular(4),
-              child: LinearProgressIndicator(
-                value: usedPercent,
-                minHeight: 8,
-                backgroundColor:
-                    theme.colorScheme.surfaceContainerHighest,
-                valueColor: AlwaysStoppedAnimation<Color>(
-                  usedPercent > 0.9
+              child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
+                  value: usedPercent,
+                  trackColor: theme.colorScheme.surfaceContainerHighest,
+                  activeColor: usedPercent > 0.9
                       ? theme.colorScheme.error
-                      : theme.colorScheme.primary,
-                ),
-              ),
+                      : theme.colorScheme.primary,),
             ),
             const SizedBox(height: Insets.xs),
             Text(
@@ -643,8 +625,7 @@ class _TasksTab extends ConsumerWidget {
     String taskName,
   ) async {
     try {
-      final SonarrApi api =
-          await ref.read(sonarrApiProvider(instance).future);
+      final SonarrApi api = await ref.read(sonarrApiProvider(instance).future);
       await api.runCommand(<String, dynamic>{'name': taskName});
       if (context.mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -674,10 +655,8 @@ class _TasksTab extends ConsumerWidget {
         await ref.read(sonarrTasksProvider(instance).future);
       },
       child: tasksAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> tasks) {
           if (tasks.isEmpty) {
             return const Center(child: Text('No scheduled tasks.'));
@@ -688,24 +667,16 @@ class _TasksTab extends ConsumerWidget {
             itemCount: tasks.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> task = tasks[index];
-              final String name =
-                  task['name'] as String? ?? 'Task';
-              final String taskName =
-                  task['taskName'] as String? ?? '';
-              final int interval =
-                  task['interval'] as int? ?? 0;
-              final String lastExecStr =
-                  task['lastExecution'] as String? ?? '';
-              final String nextExecStr =
-                  task['nextExecution'] as String? ?? '';
-              final String lastDuration =
-                  task['lastDuration'] as String? ?? '';
+              final String name = task['name'] as String? ?? 'Task';
+              final String taskName = task['taskName'] as String? ?? '';
+              final int interval = task['interval'] as int? ?? 0;
+              final String lastExecStr = task['lastExecution'] as String? ?? '';
+              final String nextExecStr = task['nextExecution'] as String? ?? '';
+              final String lastDuration = task['lastDuration'] as String? ?? '';
 
               final String intervalText = _formatInterval(interval);
-              final String lastExecText =
-                  _formatRelativeTime(lastExecStr);
-              final String nextExecText =
-                  _formatRelativeTime(nextExecStr);
+              final String lastExecText = _formatRelativeTime(lastExecStr);
+              final String nextExecText = _formatRelativeTime(nextExecStr);
 
               return Card(
                 margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -748,8 +719,7 @@ class _TasksTab extends ConsumerWidget {
                   trailing: IconButton(
                     icon: const Icon(Icons.play_arrow_outlined),
                     tooltip: 'Run now',
-                    onPressed: () =>
-                        _runTask(context, ref, taskName),
+                    onPressed: () => _runTask(context, ref, taskName),
                   ),
                 ),
               );
@@ -826,10 +796,8 @@ class _UpdatesTab extends ConsumerWidget {
         await ref.read(sonarrUpdatesProvider(instance).future);
       },
       child: updatesAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> updates) {
           if (updates.isEmpty) {
             return const Center(
@@ -863,21 +831,18 @@ class _UpdateCard extends StatelessWidget {
     final String branch = update['branch'] as String? ?? '';
     final bool installed = update['installed'] as bool? ?? false;
     final bool latest = update['latest'] as bool? ?? false;
-    final String releaseDateStr =
-        update['releaseDate'] as String? ?? '';
+    final String releaseDateStr = update['releaseDate'] as String? ?? '';
     final Map<String, dynamic>? changes =
         update['changes'] as Map<String, dynamic>?;
 
-    final List<String> newItems =
-        (changes?['new'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
-    final List<String> fixedItems =
-        (changes?['fixed'] as List<dynamic>?)
-                ?.map((dynamic e) => e as String)
-                .toList() ??
-            <String>[];
+    final List<String> newItems = (changes?['new'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
+    final List<String> fixedItems = (changes?['fixed'] as List<dynamic>?)
+            ?.map((dynamic e) => e as String)
+            .toList() ??
+        <String>[];
 
     String releaseDateText = '';
     if (releaseDateStr.isNotEmpty) {
@@ -891,9 +856,8 @@ class _UpdateCard extends StatelessWidget {
     return Card(
       margin: const EdgeInsets.only(bottom: Insets.md),
       elevation: 0,
-      color: installed
-          ? theme.colorScheme.primaryContainer.withAlpha(50)
-          : null,
+      color:
+          installed ? theme.colorScheme.primaryContainer.withAlpha(50) : null,
       shape: RoundedRectangleBorder(
         side: BorderSide(
           color: installed
@@ -925,23 +889,19 @@ class _UpdateCard extends StatelessWidget {
                       color: theme.colorScheme.onPrimaryContainer,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
                 if (latest && !installed)
                   Chip(
                     label: const Text('Latest'),
-                    backgroundColor:
-                        theme.colorScheme.tertiary.withAlpha(30),
-                    labelStyle:
-                        theme.textTheme.labelSmall?.copyWith(
+                    backgroundColor: theme.colorScheme.tertiary.withAlpha(30),
+                    labelStyle: theme.textTheme.labelSmall?.copyWith(
                       color: theme.colorScheme.tertiary,
                       fontWeight: FontWeight.bold,
                     ),
-                    materialTapTargetSize:
-                        MaterialTapTargetSize.shrinkWrap,
+                    materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
                     visualDensity: VisualDensity.compact,
                     side: BorderSide.none,
                   ),
@@ -1062,12 +1022,14 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final logsAsync = ref.watch(
-      sonarrLogsProvider((
-        widget.instance,
-        page: _currentPage,
-        pageSize: _pageSize,
-        level: _levelFilter,
-      ),),
+      sonarrLogsProvider(
+        (
+          widget.instance,
+          page: _currentPage,
+          pageSize: _pageSize,
+          level: _levelFilter,
+        ),
+      ),
     );
 
     return Column(
@@ -1122,15 +1084,12 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
 
         Expanded(
           child: logsAsync.when(
-            loading: () =>
-                const Center(child: ExpressiveProgressIndicator()),
-            error: (Object err, _) =>
-                Center(child: Text('Error: $err')),
+            loading: () => const Center(child: ExpressiveProgressIndicator()),
+            error: (Object err, _) => Center(child: Text('Error: $err')),
             data: (Map<String, dynamic> data) {
               final List<dynamic> records =
                   data['records'] as List<dynamic>? ?? <dynamic>[];
-              final int totalRecords =
-                  data['totalRecords'] as int? ?? 0;
+              final int totalRecords = data['totalRecords'] as int? ?? 0;
               final int totalPages =
                   (totalRecords / _pageSize).ceil().clamp(1, 9999);
 
@@ -1143,19 +1102,22 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                   Expanded(
                     child: M3RefreshIndicator(
                       onRefresh: () async {
-                        ref.invalidate(sonarrLogsProvider((
-                          widget.instance,
-                          page: _currentPage,
-                          pageSize: _pageSize,
-                          level: _levelFilter,
-                        ),),);
+                        ref.invalidate(
+                          sonarrLogsProvider(
+                            (
+                              widget.instance,
+                              page: _currentPage,
+                              pageSize: _pageSize,
+                              level: _levelFilter,
+                            ),
+                          ),
+                        );
                       },
                       child: ListView.builder(
                         padding:
                             const EdgeInsets.symmetric(horizontal: Insets.md),
                         itemCount: records.length,
-                        itemBuilder:
-                            (BuildContext context, int index) {
+                        itemBuilder: (BuildContext context, int index) {
                           final Map<String, dynamic> log =
                               records[index] as Map<String, dynamic>;
                           return _LogEntryTile(log: log);
@@ -1173,8 +1135,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_left),
                           onPressed: _currentPage > 1
-                              ? () =>
-                                  setState(() => _currentPage--)
+                              ? () => setState(() => _currentPage--)
                               : null,
                         ),
                         Text(
@@ -1184,8 +1145,7 @@ class _LogsTabState extends ConsumerState<_LogsTab> {
                         IconButton(
                           icon: const Icon(Icons.chevron_right),
                           onPressed: _currentPage < totalPages
-                              ? () =>
-                                  setState(() => _currentPage++)
+                              ? () => setState(() => _currentPage++)
                               : null,
                         ),
                       ],
@@ -1317,8 +1277,7 @@ class _LogEntryTile extends StatelessWidget {
                         padding: const EdgeInsets.only(top: 4),
                         child: Text(
                           exception,
-                          style:
-                              theme.textTheme.bodySmall?.copyWith(
+                          style: theme.textTheme.bodySmall?.copyWith(
                             color: theme.colorScheme.error,
                             fontFamily: 'monospace',
                             fontSize: 11,
@@ -1409,10 +1368,8 @@ class _BackupsTab extends ConsumerWidget {
         await ref.read(sonarrBackupsProvider(instance).future);
       },
       child: backupsAsync.when(
-        loading: () =>
-            const Center(child: ExpressiveProgressIndicator()),
-        error: (Object err, _) =>
-            Center(child: Text('Error: $err')),
+        loading: () => const Center(child: ExpressiveProgressIndicator()),
+        error: (Object err, _) => Center(child: Text('Error: $err')),
         data: (List<Map<String, dynamic>> backups) {
           if (backups.isEmpty) {
             return const Center(child: Text('No backups found.'));
@@ -1423,14 +1380,11 @@ class _BackupsTab extends ConsumerWidget {
             itemCount: backups.length,
             itemBuilder: (BuildContext context, int index) {
               final Map<String, dynamic> backup = backups[index];
-              final String name =
-                  backup['name'] as String? ?? 'Backup';
-              final String type =
-                  backup['type'] as String? ?? 'unknown';
+              final String name = backup['name'] as String? ?? 'Backup';
+              final String type = backup['type'] as String? ?? 'unknown';
               final int size = backup['size'] as int? ?? 0;
               final int id = backup['id'] as int? ?? 0;
-              final String timeStr =
-                  backup['time'] as String? ?? '';
+              final String timeStr = backup['time'] as String? ?? '';
 
               String dateText = '';
               if (timeStr.isNotEmpty) {
@@ -1465,8 +1419,7 @@ class _BackupsTab extends ConsumerWidget {
                 ),
                 child: ListTile(
                   leading: CircleAvatar(
-                    backgroundColor:
-                        theme.colorScheme.surfaceContainerHighest,
+                    backgroundColor: theme.colorScheme.surfaceContainerHighest,
                     child: Icon(
                       typeIcon,
                       color: theme.colorScheme.onSurfaceVariant,
@@ -1491,8 +1444,7 @@ class _BackupsTab extends ConsumerWidget {
                       Icons.delete_outline,
                       color: theme.colorScheme.error,
                     ),
-                    onPressed: () =>
-                        _deleteBackup(context, ref, id, name),
+                    onPressed: () => _deleteBackup(context, ref, id, name),
                   ),
                 ),
               );

--- a/services/service_sonarr/lib/src/series_detail_screen.dart
+++ b/services/service_sonarr/lib/src/series_detail_screen.dart
@@ -4,6 +4,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'home/sonarr_rename_dialog.dart';
 import 'models/sonarr_episode.dart';
@@ -85,7 +86,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
   }
 
   void _invalidateProviders() {
-    ref.invalidate(sonarrSeriesByIdProvider((widget.instance, widget.series.id)));
+    ref.invalidate(
+        sonarrSeriesByIdProvider((widget.instance, widget.series.id)),);
     ref.invalidate(sonarrEpisodesProvider((widget.instance, widget.series.id)));
     ref.invalidate(sonarrSeriesProvider(widget.instance));
   }
@@ -118,7 +120,9 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
             builder: (BuildContext context, constraints) {
               const double expandedHeight = 250.0;
               final double scrollOffset = constraints.scrollOffset;
-              final double progress = (scrollOffset / (expandedHeight - kToolbarHeight)).clamp(0.0, 1.0);
+              final double progress =
+                  (scrollOffset / (expandedHeight - kToolbarHeight))
+                      .clamp(0.0, 1.0);
 
               // The expanded title sits over the backdrop's bottom band, which
               // the scrim fades to opaque cs.surface (a light surface with no
@@ -128,7 +132,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
               // white->onSurface lerp because their 0.35-alpha bubbles plus the
               // top scrim back them over the image when expanded.
               final Color titleColor = cs.onSurface;
-              final Color iconColor = Color.lerp(Colors.white, cs.onSurface, progress)!;
+              final Color iconColor =
+                  Color.lerp(Colors.white, cs.onSurface, progress)!;
               final double bubbleOpacity = 1.0 - progress;
 
               return SliverAppBar(
@@ -143,7 +148,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                     height: 38,
                     decoration: BoxDecoration(
                       shape: BoxShape.circle,
-                      color: Colors.black.withValues(alpha: 0.35 * bubbleOpacity),
+                      color:
+                          Colors.black.withValues(alpha: 0.35 * bubbleOpacity),
                     ),
                     child: IconButton(
                       icon: Icon(Icons.arrow_back, size: 20, color: iconColor),
@@ -160,7 +166,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                       margin: const EdgeInsets.only(right: 16),
                       decoration: BoxDecoration(
                         shape: BoxShape.circle,
-                        color: Colors.black.withValues(alpha: 0.35 * bubbleOpacity),
+                        color: Colors.black
+                            .withValues(alpha: 0.35 * bubbleOpacity),
                       ),
                       child: _OverflowMenu(
                         instance: widget.instance,
@@ -282,7 +289,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                   data: (List<SonarrEpisode> episodes) {
                     final Map<int, List<SonarrEpisode>> episodesBySeason =
                         groupBy(episodes, (e) => e.seasonNumber);
-                    final List<int> sortedSeasons = episodesBySeason.keys.toList()
+                    final List<int> sortedSeasons = episodesBySeason.keys
+                        .toList()
                       ..sort((a, b) => b.compareTo(a)); // newest first
 
                     for (final seasonNum in sortedSeasons) {
@@ -293,39 +301,48 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                       if (sortedSeasons.isNotEmpty) ...[
                         SingleChildScrollView(
                           scrollDirection: Axis.horizontal,
-                          padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+                          padding:
+                              const EdgeInsets.symmetric(vertical: Insets.xs),
                           child: Row(
                             children: [
                               ActionChip(
                                 label: const Text('All'),
                                 onPressed: () {
-                                  if (_seasonsHeaderKey.currentContext != null) {
+                                  if (_seasonsHeaderKey.currentContext !=
+                                      null) {
                                     Scrollable.ensureVisible(
                                       _seasonsHeaderKey.currentContext!,
-                                      duration: const Duration(milliseconds: 500),
+                                      duration:
+                                          const Duration(milliseconds: 500),
                                       curve: Curves.easeInOut,
                                     );
                                   }
                                 },
                               ),
                               ...sortedSeasons.map((seasonNum) {
-                                final label = seasonNum == 0 ? 'Specials' : 'Season $seasonNum';
+                                final label = seasonNum == 0
+                                    ? 'Specials'
+                                    : 'Season $seasonNum';
                                 return Padding(
-                                  padding: const EdgeInsets.only(left: Insets.xs),
+                                  padding:
+                                      const EdgeInsets.only(left: Insets.xs),
                                   child: ActionChip(
                                     label: Text(label),
                                     onPressed: () {
-                                      if (!_expandedSeasons.contains(seasonNum)) {
+                                      if (!_expandedSeasons
+                                          .contains(seasonNum)) {
                                         setState(() {
                                           _expandedSeasons.add(seasonNum);
                                         });
                                       }
-                                      WidgetsBinding.instance.addPostFrameCallback((_) {
+                                      WidgetsBinding.instance
+                                          .addPostFrameCallback((_) {
                                         final key = _seasonKeys[seasonNum];
                                         if (key?.currentContext != null) {
                                           Scrollable.ensureVisible(
                                             key!.currentContext!,
-                                            duration: const Duration(milliseconds: 500),
+                                            duration: const Duration(
+                                                milliseconds: 500,),
                                             curve: Curves.easeInOut,
                                           );
                                         }
@@ -340,7 +357,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                         const SizedBox(height: Insets.md),
                       ],
                       Column(
-                        children: _buildSeasonCards(context, episodesBySeason, sortedSeasons),
+                        children: _buildSeasonCards(
+                            context, episodesBySeason, sortedSeasons,),
                       ),
                     ];
                   },
@@ -369,7 +387,8 @@ class _SeriesDetailBodyState extends ConsumerState<_SeriesDetailBody> {
                             const SizedBox(height: Insets.sm),
                             FilledButton.tonal(
                               onPressed: () => ref.invalidate(
-                                sonarrEpisodesProvider((widget.instance, widget.series.id)),
+                                sonarrEpisodesProvider(
+                                    (widget.instance, widget.series.id),),
                               ),
                               child: const Text('Retry'),
                             ),
@@ -601,14 +620,11 @@ class _StatsCard extends StatelessWidget {
           const SizedBox(height: Insets.md),
           ClipRRect(
             borderRadius: BorderRadius.circular(Radii.sm),
-            child: LinearProgressIndicator(
-              value: progress,
-              minHeight: 8,
-              backgroundColor: cs.surfaceContainerHighest,
-              valueColor: AlwaysStoppedAnimation<Color>(
-                progress >= 1.0 ? cs.tertiary : cs.primary,
-              ),
-            ),
+            child: LinearProgressIndicatorM3E(
+                shape: ProgressM3EShape.flat,
+                value: progress,
+                trackColor: cs.surfaceContainerHighest,
+                activeColor: progress >= 1.0 ? cs.tertiary : cs.primary,),
           ),
         ],
       ),
@@ -699,9 +715,7 @@ class _ActionsRow extends ConsumerWidget {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text(
-              !series.monitored
-                  ? 'Series monitored.'
-                  : 'Series unmonitored.',
+              !series.monitored ? 'Series monitored.' : 'Series unmonitored.',
             ),
           ),
         );
@@ -962,9 +976,8 @@ class _SeasonCard extends ConsumerWidget {
         .where((e) => e.hasFile)
         .map((e) => (e.episodeFile?['size'] as num?)?.toDouble() ?? 0.0)
         .sum;
-    final String seasonSizeStr = seasonSizeBytes > 0
-        ? ' • ${_formatSize(seasonSizeBytes.toInt())}'
-        : '';
+    final String seasonSizeStr =
+        seasonSizeBytes > 0 ? ' • ${_formatSize(seasonSizeBytes.toInt())}' : '';
 
     return AnimatedContainer(
       duration: const Duration(milliseconds: 200),
@@ -998,8 +1011,10 @@ class _SeasonCard extends ConsumerWidget {
                       size: 18,
                       color: isMonitored ? cs.primary : cs.outline,
                     ),
-                    tooltip: isMonitored ? 'Unmonitor Season' : 'Monitor Season',
-                    onPressed: () => _toggleSeasonMonitoring(context, ref, isMonitored),
+                    tooltip:
+                        isMonitored ? 'Unmonitor Season' : 'Monitor Season',
+                    onPressed: () =>
+                        _toggleSeasonMonitoring(context, ref, isMonitored),
                     visualDensity: VisualDensity.compact,
                     padding: EdgeInsets.zero,
                     constraints: const BoxConstraints(
@@ -1028,14 +1043,13 @@ class _SeasonCard extends ConsumerWidget {
                             Expanded(
                               child: ClipRRect(
                                 borderRadius: BorderRadius.circular(4),
-                                child: LinearProgressIndicator(
-                                  value: progress,
-                                  minHeight: 4,
-                                  backgroundColor: cs.surfaceContainerHighest,
-                                  valueColor: AlwaysStoppedAnimation<Color>(
-                                    progress >= 1.0 ? cs.tertiary : cs.primary,
-                                  ),
-                                ),
+                                child: LinearProgressIndicatorM3E(
+                                    shape: ProgressM3EShape.flat,
+                                    value: progress,
+                                    trackColor: cs.surfaceContainerHighest,
+                                    activeColor: progress >= 1.0
+                                        ? cs.tertiary
+                                        : cs.primary,),
                               ),
                             ),
                             const SizedBox(width: Insets.sm),
@@ -1107,14 +1121,16 @@ class _SeasonCard extends ConsumerWidget {
                         const SizedBox(width: Insets.xs),
                         Expanded(
                           child: TextButton.icon(
-                            icon: Icon(Icons.delete_outline, color: cs.error, size: 16),
+                            icon: Icon(Icons.delete_outline,
+                                color: cs.error, size: 16,),
                             label: Text(
                               'Delete',
                               style: TextStyle(color: cs.error, fontSize: 12),
                               maxLines: 1,
                               overflow: TextOverflow.ellipsis,
                             ),
-                            onPressed: () => _confirmDeleteSeasonFiles(context, ref),
+                            onPressed: () =>
+                                _confirmDeleteSeasonFiles(context, ref),
                           ),
                         ),
                       ],
@@ -1144,11 +1160,12 @@ class _SeasonCard extends ConsumerWidget {
     );
   }
 
-  Future<void> _toggleSeasonMonitoring(BuildContext context, WidgetRef ref, bool currentMonitored) async {
+  Future<void> _toggleSeasonMonitoring(
+      BuildContext context, WidgetRef ref, bool currentMonitored,) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       final raw = await api.getSeriesRaw(series.id);
-      
+
       final List<dynamic> seasons = raw['seasons'] as List<dynamic>;
       for (final dynamic s in seasons) {
         final Map<String, dynamic> season = s as Map<String, dynamic>;
@@ -1157,7 +1174,7 @@ class _SeasonCard extends ConsumerWidget {
           break;
         }
       }
-      
+
       await api.updateSeriesRaw(raw);
 
       if (!context.mounted) return;
@@ -1183,7 +1200,8 @@ class _SeasonCard extends ConsumerWidget {
     }
   }
 
-  Future<void> _confirmDeleteSeasonFiles(BuildContext context, WidgetRef ref) async {
+  Future<void> _confirmDeleteSeasonFiles(
+      BuildContext context, WidgetRef ref,) async {
     final theme = Theme.of(context);
     final confirm = await showDialog<bool>(
       context: context,
@@ -1211,7 +1229,7 @@ class _SeasonCard extends ConsumerWidget {
 
     if (confirm == true) {
       if (!context.mounted) return;
-      
+
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
           content: Text('Deleting season files...'),
@@ -1255,7 +1273,8 @@ class _SeasonCard extends ConsumerWidget {
       if (context.mounted) {
         if (failedCount == 0) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Successfully deleted $deletedCount file(s).')),
+            SnackBar(
+                content: Text('Successfully deleted $deletedCount file(s).'),),
           );
         } else {
           ScaffoldMessenger.of(context).showSnackBar(
@@ -1270,7 +1289,8 @@ class _SeasonCard extends ConsumerWidget {
     }
   }
 
-  Future<void> _searchSeason(BuildContext context, WidgetRef ref, int seasonNum) async {
+  Future<void> _searchSeason(
+      BuildContext context, WidgetRef ref, int seasonNum,) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       await api.runCommand(<String, dynamic>{
@@ -1319,7 +1339,8 @@ class _EpisodeRow extends ConsumerWidget {
   final SonarrSeries series;
   final SonarrEpisode episode;
 
-  Future<void> _toggleEpisodeMonitored(BuildContext context, WidgetRef ref) async {
+  Future<void> _toggleEpisodeMonitored(
+      BuildContext context, WidgetRef ref,) async {
     try {
       final api = await ref.read(sonarrApiProvider(instance).future);
       final updated = episode.copyWith(monitored: !episode.monitored);
@@ -1374,8 +1395,10 @@ class _EpisodeRow extends ConsumerWidget {
     }
 
     final Map<String, dynamic>? fileMap = episode.episodeFile;
-    final Map<String, dynamic>? qualityObj = fileMap?['quality'] as Map<String, dynamic>?;
-    final Map<String, dynamic>? qualityInner = qualityObj?['quality'] as Map<String, dynamic>?;
+    final Map<String, dynamic>? qualityObj =
+        fileMap?['quality'] as Map<String, dynamic>?;
+    final Map<String, dynamic>? qualityInner =
+        qualityObj?['quality'] as Map<String, dynamic>?;
     final String? quality = qualityInner?['name'] as String?;
     final int? sizeBytes = fileMap?['size'] as int?;
     final String? sizeStr = sizeBytes != null ? _formatSize(sizeBytes) : null;
@@ -1477,8 +1500,10 @@ void _showEpisodeBottomSheet({
   final ColorScheme cs = theme.colorScheme;
 
   final Map<String, dynamic>? fileMap = episode.episodeFile;
-  final Map<String, dynamic>? qualityObj = fileMap?['quality'] as Map<String, dynamic>?;
-  final Map<String, dynamic>? qualityInner = qualityObj?['quality'] as Map<String, dynamic>?;
+  final Map<String, dynamic>? qualityObj =
+      fileMap?['quality'] as Map<String, dynamic>?;
+  final Map<String, dynamic>? qualityInner =
+      qualityObj?['quality'] as Map<String, dynamic>?;
   final String? quality = qualityInner?['name'] as String?;
   final int? sizeBytes = fileMap?['size'] as int?;
   final String? sizeStr = sizeBytes != null ? _formatSize(sizeBytes) : null;
@@ -1491,208 +1516,232 @@ void _showEpisodeBottomSheet({
       return SafeArea(
         child: SingleChildScrollView(
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(Insets.lg, 0, Insets.lg, Insets.lg),
+            padding:
+                const EdgeInsets.fromLTRB(Insets.lg, 0, Insets.lg, Insets.lg),
             child: Column(
               mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-              // Title / Header
-              Text(
-                'Season ${episode.seasonNumber}, Episode ${episode.episodeNumber}',
-                style: theme.textTheme.labelSmall?.copyWith(color: cs.outline),
-              ),
-              const SizedBox(height: Insets.xs),
-              Text(
-                episode.title,
-                style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: Insets.sm),
-
-              // Air date + File size / Quality row
-              Wrap(
-                spacing: Insets.xs,
-                runSpacing: Insets.xs,
-                children: <Widget>[
-                  if (episode.airDate != null)
-                    _MetaChip(label: 'Aired: ${episode.airDate}'),
-                  if (quality != null) _MetaChip(label: quality),
-                  if (sizeStr != null) _MetaChip(label: sizeStr),
-                  _MetaChip(
-                    label: episode.monitored ? 'Monitored' : 'Unmonitored',
-                  ),
-                ],
-              ),
-              const SizedBox(height: Insets.md),
-
-              // Synopsis / Overview
-              Text(
-                'Overview',
-                style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: Insets.xs),
-              Text(
-                episode.overview != null && episode.overview!.isNotEmpty
-                    ? episode.overview!
-                    : 'No overview available.',
-                style: theme.textTheme.bodyMedium?.copyWith(color: cs.onSurfaceVariant),
-              ),
-              const SizedBox(height: Insets.md),
-
-              // File Path (if downloaded)
-              if (relativePath != null) ...[
+                // Title / Header
                 Text(
-                  'Path',
-                  style: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.bold),
+                  'Season ${episode.seasonNumber}, Episode ${episode.episodeNumber}',
+                  style:
+                      theme.textTheme.labelSmall?.copyWith(color: cs.outline),
                 ),
                 const SizedBox(height: Insets.xs),
                 Text(
-                  relativePath,
-                  style: theme.textTheme.bodySmall?.copyWith(color: cs.outline),
+                  episode.title,
+                  style: theme.textTheme.titleMedium
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: Insets.sm),
+
+                // Air date + File size / Quality row
+                Wrap(
+                  spacing: Insets.xs,
+                  runSpacing: Insets.xs,
+                  children: <Widget>[
+                    if (episode.airDate != null)
+                      _MetaChip(label: 'Aired: ${episode.airDate}'),
+                    if (quality != null) _MetaChip(label: quality),
+                    if (sizeStr != null) _MetaChip(label: sizeStr),
+                    _MetaChip(
+                      label: episode.monitored ? 'Monitored' : 'Unmonitored',
+                    ),
+                  ],
                 ),
                 const SizedBox(height: Insets.md),
-              ],
 
-              // Action buttons
-              Row(
-                children: <Widget>[
-                  // Monitor/Unmonitor Toggle
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      icon: Icon(
-                        episode.monitored ? Icons.bookmark : Icons.bookmark_border,
-                        size: 18,
-                      ),
-                      label: Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        try {
-                          final api = await ref.read(sonarrApiProvider(instance).future);
-                          final updated = episode.copyWith(monitored: !episode.monitored);
-                          await api.updateEpisode(updated.toJson());
-                          ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
-                        } catch (e) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('Failed: $e')),
-                            );
-                          }
-                        }
-                      },
-                    ),
+                // Synopsis / Overview
+                Text(
+                  'Overview',
+                  style: theme.textTheme.titleSmall
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: Insets.xs),
+                Text(
+                  episode.overview != null && episode.overview!.isNotEmpty
+                      ? episode.overview!
+                      : 'No overview available.',
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                ),
+                const SizedBox(height: Insets.md),
+
+                // File Path (if downloaded)
+                if (relativePath != null) ...[
+                  Text(
+                    'Path',
+                    style: theme.textTheme.titleSmall
+                        ?.copyWith(fontWeight: FontWeight.bold),
                   ),
+                  const SizedBox(height: Insets.xs),
+                  Text(
+                    relativePath,
+                    style:
+                        theme.textTheme.bodySmall?.copyWith(color: cs.outline),
+                  ),
+                  const SizedBox(height: Insets.md),
                 ],
-              ),
-              const SizedBox(height: Insets.sm),
-              Row(
-                children: <Widget>[
-                  // Automatic Search
-                  Expanded(
-                    child: FilledButton.icon(
-                      icon: const Icon(Icons.search, size: 18),
-                      label: const Text('Auto Search'),
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        try {
-                          final api = await ref.read(sonarrApiProvider(instance).future);
-                          await api.runCommand(<String, dynamic>{
-                            'name': 'EpisodeSearch',
-                            'episodeIds': <int>[episode.id],
-                          });
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              const SnackBar(content: Text('Search queued for episode.')),
-                            );
-                          }
-                        } catch (e) {
-                          if (context.mounted) {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                              SnackBar(content: Text('Failed to queue search: $e')),
-                            );
-                          }
-                        }
-                      },
-                    ),
-                  ),
-                  const SizedBox(width: Insets.sm),
 
-                  // Interactive Search
-                  Expanded(
-                    child: OutlinedButton.icon(
-                      icon: const Icon(Icons.person_search, size: 18),
-                      label: const Text('Interactive'),
-                      onPressed: () {
-                        Navigator.pop(context);
-                        pushScreen<void>(
-                          context,
-                          SonarrReleaseSearchScreen(
-                            instance: instance,
-                            episode: episode,
-                          ),
-                        );
-                      },
-                    ),
-                  ),
-
-                  // Delete file (if has file)
-                  if (episode.hasFile && episode.episodeFileId != null) ...[
-                    const SizedBox(width: Insets.sm),
-                    IconButton.filledTonal(
-                      icon: Icon(Icons.delete_outline, color: cs.error),
-                      onPressed: () async {
-                        Navigator.pop(context);
-                        final confirm = await showDialog<bool>(
-                          context: context,
-                          builder: (context) => AlertDialog(
-                            title: const Text('Delete Episode File'),
-                            content: const Text(
-                              'Are you sure? This will delete the file from disk and cannot be undone.',
-                            ),
-                            actions: <Widget>[
-                              TextButton(
-                                onPressed: () => Navigator.pop(context, false),
-                                  child: const Text('Cancel'),
-                              ),
-                              FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor: cs.error,
-                                  foregroundColor: cs.onError,
-                                ),
-                                onPressed: () => Navigator.pop(context, true),
-                                child: const Text('Delete'),
-                              ),
-                            ],
-                          ),
-                        );
-
-                        if (confirm == true) {
+                // Action buttons
+                Row(
+                  children: <Widget>[
+                    // Monitor/Unmonitor Toggle
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        icon: Icon(
+                          episode.monitored
+                              ? Icons.bookmark
+                              : Icons.bookmark_border,
+                          size: 18,
+                        ),
+                        label:
+                            Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
+                        onPressed: () async {
+                          Navigator.pop(context);
                           try {
-                            final api = await ref.read(sonarrApiProvider(instance).future);
-                            await api.deleteEpisodeFile(episode.episodeFileId!);
-                            ref.invalidate(sonarrEpisodesProvider((instance, series.id)));
+                            final api = await ref
+                                .read(sonarrApiProvider(instance).future);
+                            final updated =
+                                episode.copyWith(monitored: !episode.monitored);
+                            await api.updateEpisode(updated.toJson());
+                            ref.invalidate(
+                                sonarrEpisodesProvider((instance, series.id)),);
+                          } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('File deleted.')),
+                                SnackBar(content: Text('Failed: $e')),
+                              );
+                            }
+                          }
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: Insets.sm),
+                Row(
+                  children: <Widget>[
+                    // Automatic Search
+                    Expanded(
+                      child: FilledButton.icon(
+                        icon: const Icon(Icons.search, size: 18),
+                        label: const Text('Auto Search'),
+                        onPressed: () async {
+                          Navigator.pop(context);
+                          try {
+                            final api = await ref
+                                .read(sonarrApiProvider(instance).future);
+                            await api.runCommand(<String, dynamic>{
+                              'name': 'EpisodeSearch',
+                              'episodeIds': <int>[episode.id],
+                            });
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content:
+                                        Text('Search queued for episode.'),),
                               );
                             }
                           } catch (e) {
                             if (context.mounted) {
                               ScaffoldMessenger.of(context).showSnackBar(
-                                SnackBar(content: Text('Failed to delete: $e')),
+                                SnackBar(
+                                    content:
+                                        Text('Failed to queue search: $e'),),
                               );
                             }
                           }
-                        }
-                      },
+                        },
+                      ),
                     ),
+                    const SizedBox(width: Insets.sm),
+
+                    // Interactive Search
+                    Expanded(
+                      child: OutlinedButton.icon(
+                        icon: const Icon(Icons.person_search, size: 18),
+                        label: const Text('Interactive'),
+                        onPressed: () {
+                          Navigator.pop(context);
+                          pushScreen<void>(
+                            context,
+                            SonarrReleaseSearchScreen(
+                              instance: instance,
+                              episode: episode,
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+
+                    // Delete file (if has file)
+                    if (episode.hasFile && episode.episodeFileId != null) ...[
+                      const SizedBox(width: Insets.sm),
+                      IconButton.filledTonal(
+                        icon: Icon(Icons.delete_outline, color: cs.error),
+                        onPressed: () async {
+                          Navigator.pop(context);
+                          final confirm = await showDialog<bool>(
+                            context: context,
+                            builder: (context) => AlertDialog(
+                              title: const Text('Delete Episode File'),
+                              content: const Text(
+                                'Are you sure? This will delete the file from disk and cannot be undone.',
+                              ),
+                              actions: <Widget>[
+                                TextButton(
+                                  onPressed: () =>
+                                      Navigator.pop(context, false),
+                                  child: const Text('Cancel'),
+                                ),
+                                FilledButton(
+                                  style: FilledButton.styleFrom(
+                                    backgroundColor: cs.error,
+                                    foregroundColor: cs.onError,
+                                  ),
+                                  onPressed: () => Navigator.pop(context, true),
+                                  child: const Text('Delete'),
+                                ),
+                              ],
+                            ),
+                          );
+
+                          if (confirm == true) {
+                            try {
+                              final api = await ref
+                                  .read(sonarrApiProvider(instance).future);
+                              await api
+                                  .deleteEpisodeFile(episode.episodeFileId!);
+                              ref.invalidate(sonarrEpisodesProvider(
+                                  (instance, series.id),),);
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text('File deleted.'),),
+                                );
+                              }
+                            } catch (e) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                      content: Text('Failed to delete: $e'),),
+                                );
+                              }
+                            }
+                          }
+                        },
+                      ),
+                    ],
                   ],
-                ],
-              ),
-            ],
+                ),
+              ],
+            ),
           ),
         ),
-      ),
-    );
-  },
+      );
+    },
   );
 }
 
@@ -1947,7 +1996,8 @@ void _showMonitorSeriesDialog({
                 onPressed: () async {
                   Navigator.of(context).pop();
                   try {
-                    final api = await ref.read(sonarrApiProvider(instance).future);
+                    final api =
+                        await ref.read(sonarrApiProvider(instance).future);
                     await api.updateSeasonPass(
                       seriesIds: [series.id],
                       monitorType: selectedType,
@@ -1967,7 +2017,8 @@ void _showMonitorSeriesDialog({
                   } catch (e) {
                     if (context.mounted) {
                       ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(content: Text('Failed to update monitoring: $e')),
+                        SnackBar(
+                            content: Text('Failed to update monitoring: $e'),),
                       );
                     }
                   }
@@ -2022,7 +2073,8 @@ class _StatusPill extends StatelessWidget {
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final bool isContinuing = status?.toLowerCase() == 'continuing';
-    final Color tint = isContinuing ? theme.colorScheme.tertiary : theme.colorScheme.outline;
+    final Color tint =
+        isContinuing ? theme.colorScheme.tertiary : theme.colorScheme.outline;
     final String label = status ?? 'Unknown';
 
     return Container(

--- a/services/service_sonarr/lib/src/sonarr_add_series_sheet.dart
+++ b/services/service_sonarr/lib/src/sonarr_add_series_sheet.dart
@@ -4,6 +4,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/sonarr_series.dart';
 import 'sonarr_api.dart';
@@ -196,7 +197,9 @@ class _SonarrAddSeriesSheetState extends ConsumerState<SonarrAddSeriesSheet> {
                                   },
                                 );
                               },
-                              loading: () => const LinearProgressIndicator(),
+                              loading: () => const LinearProgressIndicatorM3E(
+                                shape: ProgressM3EShape.flat,
+                              ),
                               error: (e, s) =>
                                   Text('Error loading folders: $e'),
                             ),
@@ -467,7 +470,8 @@ class _SonarrAddSeriesSheetState extends ConsumerState<SonarrAddSeriesSheet> {
     if (_selectedRootFolder == null || _selectedQualityProfileId == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
-          content: const Text('Please select a root folder and quality profile.'),
+          content:
+              const Text('Please select a root folder and quality profile.'),
           backgroundColor: Theme.of(context).colorScheme.error,
         ),
       );

--- a/services/service_sonarr/pubspec.yaml
+++ b/services/service_sonarr/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
+  progress_indicator_m3e:
   url_launcher: ^6.3.2
 
 dev_dependencies:

--- a/services/service_tautulli/lib/src/tautulli_home.dart
+++ b/services/service_tautulli/lib/src/tautulli_home.dart
@@ -7,6 +7,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:intl/intl.dart';
+import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
 import 'models/tautulli_activity.dart';
 import 'models/tautulli_models.dart';
@@ -194,8 +195,8 @@ class _StatTile extends StatelessWidget {
           value,
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
-          style: theme.textTheme.titleLarge
-              ?.copyWith(fontWeight: FontWeight.w700),
+          style:
+              theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.w700),
         ),
         const SizedBox(height: 2),
         Text(
@@ -332,8 +333,8 @@ class _SessionCard extends StatelessWidget {
                                       session.friendlyName,
                                       maxLines: 1,
                                       overflow: TextOverflow.ellipsis,
-                                      style: theme.textTheme.labelMedium
-                                          ?.copyWith(
+                                      style:
+                                          theme.textTheme.labelMedium?.copyWith(
                                         color: Colors.white,
                                         fontWeight: FontWeight.w600,
                                       ),
@@ -401,13 +402,13 @@ class _SessionCard extends StatelessWidget {
                 bottom: 0,
                 left: 0,
                 right: 0,
-                child: LinearProgressIndicator(
+                child: LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
                   value: pct.clamp(0, 1),
-                  minHeight: 5,
-                  color: playing
+                  activeColor: playing
                       ? theme.colorScheme.primary
                       : theme.colorScheme.outline,
-                  backgroundColor: Colors.white.withValues(alpha: 0.15),
+                  trackColor: Colors.white.withValues(alpha: 0.15),
                 ),
               ),
             ],
@@ -510,14 +511,16 @@ class _SessionSheetState extends ConsumerState<_SessionSheet> {
             Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                _Poster(url: api?.imageUrl(s.posterThumb), width: 64, height: 96),
+                _Poster(
+                    url: api?.imageUrl(s.posterThumb), width: 64, height: 96,),
                 const SizedBox(width: Insets.md),
                 Expanded(
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
                       Text(s.fullTitle, style: theme.textTheme.titleMedium),
-                      if (s.episodeLabel.isNotEmpty || s.year.isNotEmpty) ...<Widget>[
+                      if (s.episodeLabel.isNotEmpty ||
+                          s.year.isNotEmpty) ...<Widget>[
                         const SizedBox(height: Insets.xs),
                         Text(
                           <String>[
@@ -862,9 +865,8 @@ class _StatsTab extends ConsumerWidget {
         value: stats,
         onRetry: () => ref.invalidate(tautulliHomeStatsProvider(instance)),
         data: (List<TautulliHomeStat> all) {
-          final List<TautulliHomeStat> sections = all
-              .where((TautulliHomeStat s) => s.rows.isNotEmpty)
-              .toList();
+          final List<TautulliHomeStat> sections =
+              all.where((TautulliHomeStat s) => s.rows.isNotEmpty).toList();
           if (sections.isEmpty) {
             return const EmptyView(
               icon: Icons.bar_chart,
@@ -976,10 +978,10 @@ class _StatSection extends StatelessWidget {
                             const SizedBox(height: 4),
                             ClipRRect(
                               borderRadius: BorderRadius.circular(8),
-                              child: LinearProgressIndicator(
+                              child: LinearProgressIndicatorM3E(
+                                shape: ProgressM3EShape.flat,
                                 value: (metric(row) / maxMetric).clamp(0, 1),
-                                minHeight: 6,
-                                backgroundColor:
+                                trackColor:
                                     theme.colorScheme.surfaceContainerHighest,
                               ),
                             ),
@@ -1041,8 +1043,11 @@ class _StatLeading extends StatelessWidget {
       return CircleAvatar(
         radius: 17,
         backgroundColor: theme.colorScheme.surfaceContainerHighest,
-        child: Icon(Icons.devices_outlined,
-            size: 18, color: theme.colorScheme.onSurfaceVariant,),
+        child: Icon(
+          Icons.devices_outlined,
+          size: 18,
+          color: theme.colorScheme.onSurfaceVariant,
+        ),
       );
     }
     return _Poster(url: api?.imageUrl(row.posterThumb), width: 34, height: 51);

--- a/services/service_tautulli/pubspec.yaml
+++ b/services/service_tautulli/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
+  progress_indicator_m3e:
 
 dev_dependencies:
   build_runner: ^2.4.13


### PR DESCRIPTION
Reviewed and cleaned extraction of the substantive work from #34, without the repo-wide reformat.

## Changes
- **Streams widget**: full-bleed backdrop banners tinted from a palette extracted off the session artwork (wired to the existing palette_generator_plus, so no extra palette dependency).
- **M3 Expressive progress indicators**: the stock spinners and bars are swapped for the M3E variants across the qBittorrent, Sonarr, Radarr, Emby, Jellyfin, Plex, Tautulli and SABnzbd screens (progress_indicator_m3e added, sorted, to each service).
- **Circular progress fix**: the fork no longer clips the arc at a value of 0.0 or 1.0.

## Dropped from #34
- The whole-repo dart format reflow (only the ~30 files that are actually part of the feature are touched).
- A redundant palette_generator dependency (palette_generator_plus is already present).
- An unrelated activity-card poster change that had leaked into a swap file.

Authored to lxBlazarxl.

## Testing
- flutter analyze: No issues found
- app test suite: 52 tests pass
- Built and installed on device (build 4114)