### PR TITLE
Calendar list view and sidebar service reorder

### DIFF
--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -42,7 +42,8 @@ class RadarrCalendarEvent extends CalendarEvent {
   @override
   DateTime get date {
     final DateTime start = DateTime(month.year, month.month, 1);
-    final DateTime end = DateTime(month.year, month.month + 1, 1).subtract(const Duration(seconds: 1));
+    final DateTime end = DateTime(month.year, month.month + 1, 1)
+        .subtract(const Duration(seconds: 1));
 
     final DateTime? digital = _parseDate(movie.digitalRelease);
     if (digital != null && digital.isAfter(start) && digital.isBefore(end)) {
@@ -73,8 +74,7 @@ class RadarrCalendarEvent extends CalendarEvent {
   String get primaryTitle => movie.title;
 
   @override
-  String get subtitle =>
-      movie.year == null ? 'Movie' : '${movie.year} - Movie';
+  String get subtitle => movie.year == null ? 'Movie' : '${movie.year} - Movie';
 
   @override
   String? get posterUrl => _image('poster');
@@ -136,7 +136,6 @@ class SonarrCalendarEvent extends CalendarEvent {
       ?.remoteUrl;
 }
 
-
 /// Aggregated calendar provider for all active Sonarr and Radarr instances.
 final globalCalendarProvider =
     FutureProvider.autoDispose.family<List<CalendarEvent>, DateTime>((
@@ -144,30 +143,64 @@ final globalCalendarProvider =
   DateTime month,
 ) async {
   final List<Instance> instances = ref.watch(activeInstancesProvider);
-  final List<Future<List<CalendarEvent>>> futures = [];
+  final List<CalendarEvent> allEvents = [];
+  final List<Future<void>> futures = [];
 
   for (final Instance instance in instances) {
     if (instance.kind == ServiceKind.radarr) {
-      futures.add(
-        ref.watch(radarrCalendarProvider((instance, month)).future).then(
-              (List<RadarrMovie> movies) => movies
-                  .map((RadarrMovie m) => RadarrCalendarEvent(m, instance, month))
-                  .toList(),
-            ),
-      );
+      final AsyncValue<List<RadarrMovie>> state =
+          ref.watch(radarrCalendarProvider((instance, month)));
+
+      if (state is AsyncLoading) {
+        futures.add(
+          ref
+              .read(radarrCalendarProvider((instance, month)).future)
+              .then((List<RadarrMovie> movies) {
+            allEvents.addAll(
+              movies.map(
+                  (RadarrMovie m) => RadarrCalendarEvent(m, instance, month)),
+            );
+          }).catchError((Object e) {
+            // Ignore error
+          }),
+        );
+      } else if (state is AsyncData<List<RadarrMovie>>) {
+        allEvents.addAll(
+          state.value
+              .map((RadarrMovie m) => RadarrCalendarEvent(m, instance, month)),
+        );
+      }
     } else if (instance.kind == ServiceKind.sonarr) {
-      futures.add(
-        ref.watch(sonarrCalendarProvider((instance, month)).future).then(
-              (List<SonarrEpisode> episodes) => episodes
-                  .map((SonarrEpisode e) => SonarrCalendarEvent(e, instance))
-                  .toList(),
-            ),
-      );
+      final AsyncValue<List<SonarrEpisode>> state =
+          ref.watch(sonarrCalendarProvider((instance, month)));
+
+      if (state is AsyncLoading) {
+        futures.add(
+          ref
+              .read(sonarrCalendarProvider((instance, month)).future)
+              .then((List<SonarrEpisode> episodes) {
+            allEvents.addAll(
+              episodes
+                  .map((SonarrEpisode e) => SonarrCalendarEvent(e, instance)),
+            );
+          }).catchError((Object e) {
+            // Ignore error
+          }),
+        );
+      } else if (state is AsyncData<List<SonarrEpisode>>) {
+        allEvents.addAll(
+          state.value
+              .map((SonarrEpisode e) => SonarrCalendarEvent(e, instance)),
+        );
+      }
     }
   }
 
-  final List<List<CalendarEvent>> results = await Future.wait(futures);
-  return results.expand((List<CalendarEvent> list) => list).toList();
+  if (futures.isNotEmpty) {
+    await Future.wait(futures).catchError((_) => []);
+  }
+
+  return allEvents;
 });
 
 /// Displays a unified schedule and release calendar across all configured
@@ -182,6 +215,7 @@ class CalendarScreen extends ConsumerStatefulWidget {
 class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   late DateTime _visibleMonth;
   late DateTime _selectedDay;
+  bool _showListView = false;
 
   @override
   void initState() {
@@ -189,6 +223,28 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     final DateTime now = DateTime.now();
     _visibleMonth = DateTime(now.year, now.month);
     _selectedDay = DateTime(now.year, now.month, now.day);
+  }
+
+  Future<void> _handleRefresh() async {
+    final List<Instance> instances = ref.read(activeInstancesProvider);
+    final List<Future<void>> futures = [];
+    for (final Instance instance in instances) {
+      if (instance.kind == ServiceKind.radarr) {
+        ref.invalidate(radarrCalendarProvider((instance, _visibleMonth)));
+        futures.add(
+            ref.read(radarrCalendarProvider((instance, _visibleMonth)).future));
+      } else if (instance.kind == ServiceKind.sonarr) {
+        ref.invalidate(sonarrCalendarProvider((instance, _visibleMonth)));
+        futures.add(
+            ref.read(sonarrCalendarProvider((instance, _visibleMonth)).future));
+      }
+    }
+    if (futures.isNotEmpty) {
+      await Future.wait(futures).catchError((_) => []);
+    }
+    await ref
+        .read(globalCalendarProvider(_visibleMonth).future)
+        .catchError((_) => <CalendarEvent>[]);
   }
 
   void _prevMonth() {
@@ -240,7 +296,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
           builder: (BuildContext context, StateSetter setModalState) {
             final ThemeData theme = Theme.of(context);
             return Container(
-              padding: const EdgeInsets.fromLTRB(Insets.md, 0, Insets.md, Insets.md),
+              padding:
+                  const EdgeInsets.fromLTRB(Insets.md, 0, Insets.md, Insets.md),
               height: 320,
               child: Column(
                 children: <Widget>[
@@ -252,7 +309,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                         icon: const Icon(Icons.chevron_left),
                         onPressed: () {
                           setModalState(() {
-                            _visibleMonth = DateTime(_visibleMonth.year - 1, _visibleMonth.month);
+                            _visibleMonth = DateTime(
+                                _visibleMonth.year - 1, _visibleMonth.month);
                           });
                           setState(() {});
                         },
@@ -267,7 +325,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                         icon: const Icon(Icons.chevron_right),
                         onPressed: () {
                           setModalState(() {
-                            _visibleMonth = DateTime(_visibleMonth.year + 1, _visibleMonth.month);
+                            _visibleMonth = DateTime(
+                                _visibleMonth.year + 1, _visibleMonth.month);
                           });
                           setState(() {});
                         },
@@ -278,7 +337,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                   // Month Grid (3x4)
                   Expanded(
                     child: GridView.builder(
-                      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      gridDelegate:
+                          const SliverGridDelegateWithFixedCrossAxisCount(
                         crossAxisCount: 4,
                         childAspectRatio: 1.6,
                         crossAxisSpacing: Insets.sm,
@@ -288,11 +348,13 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                       itemBuilder: (BuildContext context, int index) {
                         final int monthNum = index + 1;
                         final bool isCurrent = _visibleMonth.month == monthNum;
-                        final String monthName = DateFormat('MMMM').format(DateTime(2000, monthNum));
+                        final String monthName =
+                            DateFormat('MMMM').format(DateTime(2000, monthNum));
                         return InkWell(
                           onTap: () {
                             setState(() {
-                              _visibleMonth = DateTime(_visibleMonth.year, monthNum);
+                              _visibleMonth =
+                                  DateTime(_visibleMonth.year, monthNum);
                             });
                             Navigator.pop(context);
                           },
@@ -343,15 +405,17 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
         ref.watch(globalCalendarProvider(_visibleMonth));
 
     // Prefetch and cache adjacent months to ensure instant navigation transitions
-    final DateTime nextMonth = DateTime(_visibleMonth.year, _visibleMonth.month + 1);
-    final DateTime prevMonth = DateTime(_visibleMonth.year, _visibleMonth.month - 1);
+    final DateTime nextMonth =
+        DateTime(_visibleMonth.year, _visibleMonth.month + 1);
+    final DateTime prevMonth =
+        DateTime(_visibleMonth.year, _visibleMonth.month - 1);
     ref.watch(globalCalendarProvider(nextMonth));
     ref.watch(globalCalendarProvider(prevMonth));
 
     final bool hasCalendarServices = ref.watch(activeInstancesProvider).any(
-      (Instance i) =>
-          i.kind == ServiceKind.radarr || i.kind == ServiceKind.sonarr,
-    );
+          (Instance i) =>
+              i.kind == ServiceKind.radarr || i.kind == ServiceKind.sonarr,
+        );
 
     if (!hasCalendarServices) {
       return Scaffold(
@@ -390,34 +454,190 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
           },
         ),
         title: const Text('Calendar'),
+        actions: <Widget>[
+          IconButton(
+            icon: Icon(
+              _showListView ? Icons.calendar_month : Icons.format_list_bulleted,
+            ),
+            tooltip:
+                _showListView ? 'Switch to grid view' : 'Switch to list view',
+            onPressed: () {
+              setState(() {
+                _showListView = !_showListView;
+              });
+            },
+          ),
+          const SizedBox(width: 8),
+        ],
       ),
-      body: M3RefreshIndicator(
-        onRefresh: () async => ref.invalidate(globalCalendarProvider(_visibleMonth)),
-        child: AsyncValueView<List<CalendarEvent>>(
-          value: calendar,
-          onRetry: () => ref.invalidate(globalCalendarProvider(_visibleMonth)),
-          data: (List<CalendarEvent> entries) {
+      body: AsyncValueView<List<CalendarEvent>>(
+        value: calendar,
+        onRetry: _handleRefresh,
+        data: (List<CalendarEvent> entries) {
+          // Group entries by local date
+          final Map<DateTime, List<CalendarEvent>> entriesMap = {};
+          for (final CalendarEvent entry in entries) {
+            final DateTime local = entry.date.toLocal();
+            final DateTime key = DateTime(local.year, local.month, local.day);
+            entriesMap.putIfAbsent(key, () => []).add(entry);
+          }
+
+          final ThemeData theme = Theme.of(context);
+          final DateTime now = DateTime.now();
+
+          final Widget content;
+          if (_showListView) {
+            final List<DateTime> eventDates = entriesMap.keys.toList()
+              ..sort((a, b) => a.compareTo(b));
+
+            content = GestureDetector(
+              onHorizontalDragEnd: (DragEndDetails details) {
+                if (details.primaryVelocity == null) return;
+                if (details.primaryVelocity! < 0) {
+                  _nextMonth();
+                } else if (details.primaryVelocity! > 0) {
+                  _prevMonth();
+                }
+              },
+              behavior: HitTestBehavior.translucent,
+              child: ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                padding: Insets.page,
+                children: <Widget>[
+                  Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: InkWell(
+                          onTap: () => _showMonthYearPicker(context),
+                          borderRadius: BorderRadius.circular(8),
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: Insets.xs,
+                              vertical: 4,
+                            ),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                Text(
+                                  DateFormat('yyyy').format(_visibleMonth),
+                                  style: theme.textTheme.labelSmall?.copyWith(
+                                    color: theme.colorScheme.outline,
+                                    fontWeight: FontWeight.bold,
+                                    letterSpacing: 1.2,
+                                  ),
+                                ),
+                                Row(
+                                  mainAxisSize: MainAxisSize.min,
+                                  children: <Widget>[
+                                    Flexible(
+                                      child: Text(
+                                        DateFormat('MMMM')
+                                            .format(_visibleMonth),
+                                        style: theme.textTheme.titleLarge
+                                            ?.copyWith(
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                      ),
+                                    ),
+                                    const SizedBox(width: 2),
+                                    Icon(
+                                      Icons.arrow_drop_down,
+                                      size: 20,
+                                      color: theme.colorScheme.onSurfaceVariant,
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: Insets.xs),
+                      TextButton.icon(
+                        onPressed: _goToToday,
+                        style: TextButton.styleFrom(
+                          visualDensity: VisualDensity.compact,
+                          padding:
+                              const EdgeInsets.symmetric(horizontal: Insets.sm),
+                        ),
+                        icon: const Icon(Icons.today, size: 16),
+                        label: const Text('Today'),
+                      ),
+                      IconButton(
+                        icon: const Icon(Icons.chevron_left),
+                        onPressed: _prevMonth,
+                        visualDensity: VisualDensity.compact,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                      const SizedBox(width: Insets.xs),
+                      IconButton(
+                        icon: const Icon(Icons.chevron_right),
+                        onPressed: _nextMonth,
+                        visualDensity: VisualDensity.compact,
+                        padding: EdgeInsets.zero,
+                        constraints: const BoxConstraints(),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: Insets.md),
+                  if (eventDates.isEmpty)
+                    Center(
+                      child: Padding(
+                        padding:
+                            const EdgeInsets.symmetric(vertical: Insets.xxl),
+                        child: Column(
+                          children: <Widget>[
+                            Icon(
+                              Icons.calendar_today_outlined,
+                              size: 48,
+                              color: theme.colorScheme.outline
+                                  .withValues(alpha: 0.5),
+                            ),
+                            const SizedBox(height: Insets.md),
+                            Text(
+                              'No releases scheduled this month',
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                color: theme.colorScheme.outline,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    )
+                  else
+                    for (final DateTime date in eventDates) ...[
+                      Padding(
+                        padding: const EdgeInsets.only(
+                          top: Insets.md,
+                          bottom: Insets.xs,
+                        ),
+                        child: _DateHeader(date: date),
+                      ),
+                      for (final CalendarEvent event
+                          in entriesMap[date]!
+                            ..sort((a, b) => a.date.compareTo(b.date)))
+                        _EventTile(event: event),
+                    ],
+                ],
+              ),
+            );
+          } else {
             final List<DateTime> gridDays = _generateGridDays(_visibleMonth);
 
-            // Group entries by local date
-            final Map<DateTime, List<CalendarEvent>> entriesMap = {};
-            for (final CalendarEvent entry in entries) {
-              final DateTime local = entry.date.toLocal();
-              final DateTime key = DateTime(local.year, local.month, local.day);
-              entriesMap.putIfAbsent(key, () => []).add(entry);
-            }
-
             // Selected day entries
-            final DateTime selectedDayKey =
-                DateTime(_selectedDay.year, _selectedDay.month, _selectedDay.day);
+            final DateTime selectedDayKey = DateTime(
+                _selectedDay.year, _selectedDay.month, _selectedDay.day);
             final List<CalendarEvent> selectedDayEntries =
                 entriesMap[selectedDayKey] ?? [];
 
-            final ThemeData theme = Theme.of(context);
-            final DateTime now = DateTime.now();
             final DateTime todayKey = DateTime(now.year, now.month, now.day);
 
-            return ListView(
+            content = ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
               padding: Insets.page,
               children: <Widget>[
                 // Header Row
@@ -450,7 +670,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                                   Flexible(
                                     child: Text(
                                       DateFormat('MMMM').format(_visibleMonth),
-                                      style: theme.textTheme.titleLarge?.copyWith(
+                                      style:
+                                          theme.textTheme.titleLarge?.copyWith(
                                         fontWeight: FontWeight.bold,
                                       ),
                                       maxLines: 1,
@@ -475,7 +696,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                       onPressed: _goToToday,
                       style: TextButton.styleFrom(
                         visualDensity: VisualDensity.compact,
-                        padding: const EdgeInsets.symmetric(horizontal: Insets.sm),
+                        padding:
+                            const EdgeInsets.symmetric(horizontal: Insets.sm),
                       ),
                       icon: const Icon(Icons.today, size: 16),
                       label: const Text('Today'),
@@ -528,22 +750,27 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                   child: GridView.builder(
                     shrinkWrap: true,
                     physics: const NeverScrollableScrollPhysics(),
-                    gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                    gridDelegate:
+                        const SliverGridDelegateWithFixedCrossAxisCount(
                       crossAxisCount: 7,
                       childAspectRatio: 0.82,
                     ),
                     itemCount: gridDays.length,
                     itemBuilder: (BuildContext context, int index) {
                       final DateTime day = gridDays[index];
-                      final bool isCurrentMonth = day.month == _visibleMonth.month;
-                      final DateTime dayKey = DateTime(day.year, day.month, day.day);
+                      final bool isCurrentMonth =
+                          day.month == _visibleMonth.month;
+                      final DateTime dayKey =
+                          DateTime(day.year, day.month, day.day);
                       final bool isSelected = dayKey == selectedDayKey;
                       final bool isToday = dayKey == todayKey;
 
-                      final List<CalendarEvent> dayEntries = entriesMap[dayKey] ?? [];
+                      final List<CalendarEvent> dayEntries =
+                          entriesMap[dayKey] ?? [];
 
                       // Dots calculations
-                      final bool hasDownloaded = dayEntries.any((CalendarEvent e) => e.hasFile);
+                      final bool hasDownloaded =
+                          dayEntries.any((CalendarEvent e) => e.hasFile);
                       final bool hasUpcoming = dayEntries.any(
                         (CalendarEvent e) => !e.hasFile && e.date.isAfter(now),
                       );
@@ -565,7 +792,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                                 color: isSelected
                                     ? theme.colorScheme.primary
                                     : isToday
-                                        ? theme.colorScheme.primaryContainer.withValues(alpha: 0.45)
+                                        ? theme.colorScheme.primaryContainer
+                                            .withValues(alpha: 0.45)
                                         : Colors.transparent,
                                 shape: BoxShape.circle,
                                 border: isToday && !isSelected
@@ -582,8 +810,11 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                                       ? theme.colorScheme.onPrimary
                                       : isCurrentMonth
                                           ? theme.colorScheme.onSurface
-                                          : theme.colorScheme.onSurface.withValues(alpha: 0.35),
-                                  fontWeight: isSelected || isToday ? FontWeight.bold : FontWeight.normal,
+                                          : theme.colorScheme.onSurface
+                                              .withValues(alpha: 0.35),
+                                  fontWeight: isSelected || isToday
+                                      ? FontWeight.bold
+                                      : FontWeight.normal,
                                 ),
                               ),
                             ),
@@ -593,9 +824,12 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                               child: Row(
                                 mainAxisAlignment: MainAxisAlignment.center,
                                 children: <Widget>[
-                                  if (hasDownloaded) const _Dot(color: Colors.green),
-                                  if (hasUpcoming) _Dot(color: theme.colorScheme.primary),
-                                  if (hasMissing) _Dot(color: theme.colorScheme.error),
+                                  if (hasDownloaded)
+                                    const _Dot(color: Colors.green),
+                                  if (hasUpcoming)
+                                    _Dot(color: theme.colorScheme.primary),
+                                  if (hasMissing)
+                                    _Dot(color: theme.colorScheme.error),
                                 ],
                               ),
                             ),
@@ -621,7 +855,8 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                           Icon(
                             Icons.calendar_today_outlined,
                             size: 40,
-                            color: theme.colorScheme.outline.withValues(alpha: 0.5),
+                            color: theme.colorScheme.outline
+                                .withValues(alpha: 0.5),
                           ),
                           const SizedBox(height: Insets.sm),
                           Text(
@@ -639,8 +874,13 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
                     _EventTile(event: event),
               ],
             );
-          },
-        ),
+          }
+
+          return M3RefreshIndicator(
+            onRefresh: _handleRefresh,
+            child: content,
+          );
+        },
       ),
     );
   }
@@ -726,14 +966,18 @@ class _EventTile extends ConsumerWidget {
     if (event is RadarrCalendarEvent) {
       final RadarrMovie movie = (event as RadarrCalendarEvent).movie;
       final RadarrApi? api = ref.watch(radarrApiProvider(instance)).value;
-      final RadarrImage? poster =
-          movie.images.firstWhereOrNull((RadarrImage i) => i.coverType == 'poster');
+      final RadarrImage? poster = movie.images
+          .firstWhereOrNull((RadarrImage i) => i.coverType == 'poster');
       final String? imageUrl = poster == null ? null : api?.posterUrl(poster);
 
       final DateTime eventDate = event.date;
-      if (movie.digitalRelease != null && DateTime.tryParse(movie.digitalRelease!)?.toLocal().day == eventDate.day) {
+      if (movie.digitalRelease != null &&
+          DateTime.tryParse(movie.digitalRelease!)?.toLocal().day ==
+              eventDate.day) {
         releaseType = 'Digital Release';
-      } else if (movie.physicalRelease != null && DateTime.tryParse(movie.physicalRelease!)?.toLocal().day == eventDate.day) {
+      } else if (movie.physicalRelease != null &&
+          DateTime.tryParse(movie.physicalRelease!)?.toLocal().day ==
+              eventDate.day) {
         releaseType = 'Physical Release';
       } else {
         releaseType = 'Cinema Release';
@@ -752,17 +996,19 @@ class _EventTile extends ConsumerWidget {
     } else if (event is SonarrCalendarEvent) {
       final SonarrEpisode episode = (event as SonarrCalendarEvent).episode;
       final SonarrApi? api = ref.watch(sonarrApiProvider(instance)).value;
-      final SonarrImage? poster =
-          episode.series?.images.firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
+      final SonarrImage? poster = episode.series?.images
+          .firstWhereOrNull((SonarrImage i) => i.coverType == 'poster');
       final String? imageUrl = poster == null ? null : api?.posterUrl(poster);
 
-      releaseType = 'S${episode.seasonNumber.toString().padLeft(2, '0')}E${episode.episodeNumber.toString().padLeft(2, '0')}';
+      releaseType =
+          'S${episode.seasonNumber.toString().padLeft(2, '0')}E${episode.episodeNumber.toString().padLeft(2, '0')}';
 
       onTap = () => Navigator.of(context, rootNavigator: true).push(
             MaterialPageRoute<void>(
               builder: (_) => SeriesDetailScreen(
                 instance: instance,
-                series: episode.series ?? SonarrSeries(id: episode.seriesId, title: ''),
+                series: episode.series ??
+                    SonarrSeries(id: episode.seriesId, title: ''),
               ),
             ),
           );
@@ -846,7 +1092,8 @@ class _EventTile extends ConsumerWidget {
                       crossAxisAlignment: WrapCrossAlignment.center,
                       children: [
                         Container(
-                          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                          padding: const EdgeInsets.symmetric(
+                              horizontal: 8, vertical: 2),
                           decoration: BoxDecoration(
                             color: theme.colorScheme.surfaceContainerHighest,
                             borderRadius: BorderRadius.circular(6),
@@ -890,7 +1137,9 @@ class _EventTile extends ConsumerWidget {
                         ),
                         const SizedBox(width: Insets.md),
                         Icon(
-                          event.monitored ? Icons.bookmark : Icons.bookmark_border,
+                          event.monitored
+                              ? Icons.bookmark
+                              : Icons.bookmark_border,
                           size: 14,
                           color: theme.colorScheme.outline,
                         ),
@@ -908,7 +1157,8 @@ class _EventTile extends ConsumerWidget {
               ),
               const SizedBox(width: Insets.sm),
               Container(
-                padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                padding:
+                    const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
                 decoration: BoxDecoration(
                   color: bg,
                   borderRadius: BorderRadius.circular(12),
@@ -952,7 +1202,8 @@ class _Poster extends StatelessWidget {
       fit: BoxFit.cover,
       memCacheWidth: 100,
       memCacheHeight: 150,
-      placeholder: (_, __) => Container(color: theme.colorScheme.surfaceContainerHighest),
+      placeholder: (_, __) =>
+          Container(color: theme.colorScheme.surfaceContainerHighest),
       errorWidget: (_, __, ___) => fallback,
     );
   }

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -9,6 +9,7 @@ import 'package:go_router/go_router.dart';
 
 import '../dashboard/dashboard_board.dart';
 import '../health_providers.dart';
+import 'reorder_sidebar_screen.dart';
 
 /// Home screen. Services live in the navigation drawer (the sidebar); the
 /// dashboard body is the at-a-glance widget board. Until a service exists,
@@ -163,6 +164,21 @@ class ServicesDrawer extends ConsumerWidget {
                     onPressed: () =>
                         _navTo(context, AtriumRoutes.addInstanceName),
                   ),
+                  if (instances.isNotEmpty)
+                    IconButton(
+                      tooltip: 'Reorder sidebar',
+                      icon: Icon(Icons.reorder, color: cs.onSurfaceVariant),
+                      onPressed: () {
+                        // Capture the navigator before closing the drawer, then
+                        // push over the root so the reorder screen covers the
+                        // bottom nav bar.
+                        final NavigatorState nav = Navigator.of(context);
+                        nav.pop();
+                        nav.push(MaterialPageRoute<void>(
+                          builder: (_) => const ReorderSidebarScreen(),
+                        ));
+                      },
+                    ),
                   const SizedBox(width: Insets.xs),
                   Expanded(
                     child: Builder(

--- a/app/lib/src/screens/reorder_sidebar_screen.dart
+++ b/app/lib/src/screens/reorder_sidebar_screen.dart
@@ -1,0 +1,186 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Screen allowing drag-and-drop reordering of configured services in the sidebar.
+class ReorderSidebarScreen extends ConsumerStatefulWidget {
+  const ReorderSidebarScreen({super.key});
+
+  @override
+  ConsumerState<ReorderSidebarScreen> createState() =>
+      _ReorderSidebarScreenState();
+}
+
+class _ReorderSidebarScreenState extends ConsumerState<ReorderSidebarScreen> {
+  List<Instance>? _localInstances;
+
+  @override
+  Widget build(BuildContext context) {
+    final Profile? profile = ref.watch(activeProfileProvider);
+    if (profile == null) {
+      return const Scaffold(
+        body: Center(child: Text('No active profile')),
+      );
+    }
+
+    // Sync local instances state with active profile's instances.
+    final List<Instance> providerInstances = profile.instances;
+    if (_localInstances == null ||
+        _localInstances!.length != providerInstances.length) {
+      _localInstances = List<Instance>.from(providerInstances);
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Reorder Sidebar'),
+      ),
+      body: _localInstances!.isEmpty
+          ? Center(
+              child: Padding(
+                padding: const EdgeInsets.all(Insets.lg),
+                child: Text(
+                  'No services configured.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: cs.onSurfaceVariant,
+                  ),
+                ),
+              ),
+            )
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: Insets.lg,
+                    vertical: Insets.md,
+                  ),
+                  child: Text(
+                    'Drag and drop service cards to rearrange their order in the sidebar.',
+                    style: theme.textTheme.bodyMedium?.copyWith(
+                      color: cs.onSurfaceVariant,
+                    ),
+                  ),
+                ),
+                Expanded(
+                  child: ReorderableListView.builder(
+                    itemCount: _localInstances!.length,
+                    onReorderItem: (int oldIndex, int newIndex) {
+                      setState(() {
+                        final Instance item =
+                            _localInstances!.removeAt(oldIndex);
+                        _localInstances!.insert(newIndex, item);
+                      });
+
+                      // Write the reordered instances back to profile repository.
+                      ref
+                          .read(profileListProvider.notifier)
+                          .updateProfile(profile.copyWith(
+                            instances: _localInstances!,
+                          ));
+                    },
+                    proxyDecorator:
+                        (Widget child, int index, Animation<double> animation) {
+                      return AnimatedBuilder(
+                        animation: animation,
+                        builder: (BuildContext context, Widget? child) {
+                          final double animValue =
+                              Curves.easeInOut.transform(animation.value);
+                          final double scale = 1.0 + (animValue * 0.04);
+                          return Transform.scale(
+                            scale: scale,
+                            child: Material(
+                              elevation: 8,
+                              color: Colors.transparent,
+                              borderRadius: BorderRadius.circular(16),
+                              child: child,
+                            ),
+                          );
+                        },
+                        child: child,
+                      );
+                    },
+                    itemBuilder: (BuildContext context, int index) {
+                      final Instance instance = _localInstances![index];
+                      return Padding(
+                        key: ValueKey<String>(instance.id),
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: Insets.lg,
+                          vertical: Insets.xs,
+                        ),
+                        child: Card(
+                          elevation: 0,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(16),
+                            side: BorderSide(
+                              color: cs.outlineVariant,
+                            ),
+                          ),
+                          color: cs.surfaceContainerLow,
+                          child: Padding(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: Insets.md,
+                              vertical: Insets.sm,
+                            ),
+                            child: Row(
+                              children: <Widget>[
+                                Container(
+                                  width: 40,
+                                  height: 40,
+                                  decoration: BoxDecoration(
+                                    color: ServiceVisuals.accent(instance.kind)
+                                        .withValues(alpha: 0.12),
+                                    shape: BoxShape.circle,
+                                  ),
+                                  child: Icon(
+                                    ServiceVisuals.icon(instance.kind),
+                                    color: ServiceVisuals.accent(instance.kind),
+                                    size: 20,
+                                  ),
+                                ),
+                                const SizedBox(width: Insets.md),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment:
+                                        CrossAxisAlignment.start,
+                                    children: <Widget>[
+                                      Text(
+                                        instance.name,
+                                        style: theme.textTheme.titleMedium
+                                            ?.copyWith(
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 2),
+                                      Text(
+                                        '${ServiceVisuals.roleLabel(instance.kind.role)} • ${instance.kind.displayName}',
+                                        style:
+                                            theme.textTheme.bodySmall?.copyWith(
+                                          color: cs.onSurfaceVariant,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                                const SizedBox(width: Insets.md),
+                                Icon(
+                                  Icons.drag_handle_rounded,
+                                  color: cs.onSurfaceVariant,
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/app/lib/src/screens/reorder_sidebar_screen.dart
+++ b/app/lib/src/screens/reorder_sidebar_screen.dart
@@ -69,14 +69,19 @@ class _ReorderSidebarScreenState extends ConsumerState<ReorderSidebarScreen> {
                 Expanded(
                   child: ReorderableListView.builder(
                     itemCount: _localInstances!.length,
-                    onReorderItem: (int oldIndex, int newIndex) {
+                    onReorder: (int oldIndex, int newIndex) {
                       setState(() {
+                        // ReorderableListView reports the insertion index
+                        // including the dragged item; adjust when moving down.
+                        if (newIndex > oldIndex) {
+                          newIndex -= 1;
+                        }
                         final Instance item =
                             _localInstances!.removeAt(oldIndex);
                         _localInstances!.insert(newIndex, item);
                       });
 
-                      // Write the reordered instances back to profile repository.
+                      // Persist the new order to the active profile.
                       ref
                           .read(profileListProvider.notifier)
                           .updateProfile(profile.copyWith(

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -15,6 +15,7 @@ import '../preferences.dart';
 import '../profile_io.dart';
 import 'changelog_screen.dart';
 import 'custom_headers_screen.dart';
+import 'reorder_sidebar_screen.dart';
 import 'wake_on_lan_screen.dart';
 
 /// App settings: theme mode, optional biometric unlock, network tools
@@ -160,6 +161,14 @@ class SettingsScreen extends ConsumerWidget {
               'kept.',
             ),
             onTap: () => ProfileIo.importProfile(context, ref),
+          ),
+          const Divider(),
+          const _SectionHeader('Sidebar'),
+          ListTile(
+            leading: const Icon(Icons.reorder_rounded),
+            title: const Text('Reorder sidebar services'),
+            subtitle: const Text('Drag to change the order services appear in.'),
+            onTap: () => pushScreen<void>(context, const ReorderSidebarScreen()),
           ),
           const Divider(),
           const _SectionHeader('About'),


### PR DESCRIPTION
Extracts the two self-contained features from #36 without the whole-repo reformat, the easy_refresh dependency swap, or the test deletions.

## Changes
- **Calendar list view**: the calendar app bar toggles between the month grid and an agenda list.
- **Calendar robustness**: the aggregated provider now catches each Sonarr / Radarr error on its own, so one unreachable instance no longer blanks the whole calendar.
- **Sidebar reorder**: a drag-and-drop screen to order the configured services, persisted to the active profile, reachable from the drawer and from settings.

## Not included from #36
- The easy_refresh dependency swap (kept the existing M3RefreshIndicator - the calendar pull-to-refresh was reverted to it).
- The SelectServiceScreen add-flow redesign and its router rework.
- The whole-repo dart format reflow and the deleted test files.

## Fixed while extracting
- The reorder list used a non-existent `onReorderItem` parameter and skipped the move-down index adjustment, so that screen never compiled. Corrected to `onReorder` with the standard index fix.

Authored to Bhavya Shah.

## Testing
- flutter analyze: No issues found
- app test suite: 50 tests pass
- Built and installed on device (build 4118)