### PR TITLE
Recently downloaded widget, qBittorrent floating action menu, Glances polish

### DIFF
--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -20,6 +20,7 @@ import 'dashboard_layout.dart';
 import 'dashboard_widget_kind.dart';
 import 'widgets/downloads_widget.dart';
 import 'widgets/recently_added_widget.dart';
+import 'widgets/recently_downloaded_widget.dart';
 import 'widgets/requests_widget.dart';
 import 'widgets/server_info_widget.dart';
 import 'widgets/streams_widget.dart';
@@ -116,6 +117,11 @@ class DashboardBoard extends ConsumerWidget {
           sonarrInstances: _byKind(instances, ServiceKind.sonarr),
           radarrInstances: _byKind(instances, ServiceKind.radarr),
         );
+      case DashboardWidgetKind.recentlyDownloaded:
+        return DashboardRecentlyDownloadedWidget(
+          sonarrInstances: _byKind(instances, ServiceKind.sonarr),
+          radarrInstances: _byKind(instances, ServiceKind.radarr),
+        );
       case DashboardWidgetKind.requests:
         return DashboardRequestsWidget(
           instances: _byKind(instances, ServiceKind.seerr),
@@ -133,8 +139,10 @@ class DashboardBoard extends ConsumerWidget {
       switch (i.kind) {
         case ServiceKind.sonarr:
           ref.invalidate(sonarrSeriesProvider(i));
+          ref.invalidate(sonarrHistoryProvider(i));
         case ServiceKind.radarr:
           ref.invalidate(radarrMoviesProvider(i));
+          ref.invalidate(radarrHistoryProvider(i));
         case ServiceKind.qbittorrent:
           ref.invalidate(qbitRawTorrentsProvider(i));
           ref.invalidate(qbitTransferProvider(i));

--- a/app/lib/src/dashboard/dashboard_widget_kind.dart
+++ b/app/lib/src/dashboard/dashboard_widget_kind.dart
@@ -7,6 +7,7 @@ enum DashboardWidgetKind {
   streams,
   upcoming,
   recentlyAdded,
+  recentlyDownloaded,
   requests,
   serverInfo,
 }
@@ -17,6 +18,7 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.streams => 'Now streaming',
         DashboardWidgetKind.upcoming => 'Upcoming releases',
         DashboardWidgetKind.recentlyAdded => 'Recently added',
+        DashboardWidgetKind.recentlyDownloaded => 'Recently downloaded',
         DashboardWidgetKind.requests => 'Requests',
         DashboardWidgetKind.serverInfo => 'Server info',
       };
@@ -26,6 +28,7 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.streams => Icons.play_circle_outline,
         DashboardWidgetKind.upcoming => Icons.event_outlined,
         DashboardWidgetKind.recentlyAdded => Icons.new_releases_outlined,
+        DashboardWidgetKind.recentlyDownloaded => Icons.history,
         DashboardWidgetKind.requests => Icons.bookmark_added_outlined,
         DashboardWidgetKind.serverInfo => Icons.memory,
       };
@@ -42,6 +45,8 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.upcoming =>
           const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
         DashboardWidgetKind.recentlyAdded =>
+          const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
+        DashboardWidgetKind.recentlyDownloaded =>
           const <ServiceKind>[ServiceKind.sonarr, ServiceKind.radarr],
         DashboardWidgetKind.requests => const <ServiceKind>[ServiceKind.seerr],
         DashboardWidgetKind.serverInfo =>

--- a/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
@@ -1,0 +1,217 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:collection/collection.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:service_radarr/service_radarr.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+class _RecentDownloadItem {
+  const _RecentDownloadItem({
+    required this.title,
+    required this.date,
+    required this.isMovie,
+    required this.instance,
+    this.posterUrl,
+    this.subtitle,
+  });
+
+  final String title;
+  final DateTime date;
+  final bool isMovie;
+  final Instance instance;
+  final String? posterUrl;
+  final String? subtitle;
+}
+
+/// The most recently downloaded Sonarr series and Radarr movies across every
+/// instance, merged and shown as a horizontally scrollable poster row.
+class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
+  const DashboardRecentlyDownloadedWidget({
+    required this.sonarrInstances,
+    required this.radarrInstances,
+    super.key,
+  });
+
+  final List<Instance> sonarrInstances;
+  final List<Instance> radarrInstances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final ColorScheme cs = Theme.of(context).colorScheme;
+
+    final List<_RecentDownloadItem> items = <_RecentDownloadItem>[];
+    bool anyLoading = false;
+    bool anyError = false;
+
+    for (final Instance i in sonarrInstances) {
+      final AsyncValue<List<SonarrHistoryItem>> history =
+          ref.watch(sonarrHistoryProvider(i));
+      anyLoading |= history.isLoading && !history.hasValue;
+      anyError |= history.hasError;
+      for (final SonarrHistoryItem h in history.value ?? const <SonarrHistoryItem>[]) {
+        final DateTime? date = DateTime.tryParse(h.date ?? '');
+        if (date == null || h.series == null) {
+          continue;
+        }
+        items.add(_RecentDownloadItem(
+          title: h.episode?.title ?? h.series!.title,
+          date: date,
+          isMovie: false,
+          instance: i,
+          subtitle: h.episode != null ? h.series!.title : null,
+          posterUrl: h.series!.images
+              .firstWhereOrNull((SonarrImage im) => im.coverType == 'poster')
+              ?.remoteUrl,
+        ));
+      }
+    }
+    for (final Instance i in radarrInstances) {
+      final AsyncValue<List<RadarrHistoryItem>> history =
+          ref.watch(radarrHistoryProvider(i));
+      anyLoading |= history.isLoading && !history.hasValue;
+      anyError |= history.hasError;
+      for (final RadarrHistoryItem h in history.value ?? const <RadarrHistoryItem>[]) {
+        final DateTime? date = DateTime.tryParse(h.date ?? '');
+        if (date == null || h.movie == null) {
+          continue;
+        }
+        items.add(_RecentDownloadItem(
+          title: h.movie!.title,
+          date: date,
+          isMovie: true,
+          instance: i,
+          subtitle: h.movie!.year?.toString(),
+          posterUrl: h.movie!.images
+              .firstWhereOrNull((RadarrImage im) => im.coverType == 'poster')
+              ?.remoteUrl,
+        ));
+      }
+    }
+
+    items.sort((_RecentDownloadItem a, _RecentDownloadItem b) => b.date.compareTo(a.date));
+    final List<_RecentDownloadItem> top = items.take(15).toList();
+
+    Widget body;
+    if (items.isEmpty && anyLoading) {
+      body = const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.sm),
+          child: SizedBox(
+            width: 22,
+            height: 22,
+            child: CircularProgressIndicator(strokeWidth: 2.5),
+          ),
+        ),
+      );
+    } else if (items.isEmpty && anyError) {
+      body = DashboardErrorRow(
+        onRetry: () {
+          for (final Instance i in sonarrInstances) {
+            ref.invalidate(sonarrHistoryProvider(i));
+          }
+          for (final Instance i in radarrInstances) {
+            ref.invalidate(radarrHistoryProvider(i));
+          }
+        },
+      );
+    } else if (items.isEmpty) {
+      body = const DashboardIdleRow(text: 'No recent downloads found');
+    } else {
+      body = SizedBox(
+        height: 184,
+        child: ListView.separated(
+          scrollDirection: Axis.horizontal,
+          padding: EdgeInsets.zero,
+          itemCount: top.length,
+          separatorBuilder: (_, __) => const SizedBox(width: Insets.sm),
+          itemBuilder: (BuildContext context, int index) {
+            final _RecentDownloadItem item = top[index];
+            return SizedBox(
+              width: 104,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Expanded(
+                    child: AspectRatio(
+                      aspectRatio: 2 / 3,
+                      child: Material(
+                        color: cs.surfaceContainerHigh,
+                        clipBehavior: Clip.antiAlias,
+                        borderRadius: BorderRadius.circular(Insets.sm),
+                        child: InkWell(
+                          onTap: () {
+                            context.go(AtriumRoutes.servicePath(
+                              item.instance.kind.name,
+                              item.instance.id,
+                            ));
+                          },
+                          child: item.posterUrl != null
+                              ? CachedNetworkImage(
+                                  imageUrl: item.posterUrl!,
+                                  fit: BoxFit.cover,
+                                  httpHeaders: switch (
+                                      item.instance.auth) {
+                                    InstanceAuthApiKey(:final String apiKey) =>
+                                      <String, String>{
+                                        'X-Api-Key': apiKey
+                                      },
+                                    _ => const <String, String>{},
+                                  },
+                                  errorWidget: (_, __, ___) => Icon(
+                                    item.isMovie
+                                        ? Icons.movie
+                                        : Icons.tv,
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                )
+                              : Center(
+                                  child: Icon(
+                                    item.isMovie
+                                        ? Icons.movie
+                                        : Icons.tv,
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(height: Insets.xs),
+                  Text(
+                    item.title,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                  if (item.subtitle != null)
+                    Text(
+                      item.subtitle!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context)
+                          .textTheme
+                          .labelSmall
+                          ?.copyWith(color: cs.onSurfaceVariant),
+                    ),
+                ],
+              ),
+            );
+          },
+        ),
+      );
+    }
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.recentlyDownloaded,
+      accent: cs.primary,
+      child: body,
+    );
+  }
+}

--- a/app/test/dashboard_layout_test.dart
+++ b/app/test/dashboard_layout_test.dart
@@ -88,8 +88,8 @@ void main() {
           container.read(dashboardLayoutProvider.notifier);
       // Hide one widget so enabled != full list.
       controller.setEnabled(DashboardWidgetKind.streams, false);
-      // Enabled order is now: downloads, upcoming, recentlyAdded, requests,
-      // serverInfo.
+      // Enabled order is now: downloads, upcoming, recentlyAdded,
+      // recentlyDownloaded, requests, serverInfo.
       controller.moveEnabled(0, 3); // drag downloads down two slots
       final List<DashboardWidgetKind> enabled = container
           .read(dashboardLayoutProvider)
@@ -100,6 +100,7 @@ void main() {
         DashboardWidgetKind.upcoming,
         DashboardWidgetKind.recentlyAdded,
         DashboardWidgetKind.downloads,
+        DashboardWidgetKind.recentlyDownloaded,
         DashboardWidgetKind.requests,
         DashboardWidgetKind.serverInfo,
       ]);

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -448,14 +448,14 @@ void main() {
       ],
       const DashboardBoard(),
     );
-    // All six widgets are arrangeable in edit mode, configured or not.
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(6));
+    // All seven widgets are arrangeable in edit mode, configured or not.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(7));
     expect(find.text('Hidden'), findsNothing);
     // Hide the first widget -> it moves to the Hidden section.
     await tester.tap(find.byIcon(Icons.visibility_off_outlined).first);
     await tester.pump();
     expect(find.text('Hidden'), findsOneWidget);
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(5));
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(6));
     expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
   });
 }

--- a/services/service_glances/lib/src/glances_home.dart
+++ b/services/service_glances/lib/src/glances_home.dart
@@ -32,14 +32,17 @@ class GlancesHome extends ConsumerWidget {
               shape: RoundedRectangleBorder(
                 borderRadius: Radii.card,
                 side: BorderSide(
-                    color: Theme.of(context).colorScheme.outlineVariant,),
+                  color: Theme.of(context).colorScheme.outlineVariant,
+                ),
               ),
               child: Padding(
                 padding: const EdgeInsets.all(Insets.md),
                 child: Row(
                   children: <Widget>[
-                    const Icon(Icons.schedule_outlined,
-                        color: Color(0xFF3B82F6),),
+                    const Icon(
+                      Icons.schedule_outlined,
+                      color: Color(0xFF3B82F6),
+                    ),
                     const SizedBox(width: Insets.md),
                     Expanded(
                       child: Text(
@@ -63,8 +66,10 @@ class GlancesHome extends ConsumerWidget {
             const SizedBox(height: Insets.md),
             _buildNetworkSectionHeader(context, ref, stats.network),
             ...stats.network
-                .where((GlancesNetwork n) =>
-                    pinnedNets.isEmpty || pinnedNets.contains(n.interface),)
+                .where(
+                  (GlancesNetwork n) =>
+                      pinnedNets.isEmpty || pinnedNets.contains(n.interface),
+                )
                 .map((GlancesNetwork n) => _buildNetworkCard(context, n)),
             const SizedBox(height: Insets.md),
             _buildSectionHeader(context, 'Disks', Icons.storage_outlined),
@@ -112,7 +117,10 @@ class GlancesHome extends ConsumerWidget {
   }
 
   Widget _buildSectionHeader(
-      BuildContext context, String title, IconData icon,) {
+    BuildContext context,
+    String title,
+    IconData icon,
+  ) {
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: Insets.sm),
       child: Row(
@@ -132,7 +140,10 @@ class GlancesHome extends ConsumerWidget {
   }
 
   Widget _buildNetworkSectionHeader(
-      BuildContext context, WidgetRef ref, List<GlancesNetwork> networks,) {
+    BuildContext context,
+    WidgetRef ref,
+    List<GlancesNetwork> networks,
+  ) {
     final Set<String> pinnedNets =
         ref.watch(glancesPinnedNetworkProvider(instance));
 
@@ -140,8 +151,11 @@ class GlancesHome extends ConsumerWidget {
       padding: const EdgeInsets.symmetric(vertical: Insets.sm),
       child: Row(
         children: <Widget>[
-          Icon(Icons.network_check_outlined,
-              size: 20, color: Theme.of(context).colorScheme.primary,),
+          Icon(
+            Icons.network_check_outlined,
+            size: 20,
+            color: Theme.of(context).colorScheme.primary,
+          ),
           const SizedBox(width: Insets.sm),
           Text(
             'Network',
@@ -180,8 +194,11 @@ class GlancesHome extends ConsumerWidget {
     );
   }
 
-  void _showNetworkFilterDialog(BuildContext context, WidgetRef parentRef,
-      List<GlancesNetwork> networks,) {
+  void _showNetworkFilterDialog(
+    BuildContext context,
+    WidgetRef parentRef,
+    List<GlancesNetwork> networks,
+  ) {
     showDialog<void>(
       context: context,
       builder: (BuildContext dialogContext) {
@@ -205,8 +222,9 @@ class GlancesHome extends ConsumerWidget {
                         final Set<String> newSet = Set<String>.from(pinnedNets);
                         if (pinnedNets.isEmpty) {
                           if (checked != true) {
-                            newSet.addAll(networks
-                                .map((GlancesNetwork e) => e.interface),);
+                            newSet.addAll(
+                              networks.map((GlancesNetwork e) => e.interface),
+                            );
                             newSet.remove(net.interface);
                           }
                         } else {
@@ -221,7 +239,8 @@ class GlancesHome extends ConsumerWidget {
                         }
                         ref
                             .read(
-                                glancesPinnedNetworkProvider(instance).notifier,)
+                              glancesPinnedNetworkProvider(instance).notifier,
+                            )
                             .set(newSet);
                       },
                     );
@@ -296,8 +315,10 @@ class GlancesHome extends ConsumerWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
-                      Text('Swap',
-                          style: Theme.of(context).textTheme.titleSmall,),
+                      Text(
+                        'Swap',
+                        style: Theme.of(context).textTheme.titleSmall,
+                      ),
                       const SizedBox(height: 6),
                       LinearProgressIndicatorM3E(
                         shape: ProgressM3EShape.flat,
@@ -349,8 +370,11 @@ class GlancesHome extends ConsumerWidget {
           children: <Widget>[
             Row(
               children: <Widget>[
-                Icon(Icons.developer_board,
-                    size: 20, color: theme.colorScheme.primary,),
+                Icon(
+                  Icons.developer_board,
+                  size: 20,
+                  color: theme.colorScheme.primary,
+                ),
                 const SizedBox(width: Insets.sm),
                 Text(
                   'Cores (${cpu.physicalCores} Phys, ${cpu.logicalCores} Log)',
@@ -368,35 +392,47 @@ class GlancesHome extends ConsumerWidget {
                   children: <Widget>[
                     SizedBox(
                       width: 60,
-                      child: Text('Core ${core.id}',
-                          style: theme.textTheme.labelMedium,),
+                      child: Text(
+                        'Core ${core.id}',
+                        style: theme.textTheme.labelMedium,
+                      ),
                     ),
                     Expanded(
                       child: TweenAnimationBuilder<double>(
                         tween: Tween<double>(
-                            begin: 0.0,
-                            end: (core.usage / 100.0).clamp(0.0, 1.0),),
+                          begin: 0.0,
+                          end: (core.usage / 100.0).clamp(0.0, 1.0),
+                        ),
                         duration: const Duration(milliseconds: 600),
                         curve: Curves.easeOutCubic,
-                        builder: (BuildContext context, double value,
-                            Widget? child,) {
-                          return LinearProgressIndicatorM3E(
-                            shape: ProgressM3EShape.flat,
-                            value: value,
-                            trackColor: theme.colorScheme.onSurface
-                                .withValues(alpha: 0.1),
-                            activeColor: theme.colorScheme.primary,
+                        builder: (
+                          BuildContext context,
+                          double value,
+                          Widget? child,
+                        ) {
+                          return Row(
+                            children: <Widget>[
+                              Expanded(
+                                child: LinearProgressIndicatorM3E(
+                                  shape: ProgressM3EShape.flat,
+                                  value: value,
+                                  trackColor: theme.colorScheme.onSurface
+                                      .withValues(alpha: 0.1),
+                                  activeColor: theme.colorScheme.primary,
+                                ),
+                              ),
+                              const SizedBox(width: Insets.sm),
+                              SizedBox(
+                                width: 50,
+                                child: Text(
+                                  '${(value * 100).toStringAsFixed(1)}%',
+                                  textAlign: TextAlign.end,
+                                  style: theme.textTheme.labelMedium,
+                                ),
+                              ),
+                            ],
                           );
                         },
-                      ),
-                    ),
-                    const SizedBox(width: Insets.sm),
-                    SizedBox(
-                      width: 50,
-                      child: Text(
-                        '${core.usage.toStringAsFixed(1)}%',
-                        textAlign: TextAlign.end,
-                        style: theme.textTheme.labelMedium,
                       ),
                     ),
                   ],
@@ -420,50 +456,56 @@ class GlancesHome extends ConsumerWidget {
       ),
       child: Padding(
         padding: Insets.page,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Row(
+        child: TweenAnimationBuilder<double>(
+          tween: Tween<double>(begin: 0.0, end: pct.clamp(0.0, 1.0)),
+          duration: const Duration(milliseconds: 600),
+          curve: Curves.easeOutCubic,
+          builder: (BuildContext context, double value, Widget? child) {
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: <Widget>[
-                const Icon(Icons.dns_outlined, size: 20),
-                const SizedBox(width: Insets.sm),
-                Expanded(
-                  child: Text(
-                    disk.path,
-                    style: Theme.of(context).textTheme.bodyLarge,
-                  ),
+                Row(
+                  children: <Widget>[
+                    const Icon(Icons.dns_outlined, size: 20),
+                    const SizedBox(width: Insets.sm),
+                    Expanded(
+                      child: Text(
+                        disk.path,
+                        style: Theme.of(context).textTheme.bodyLarge,
+                      ),
+                    ),
+                    Text(
+                      '${(value * 100).toStringAsFixed(1)}%',
+                      style: Theme.of(context).textTheme.labelLarge,
+                    ),
+                  ],
                 ),
-                Text(
-                  '${disk.percentage.toStringAsFixed(1)}%',
-                  style: Theme.of(context).textTheme.labelLarge,
+                const SizedBox(height: Insets.md),
+                LinearProgressIndicatorM3E(
+                  shape: ProgressM3EShape.flat,
+                  value: value,
+                  trackColor: Theme.of(context).colorScheme.surfaceContainerHighest,
+                  activeColor: value > 0.9
+                      ? Theme.of(context).colorScheme.error
+                      : Theme.of(context).colorScheme.primary,
+                ),
+                const SizedBox(height: Insets.sm),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: <Widget>[
+                    Text(
+                      '${(disk.used / 1024 / 1024 / 1024).toStringAsFixed(2)} GB used',
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                    Text(
+                      '${(disk.total / 1024 / 1024 / 1024).toStringAsFixed(2)} GB total',
+                      style: Theme.of(context).textTheme.labelSmall,
+                    ),
+                  ],
                 ),
               ],
-            ),
-            const SizedBox(height: Insets.md),
-            LinearProgressIndicatorM3E(
-              shape: ProgressM3EShape.flat,
-              value: pct.clamp(0.0, 1.0),
-              trackColor:
-                  Theme.of(context).colorScheme.surfaceContainerHighest,
-              activeColor: pct > 0.9
-                  ? Theme.of(context).colorScheme.error
-                  : Theme.of(context).colorScheme.primary,
-            ),
-            const SizedBox(height: Insets.sm),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: <Widget>[
-                Text(
-                  '${(disk.used / 1024 / 1024 / 1024).toStringAsFixed(2)} GB used',
-                  style: Theme.of(context).textTheme.labelSmall,
-                ),
-                Text(
-                  '${(disk.total / 1024 / 1024 / 1024).toStringAsFixed(2)} GB total',
-                  style: Theme.of(context).textTheme.labelSmall,
-                ),
-              ],
-            ),
-          ],
+            );
+          },
         ),
       ),
     );
@@ -502,16 +544,22 @@ class GlancesHome extends ConsumerWidget {
                   const SizedBox(height: 6),
                   Row(
                     children: <Widget>[
-                      Icon(Icons.arrow_upward,
-                          size: 14, color: theme.colorScheme.tertiary,),
+                      Icon(
+                        Icons.arrow_upward,
+                        size: 14,
+                        color: theme.colorScheme.tertiary,
+                      ),
                       const SizedBox(width: 4),
                       Text(
                         '${_formatBytes(net.txSpeed)}/s',
                         style: theme.textTheme.labelMedium,
                       ),
                       const SizedBox(width: Insets.lg),
-                      Icon(Icons.arrow_downward,
-                          size: 14, color: theme.colorScheme.primary,),
+                      Icon(
+                        Icons.arrow_downward,
+                        size: 14,
+                        color: theme.colorScheme.primary,
+                      ),
                       const SizedBox(width: 4),
                       Text(
                         '${_formatBytes(net.rxSpeed)}/s',
@@ -565,7 +613,9 @@ class _GaugeCard extends StatelessWidget {
       ),
       child: Padding(
         padding: const EdgeInsets.symmetric(
-            vertical: Insets.lg, horizontal: Insets.md,),
+          vertical: Insets.lg,
+          horizontal: Insets.md,
+        ),
         child: Column(
           children: <Widget>[
             Row(
@@ -577,35 +627,33 @@ class _GaugeCard extends StatelessWidget {
               ],
             ),
             const SizedBox(height: Insets.lg),
-            Stack(
-              alignment: Alignment.center,
-              children: <Widget>[
-                SizedBox(
-                  width: 80,
-                  height: 80,
-                  child: TweenAnimationBuilder<double>(
-                    tween:
-                        Tween<double>(begin: 0.0, end: percent.clamp(0.0, 1.0)),
-                    duration: const Duration(milliseconds: 600),
-                    curve: Curves.easeOutCubic,
-                    builder:
-                        (BuildContext context, double value, Widget? child) {
-                      return CircularProgressIndicatorM3E(
+            TweenAnimationBuilder<double>(
+              tween: Tween<double>(begin: 0.0, end: percent.clamp(0.0, 1.0)),
+              duration: const Duration(milliseconds: 600),
+              curve: Curves.easeOutCubic,
+              builder: (BuildContext context, double value, Widget? child) {
+                return Stack(
+                  alignment: Alignment.center,
+                  children: <Widget>[
+                    SizedBox(
+                      width: 80,
+                      height: 80,
+                      child: CircularProgressIndicatorM3E(
                         shape: ProgressM3EShape.flat,
                         value: value,
                         trackColor: color.withValues(alpha: 0.15),
                         activeColor: color,
-                      );
-                    },
-                  ),
-                ),
-                Text(
-                  '${(percent * 100).toStringAsFixed(0)}%',
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                        fontWeight: FontWeight.bold,
                       ),
-                ),
-              ],
+                    ),
+                    Text(
+                      '${(value * 100).toStringAsFixed(0)}%',
+                      style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.bold,
+                          ),
+                    ),
+                  ],
+                );
+              },
             ),
             const SizedBox(height: Insets.lg),
             Row(

--- a/services/service_qbittorrent/lib/src/qbittorrent_action_utils.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_action_utils.dart
@@ -1,0 +1,213 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'qbittorrent_client.dart';
+import 'qbittorrent_providers.dart';
+
+class QbittorrentActionUtils {
+  static Future<void> run(
+    WidgetRef ref,
+    Instance instance,
+    Future<void> Function(QbittorrentClient) action,
+  ) async {
+    final QbittorrentClient client =
+        await ref.read(qbittorrentClientProvider(instance).future);
+    await action(client);
+    ref.invalidate(qbitRawTorrentsProvider(instance));
+    ref.invalidate(qbitSelectionProvider(instance));
+  }
+
+  static Future<void> confirmDelete(
+    BuildContext context,
+    WidgetRef ref,
+    Instance instance,
+    Set<String> selectedHashes,
+  ) async {
+    bool deleteFiles = false;
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) => AlertDialog(
+          title: const Text('Delete select Torrents?'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Text(
+                'Are you sure to delete the selected ${selectedHashes.length} torrents?',
+              ),
+              const SizedBox(height: Insets.md),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Delete files'),
+                value: deleteFiles,
+                onChanged: (bool? v) => setState(() => deleteFiles = v ?? false),
+              ),
+            ],
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('CANCEL'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('CONFIRM'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (ok ?? false) {
+      final QbittorrentClient client =
+          await ref.read(qbittorrentClientProvider(instance).future);
+      await client.delete(selectedHashes.toList(), deleteFiles: deleteFiles);
+      ref.invalidate(qbitSelectionProvider(instance));
+      ref.invalidate(qbitRawTorrentsProvider(instance));
+    }
+  }
+
+  static Future<void> editCategory(
+    BuildContext context,
+    WidgetRef ref,
+    Instance instance,
+    Set<String> selectedHashes,
+  ) async {
+    final List<String> cats =
+        await ref.read(qbitCategoriesProvider(instance).future);
+    if (!context.mounted) return;
+    final String? chosen = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) => SimpleDialog(
+        title: const Text('Set category'),
+        children: <Widget>[
+          SimpleDialogOption(
+            onPressed: () => Navigator.of(context).pop(''),
+            child: const Text('None'),
+          ),
+          for (final String c in cats)
+            SimpleDialogOption(
+              onPressed: () => Navigator.of(context).pop(c),
+              child: Text(c),
+            ),
+        ],
+      ),
+    );
+    if (chosen != null) {
+      await run(
+        ref,
+        instance,
+        (QbittorrentClient c) => c.setCategory(selectedHashes.toList(), chosen),
+      );
+    }
+  }
+
+  static Future<void> editTags(
+    BuildContext context,
+    WidgetRef ref,
+    Instance instance,
+    Set<String> selectedHashes,
+  ) async {
+    final TextEditingController ctrl = TextEditingController();
+    final String? chosen = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('Set tags'),
+        content: TextField(
+          controller: ctrl,
+          decoration: const InputDecoration(hintText: 'tag1, tag2'),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(ctrl.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (chosen != null && chosen.isNotEmpty) {
+      await run(
+        ref,
+        instance,
+        (QbittorrentClient c) => c.addTags(selectedHashes.toList(), chosen),
+      );
+    }
+  }
+
+  static Future<void> editSavePath(
+    BuildContext context,
+    WidgetRef ref,
+    Instance instance,
+    Set<String> selectedHashes,
+  ) async {
+    final TextEditingController ctrl = TextEditingController();
+    final String? chosen = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('Set save path'),
+        content: TextField(
+          controller: ctrl,
+          decoration: const InputDecoration(hintText: '/downloads/new_path'),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(ctrl.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (chosen != null && chosen.isNotEmpty) {
+      await run(
+        ref,
+        instance,
+        (QbittorrentClient c) => c.setLocation(selectedHashes.toList(), chosen),
+      );
+    }
+  }
+
+  static Future<void> rename(
+    BuildContext context,
+    WidgetRef ref,
+    Instance instance,
+    Set<String> selectedHashes,
+  ) async {
+    final TextEditingController ctrl = TextEditingController();
+    final String? chosen = await showDialog<String>(
+      context: context,
+      builder: (BuildContext context) => AlertDialog(
+        title: const Text('Rename'),
+        content: TextField(
+          controller: ctrl,
+          decoration: const InputDecoration(hintText: 'New name'),
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(context).pop(ctrl.text),
+            child: const Text('Save'),
+          ),
+        ],
+      ),
+    );
+    if (chosen != null && chosen.isNotEmpty) {
+      await run(
+        ref,
+        instance,
+        (QbittorrentClient c) => c.rename(selectedHashes.first, chosen),
+      );
+    }
+  }
+}

--- a/services/service_qbittorrent/lib/src/qbittorrent_home.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_home.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,10 +10,10 @@ import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 import 'add_torrent_sheet.dart';
 import 'models/qbit_torrent.dart';
 import 'models/qbit_transfer_info.dart';
+import 'qbittorrent_action_utils.dart';
 import 'qbittorrent_client.dart';
 import 'qbittorrent_providers.dart';
 import 'torrent_detail_screen.dart';
-import 'qbittorrent_action_utils.dart';
 
 /// qBittorrent's per-instance UI: a global up/down header (with pause-all /
 /// resume-all), a torrent list with progress / speeds / per-item actions, and
@@ -659,7 +658,7 @@ class _TorrentTileState extends ConsumerState<_TorrentTile> {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
     
-    Widget _buildItem(IconData icon, String label, VoidCallback onTap, {Color? color}) {
+    Widget buildItem(IconData icon, String label, VoidCallback onTap, {Color? color}) {
       return ListTile(
         leading: Icon(icon, color: color ?? cs.onSurfaceVariant),
         title: Text(label, style: TextStyle(color: color)),
@@ -685,35 +684,35 @@ class _TorrentTileState extends ConsumerState<_TorrentTile> {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
-                  _buildItem(Icons.check_circle_outline, 'Select', () {
+                  buildItem(Icons.check_circle_outline, 'Select', () {
                     ref.read(qbitSelectionProvider(inst).notifier).update(
                           (Set<String> s) => <String>{...s, hash},
                         );
                   }),
-                  _buildItem(Icons.pause, 'Pause', () {
+                  buildItem(Icons.pause, 'Pause', () {
                     QbittorrentActionUtils.run(ref, inst, (QbittorrentClient c) => c.pause(<String>[hash]));
                   }),
-                  _buildItem(Icons.play_arrow, 'Resume', () {
+                  buildItem(Icons.play_arrow, 'Resume', () {
                     QbittorrentActionUtils.run(ref, inst, (QbittorrentClient c) => c.resume(<String>[hash]));
                   }),
-                  _buildItem(Icons.copy, 'Copy Hash', () async {
+                  buildItem(Icons.copy, 'Copy Hash', () async {
                     await Clipboard.setData(ClipboardData(text: hash));
                   }),
-                  _buildItem(Icons.refresh, 'Force Recheck', () {
+                  buildItem(Icons.refresh, 'Force Recheck', () {
                     QbittorrentActionUtils.run(ref, inst, (QbittorrentClient c) => c.recheck(<String>[hash]));
                   }),
-                  _buildItem(Icons.edit, 'Rename', () {
+                  buildItem(Icons.edit, 'Rename', () {
                     QbittorrentActionUtils.rename(context, ref, inst, <String>{hash});
                   }),
-                  _buildItem(Icons.folder, 'Set SavePath', () {
+                  buildItem(Icons.folder, 'Set SavePath', () {
                     QbittorrentActionUtils.editSavePath(context, ref, inst, <String>{hash});
                   }),
-                  _buildItem(Icons.label, 'Set Category', () {
+                  buildItem(Icons.label, 'Set Category', () {
                     QbittorrentActionUtils.editCategory(context, ref, inst, <String>{hash});
                   }),
-                  _buildItem(Icons.delete, 'Delete', () {
+                  buildItem(Icons.delete, 'Delete', () {
                     QbittorrentActionUtils.confirmDelete(context, ref, inst, <String>{hash});
-                  }, color: Colors.red),
+                  }, color: Colors.red,),
                 ],
               ),
             ),

--- a/services/service_qbittorrent/lib/src/qbittorrent_home.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_home.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -11,6 +14,7 @@ import 'models/qbit_transfer_info.dart';
 import 'qbittorrent_client.dart';
 import 'qbittorrent_providers.dart';
 import 'torrent_detail_screen.dart';
+import 'qbittorrent_action_utils.dart';
 
 /// qBittorrent's per-instance UI: a global up/down header (with pause-all /
 /// resume-all), a torrent list with progress / speeds / per-item actions, and
@@ -64,6 +68,7 @@ class QbittorrentHome extends ConsumerWidget {
       floatingActionButton: _ExpandableFab(
         builder: (BuildContext context, VoidCallback close) => <Widget>[
           FloatingActionButton(
+            heroTag: null,
             tooltip: 'Magnet link',
             onPressed: () async {
               close();
@@ -78,6 +83,7 @@ class QbittorrentHome extends ConsumerWidget {
             child: const Icon(Icons.link),
           ),
           FloatingActionButton(
+            heroTag: null,
             tooltip: 'Torrent file',
             onPressed: () async {
               close();
@@ -226,173 +232,6 @@ class QbittorrentAppBarActions extends ConsumerWidget {
 
   final Instance instance;
 
-  Future<void> _run(
-      WidgetRef ref, Future<void> Function(QbittorrentClient) action,) async {
-    final QbittorrentClient client =
-        await ref.read(qbittorrentClientProvider(instance).future);
-    await action(client);
-    ref.invalidate(qbitRawTorrentsProvider(instance));
-    ref.invalidate(qbitSelectionProvider(instance));
-  }
-
-  Future<void> _confirmDelete(
-      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
-    bool deleteFiles = false;
-    final bool? ok = await showDialog<bool>(
-      context: context,
-      builder: (BuildContext context) => StatefulBuilder(
-        builder: (BuildContext context, StateSetter setState) => AlertDialog(
-          title: const Text('Delete select Torrents?'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: <Widget>[
-              Text(
-                  'Are you sure to delete the selected ${selectedHashes.length} torrents?',),
-              const SizedBox(height: Insets.md),
-              CheckboxListTile(
-                contentPadding: EdgeInsets.zero,
-                title: const Text('Delete files'),
-                value: deleteFiles,
-                onChanged: (bool? v) =>
-                    setState(() => deleteFiles = v ?? false),
-              ),
-            ],
-          ),
-          actions: <Widget>[
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(false),
-              child: const Text('CANCEL'),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(context).pop(true),
-              child: const Text('CONFIRM'),
-            ),
-          ],
-        ),
-      ),
-    );
-    if (ok ?? false) {
-      final QbittorrentClient client =
-          await ref.read(qbittorrentClientProvider(instance).future);
-      await client.delete(selectedHashes.toList(), deleteFiles: deleteFiles);
-      ref.invalidate(qbitSelectionProvider(instance));
-      ref.invalidate(qbitRawTorrentsProvider(instance));
-    }
-  }
-
-  Future<void> _editCategory(
-      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
-    final List<String> cats =
-        await ref.read(qbitCategoriesProvider(instance).future);
-    if (!context.mounted) return;
-    final String? chosen = await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => SimpleDialog(
-        title: const Text('Set category'),
-        children: <Widget>[
-          SimpleDialogOption(
-            onPressed: () => Navigator.of(context).pop(''),
-            child: const Text('None'),
-          ),
-          for (final String c in cats)
-            SimpleDialogOption(
-              onPressed: () => Navigator.of(context).pop(c),
-              child: Text(c),
-            ),
-        ],
-      ),
-    );
-    if (chosen != null) {
-      await _run(
-          ref,
-          (QbittorrentClient c) =>
-              c.setCategory(selectedHashes.toList(), chosen),);
-    }
-  }
-
-  Future<void> _editTags(
-      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
-    final TextEditingController ctrl = TextEditingController();
-    final String? chosen = await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: const Text('Set tags'),
-        content: TextField(
-          controller: ctrl,
-          decoration: const InputDecoration(hintText: 'tag1, tag2'),
-        ),
-        actions: <Widget>[
-          TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),),
-          FilledButton(
-              onPressed: () => Navigator.of(context).pop(ctrl.text),
-              child: const Text('Save'),),
-        ],
-      ),
-    );
-    if (chosen != null && chosen.isNotEmpty) {
-      await _run(ref,
-          (QbittorrentClient c) => c.addTags(selectedHashes.toList(), chosen),);
-    }
-  }
-
-  Future<void> _editSavePath(
-      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
-    final TextEditingController ctrl = TextEditingController();
-    final String? chosen = await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: const Text('Set save path'),
-        content: TextField(
-          controller: ctrl,
-          decoration: const InputDecoration(hintText: '/downloads/new_path'),
-        ),
-        actions: <Widget>[
-          TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),),
-          FilledButton(
-              onPressed: () => Navigator.of(context).pop(ctrl.text),
-              child: const Text('Save'),),
-        ],
-      ),
-    );
-    if (chosen != null && chosen.isNotEmpty) {
-      await _run(
-          ref,
-          (QbittorrentClient c) =>
-              c.setLocation(selectedHashes.toList(), chosen),);
-    }
-  }
-
-  Future<void> _rename(
-      BuildContext context, WidgetRef ref, Set<String> selectedHashes,) async {
-    final TextEditingController ctrl = TextEditingController();
-    final String? chosen = await showDialog<String>(
-      context: context,
-      builder: (BuildContext context) => AlertDialog(
-        title: const Text('Rename'),
-        content: TextField(
-          controller: ctrl,
-          decoration: const InputDecoration(hintText: 'New name'),
-        ),
-        actions: <Widget>[
-          TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),),
-          FilledButton(
-              onPressed: () => Navigator.of(context).pop(ctrl.text),
-              child: const Text('Save'),),
-        ],
-      ),
-    );
-    if (chosen != null && chosen.isNotEmpty) {
-      await _run(
-          ref, (QbittorrentClient c) => c.rename(selectedHashes.first, chosen),);
-    }
-  }
-
   void _showSortMenu(BuildContext context, WidgetRef ref) {
     showModalBottomSheet<void>(
       context: context,
@@ -488,7 +327,7 @@ class QbittorrentAppBarActions extends ConsumerWidget {
         IconButton(
           tooltip: 'Delete Selected',
           icon: const Icon(Icons.delete),
-          onPressed: () => _confirmDelete(context, ref, selectedHashes),
+          onPressed: () => QbittorrentActionUtils.confirmDelete(context, ref, instance, selectedHashes),
         ),
         PopupMenuButton<String>(
           icon: const Icon(Icons.more_vert),
@@ -496,9 +335,9 @@ class QbittorrentAppBarActions extends ConsumerWidget {
             final List<String> hashes = selectedHashes.toList();
             switch (value) {
               case 'pause':
-                await _run(ref, (QbittorrentClient c) => c.pause(hashes));
+                await QbittorrentActionUtils.run(ref, instance, (QbittorrentClient c) => c.pause(hashes));
               case 'resume':
-                await _run(ref, (QbittorrentClient c) => c.resume(hashes));
+                await QbittorrentActionUtils.run(ref, instance, (QbittorrentClient c) => c.resume(hashes));
               case 'copy':
                 await Clipboard.setData(ClipboardData(text: hashes.join('\n')));
                 if (context.mounted) {
@@ -506,22 +345,23 @@ class QbittorrentAppBarActions extends ConsumerWidget {
                       const SnackBar(content: Text('Hashes copied')),);
                 }
               case 'recheck':
-                await _run(ref, (QbittorrentClient c) => c.recheck(hashes));
+                await QbittorrentActionUtils.run(ref, instance, (QbittorrentClient c) => c.recheck(hashes));
               case 'reannounce':
-                await _run(ref, (QbittorrentClient c) => c.reannounce(hashes));
+                await QbittorrentActionUtils.run(ref, instance, (QbittorrentClient c) => c.reannounce(hashes));
               case 'forcestart':
-                await _run(
+                await QbittorrentActionUtils.run(
                     ref,
+                    instance,
                     (QbittorrentClient c) =>
                         c.setForceStart(hashes, value: true),);
               case 'rename':
-                await _rename(context, ref, selectedHashes);
+                await QbittorrentActionUtils.rename(context, ref, instance, selectedHashes);
               case 'savepath':
-                await _editSavePath(context, ref, selectedHashes);
+                await QbittorrentActionUtils.editSavePath(context, ref, instance, selectedHashes);
               case 'category':
-                await _editCategory(context, ref, selectedHashes);
+                await QbittorrentActionUtils.editCategory(context, ref, instance, selectedHashes);
               case 'tags':
-                await _editTags(context, ref, selectedHashes);
+                await QbittorrentActionUtils.editTags(context, ref, instance, selectedHashes);
               case 'export':
                 try {
                   final QbittorrentClient client = await ref
@@ -571,11 +411,26 @@ class QbittorrentAppBarActions extends ConsumerWidget {
   }
 }
 
-class _TorrentTile extends ConsumerWidget {
+class _TorrentTile extends ConsumerStatefulWidget {
   const _TorrentTile({required this.instance, required this.torrent});
 
   final Instance instance;
   final QbitTorrent torrent;
+
+  @override
+  ConsumerState<_TorrentTile> createState() => _TorrentTileState();
+}
+
+class _TorrentTileState extends ConsumerState<_TorrentTile> {
+  Timer? _longPressTimer;
+  Offset? _tapPosition;
+  bool _menuShown = false;
+
+  @override
+  void dispose() {
+    _longPressTimer?.cancel();
+    super.dispose();
+  }
 
   String _formatEta(int eta) {
     if (eta >= 8640000 || eta < 0) {
@@ -589,7 +444,9 @@ class _TorrentTile extends ConsumerWidget {
   }
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  Widget build(BuildContext context) {
+    final QbitTorrent torrent = widget.torrent;
+    final Instance instance = widget.instance;
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
     final Set<String> selection = ref.watch(qbitSelectionProvider(instance));
@@ -601,22 +458,29 @@ class _TorrentTile extends ConsumerWidget {
     final bool dlActive = torrent.dlspeed > 0;
     final bool upActive = torrent.upspeed > 0;
 
-    return Padding(
-      padding:
-          const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
-      child: Material(
-        color: isSelected ? cs.primaryContainer : cs.surfaceContainerHigh,
-        borderRadius: BorderRadius.circular(20),
-        clipBehavior: Clip.antiAlias,
-        child: InkWell(
-          onLongPress: () {
-            if (!selectionMode) {
-              ref.read(qbitSelectionProvider(instance).notifier).update(
-                    (Set<String> s) => <String>{...s, torrent.hash},
-                  );
-            }
-          },
-          onTap: () {
+    final Widget tile = Material(
+      color: isSelected ? cs.primaryContainer : cs.surfaceContainerHigh,
+      borderRadius: BorderRadius.circular(20),
+      clipBehavior: Clip.antiAlias,
+      child: InkWell(
+        onTapDown: (TapDownDetails details) {
+          _tapPosition = details.globalPosition;
+          _menuShown = false;
+          if (!selectionMode) {
+            _longPressTimer?.cancel();
+            _longPressTimer = Timer(const Duration(milliseconds: 250), () {
+              if (_tapPosition != null && mounted) {
+                _menuShown = true;
+                _showContextMenu(context);
+              }
+            });
+          }
+        },
+        onTapCancel: () => _longPressTimer?.cancel(),
+        onTap: () {
+            _longPressTimer?.cancel();
+            if (_menuShown) return;
+            
             if (selectionMode) {
               ref
                   .read(qbitSelectionProvider(instance).notifier)
@@ -774,7 +638,100 @@ class _TorrentTile extends ConsumerWidget {
             ),
           ),
         ),
-      ),
+    );
+
+    if (selectionMode) {
+      return Padding(
+        padding: const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
+        child: tile,
+      );
+    }
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(Insets.md, Insets.xs, Insets.md, Insets.xs),
+      child: tile,
+    );
+  }
+
+  void _showContextMenu(BuildContext context) {
+    final Instance inst = widget.instance;
+    final String hash = widget.torrent.hash;
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    
+    Widget _buildItem(IconData icon, String label, VoidCallback onTap, {Color? color}) {
+      return ListTile(
+        leading: Icon(icon, color: color ?? cs.onSurfaceVariant),
+        title: Text(label, style: TextStyle(color: color)),
+        onTap: () {
+          Navigator.of(context).pop();
+          onTap();
+        },
+      );
+    }
+
+    showGeneralDialog<void>(
+      context: context,
+      barrierDismissible: true,
+      barrierLabel: 'Dismiss',
+      transitionDuration: const Duration(milliseconds: 250),
+      pageBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation) {
+        return Dialog(
+          clipBehavior: Clip.antiAlias,
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(vertical: 8.0),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  _buildItem(Icons.check_circle_outline, 'Select', () {
+                    ref.read(qbitSelectionProvider(inst).notifier).update(
+                          (Set<String> s) => <String>{...s, hash},
+                        );
+                  }),
+                  _buildItem(Icons.pause, 'Pause', () {
+                    QbittorrentActionUtils.run(ref, inst, (QbittorrentClient c) => c.pause(<String>[hash]));
+                  }),
+                  _buildItem(Icons.play_arrow, 'Resume', () {
+                    QbittorrentActionUtils.run(ref, inst, (QbittorrentClient c) => c.resume(<String>[hash]));
+                  }),
+                  _buildItem(Icons.copy, 'Copy Hash', () async {
+                    await Clipboard.setData(ClipboardData(text: hash));
+                  }),
+                  _buildItem(Icons.refresh, 'Force Recheck', () {
+                    QbittorrentActionUtils.run(ref, inst, (QbittorrentClient c) => c.recheck(<String>[hash]));
+                  }),
+                  _buildItem(Icons.edit, 'Rename', () {
+                    QbittorrentActionUtils.rename(context, ref, inst, <String>{hash});
+                  }),
+                  _buildItem(Icons.folder, 'Set SavePath', () {
+                    QbittorrentActionUtils.editSavePath(context, ref, inst, <String>{hash});
+                  }),
+                  _buildItem(Icons.label, 'Set Category', () {
+                    QbittorrentActionUtils.editCategory(context, ref, inst, <String>{hash});
+                  }),
+                  _buildItem(Icons.delete, 'Delete', () {
+                    QbittorrentActionUtils.confirmDelete(context, ref, inst, <String>{hash});
+                  }, color: Colors.red),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+      transitionBuilder: (BuildContext context, Animation<double> animation, Animation<double> secondaryAnimation, Widget child) {
+        return ScaleTransition(
+          scale: CurvedAnimation(
+            parent: animation,
+            curve: Curves.fastOutSlowIn,
+          ),
+          child: FadeTransition(
+            opacity: animation,
+            child: child,
+          ),
+        );
+      },
     );
   }
 }
@@ -1053,6 +1010,7 @@ class _ExpandableFabState extends State<_ExpandableFab>
         children: <Widget>[
           ..._buildExpandingActionButtons(),
           FloatingActionButton(
+            heroTag: null,
             onPressed: _toggle,
             child: AnimatedBuilder(
               animation: _expandAnimation,

--- a/services/service_sonarr/lib/service_sonarr.dart
+++ b/services/service_sonarr/lib/service_sonarr.dart
@@ -5,6 +5,7 @@ import 'package:core_models/core_models.dart';
 import 'package:flutter_riverpod/legacy.dart';
 
 export 'src/models/sonarr_episode.dart';
+export 'src/models/sonarr_history_item.dart';
 export 'src/models/sonarr_queue_item.dart';
 export 'src/models/sonarr_series.dart';
 export 'src/series_detail_screen.dart';


### PR DESCRIPTION
Extracts the self-contained features from #38 without the whole-repo reformat.

## Changes
- **Recently downloaded widget**: a new dashboard widget listing the latest Sonarr and Radarr history across every instance, wired into the board and the pull-to-refresh.
- **qBittorrent floating action menu**: torrent actions routed through a shared utility and surfaced from a floating menu.
- **Glances**: smoother transitions.

## Not included from #38
- The whole-repo dart format reflow (182 files even ignoring whitespace); this touches 9.
- The expressive_refresh dependency. Both qBittorrent and Glances already used the existing M3RefreshIndicator, so these features needed no new dependency.
- A redundant palette_generator, alongside the palette_generator_plus already in use.
- Two committed artifacts: diff.txt (a UTF-16 dump of a git diff) and an empty history.json.

## Fixed while extracting
- SonarrHistoryItem was not exported from the service_sonarr barrel, so the widget could not compile. Added the export, matching what service_radarr already does.
- Updated two dashboard tests that hardcoded the widget-kind count.

Authored to lxBlazarxl.

## Testing
- flutter analyze: No issues found
- app test suite: 50 tests pass
- Built and installed on device (build 4119)