### PR TITLE
Correct the F-Droid privacy claim about artwork requests

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -33,8 +33,13 @@ Features:
 
 Privacy:
 
-Atrium talks only to the servers you configure. There is no analytics, no
-telemetry, no advertising and no account. Credentials are held in encrypted
-storage on the device.
+There is no analytics, no telemetry, no advertising and no account. Atrium
+never reports anything back to its developers. Credentials are held in
+encrypted storage on the device.
+
+One thing to know: posters and backdrops are fetched from the artwork sites
+your servers point at, usually TheTVDB, TMDB or Fanart.tv. Those requests
+come from your device, so those sites see your IP address and which titles
+you are looking at. Everything else goes only to the servers you configure.
 
 Free software under the GPL-3.0-or-later.


### PR DESCRIPTION
Lands before the `v1.0.0` tag is created, since F-Droid reads the listing
metadata from the tagged commit.

The description claimed "Atrium talks only to the servers you configure."
That is not true. Posters and backdrops come from the `remoteUrl` the *arr
servers return, which points at TheTVDB, TMDB or Fanart.tv, so the device
contacts those sites directly and they see its IP and what is being
browsed. Eleven files fetch artwork this way.

The no-telemetry claim is unchanged and remains accurate: nothing is
reported back to the developers.

A code-level fix is possible later. The *arr servers cache artwork and
serve it themselves, so switching to the local `url` would keep artwork
requests on the user's own machines. That is a behaviour change, not a
release-day doc fix.