### PR TITLE
Release 1.0.1: stop sending the api key to artwork CDNs

### DIFF
--- a/app/lib/src/arr_artwork.dart
+++ b/app/lib/src/arr_artwork.dart
@@ -1,0 +1,54 @@
+/// Artwork URLs for Sonarr and Radarr items, served by the instance itself.
+///
+/// Sonarr and Radarr each cache the artwork they fetch and serve it back under
+/// `/MediaCover`, so `posterUrl` resolves to the user's own machine. The models
+/// also carry a `remoteUrl` pointing straight at TheTVDB, TMDB or Fanart.tv;
+/// reading that field renders the same picture but makes the device talk to a
+/// third party, which then sees the IP and what is being browsed. Go through
+/// these helpers rather than touching `remoteUrl`.
+///
+/// The exception is artwork for something not in the library yet, such as an
+/// add-series search result. The server has nothing cached for it, so those
+/// call sites pass `preferRemote: true` deliberately.
+///
+/// Each returns null while the API is still loading or when no image of the
+/// requested type exists, and callers fall back to an icon.
+library;
+
+import 'package:collection/collection.dart';
+import 'package:service_radarr/service_radarr.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+String? _sonarr(SonarrApi? api, List<SonarrImage> images, String coverType) {
+  if (api == null) {
+    return null;
+  }
+  final SonarrImage? image =
+      images.firstWhereOrNull((SonarrImage im) => im.coverType == coverType);
+  return image == null ? null : api.posterUrl(image);
+}
+
+String? _radarr(RadarrApi? api, List<RadarrImage> images, String coverType) {
+  if (api == null) {
+    return null;
+  }
+  final RadarrImage? image =
+      images.firstWhereOrNull((RadarrImage im) => im.coverType == coverType);
+  return image == null ? null : api.posterUrl(image);
+}
+
+/// Poster for a Sonarr series.
+String? sonarrPosterUrl(SonarrApi? api, List<SonarrImage> images) =>
+    _sonarr(api, images, 'poster');
+
+/// Wide backdrop for a Sonarr series.
+String? sonarrFanartUrl(SonarrApi? api, List<SonarrImage> images) =>
+    _sonarr(api, images, 'fanart');
+
+/// Poster for a Radarr movie.
+String? radarrPosterUrl(RadarrApi? api, List<RadarrImage> images) =>
+    _radarr(api, images, 'poster');
+
+/// Wide backdrop for a Radarr movie.
+String? radarrFanartUrl(RadarrApi? api, List<RadarrImage> images) =>
+    _radarr(api, images, 'fanart');

--- a/app/lib/src/dashboard/widgets/recently_added_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_added_widget.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
@@ -9,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sonarr/service_sonarr.dart';
 
+import '../../arr_artwork.dart';
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
 
@@ -63,6 +63,7 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
           ref.watch(sonarrSeriesProvider(i));
       anyLoading |= series.isLoading && !series.hasValue;
       anyError |= series.hasError;
+      final SonarrApi? sonarrApi = ref.watch(sonarrApiProvider(i)).value;
       for (final SonarrSeries s in series.value ?? const <SonarrSeries>[]) {
         final DateTime? added = DateTime.tryParse(s.added ?? '');
         if (added == null) {
@@ -75,9 +76,7 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
           instance: i,
           year: s.year,
           series: s,
-          posterUrl: s.images
-              .firstWhereOrNull((SonarrImage im) => im.coverType == 'poster')
-              ?.remoteUrl,
+          posterUrl: sonarrPosterUrl(sonarrApi, s.images),
         ));
       }
     }
@@ -86,6 +85,7 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
           ref.watch(radarrMoviesProvider(i));
       anyLoading |= movies.isLoading && !movies.hasValue;
       anyError |= movies.hasError;
+      final RadarrApi? radarrApi = ref.watch(radarrApiProvider(i)).value;
       for (final RadarrMovie m in movies.value ?? const <RadarrMovie>[]) {
         final DateTime? added = DateTime.tryParse(m.added ?? '');
         if (added == null) {
@@ -98,9 +98,7 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
           instance: i,
           year: m.year,
           movieId: m.id,
-          posterUrl: m.images
-              .firstWhereOrNull((RadarrImage im) => im.coverType == 'poster')
-              ?.remoteUrl,
+          posterUrl: radarrPosterUrl(radarrApi, m.images),
         ));
       }
     }

--- a/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
@@ -1,5 +1,4 @@
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
@@ -9,6 +8,7 @@ import 'package:go_router/go_router.dart';
 import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sonarr/service_sonarr.dart';
 
+import '../../arr_artwork.dart';
 import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
 
@@ -88,6 +88,7 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
     for (final Instance i in sonarrInstances) {
       final AsyncValue<List<SonarrHistoryItem>> history =
           ref.watch(sonarrHistoryProvider(i));
+      final SonarrApi? api = ref.watch(sonarrApiProvider(i)).value;
       anyLoading |= history.isLoading && !history.hasValue;
       anyError |= history.hasError;
       for (final SonarrHistoryItem h
@@ -103,15 +104,14 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
           instance: i,
           series: h.series,
           subtitle: h.episode != null ? h.series!.title : null,
-          posterUrl: h.series!.images
-              .firstWhereOrNull((SonarrImage im) => im.coverType == 'poster')
-              ?.remoteUrl,
+          posterUrl: sonarrPosterUrl(api, h.series!.images),
         ));
       }
     }
     for (final Instance i in radarrInstances) {
       final AsyncValue<List<RadarrHistoryItem>> history =
           ref.watch(radarrHistoryProvider(i));
+      final RadarrApi? api = ref.watch(radarrApiProvider(i)).value;
       anyLoading |= history.isLoading && !history.hasValue;
       anyError |= history.hasError;
       for (final RadarrHistoryItem h
@@ -127,9 +127,7 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
           instance: i,
           movieId: h.movie!.id,
           subtitle: h.movie!.year?.toString(),
-          posterUrl: h.movie!.images
-              .firstWhereOrNull((RadarrImage im) => im.coverType == 'poster')
-              ?.remoteUrl,
+          posterUrl: radarrPosterUrl(api, h.movie!.images),
         ));
       }
     }
@@ -191,11 +189,6 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
                               ? CachedNetworkImage(
                                   imageUrl: item.posterUrl!,
                                   fit: BoxFit.cover,
-                                  httpHeaders: switch (item.instance.auth) {
-                                    InstanceAuthApiKey(:final String apiKey) =>
-                                      <String, String>{'X-Api-Key': apiKey},
-                                    _ => const <String, String>{},
-                                  },
                                   errorWidget: (_, __, ___) => Icon(
                                     item.isMovie ? Icons.movie : Icons.tv,
                                     color: cs.onSurfaceVariant,

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -9,10 +9,17 @@ import 'package:intl/intl.dart';
 import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sonarr/service_sonarr.dart';
 
+import '../arr_artwork.dart';
+
 /// Aggregated calendar event representation.
 sealed class CalendarEvent {
-  const CalendarEvent(this.instance);
+  const CalendarEvent(this.instance, {this.posterUrl, this.backdropUrl});
   final Instance instance;
+
+  /// Artwork served by the instance itself, resolved when the event is built
+  /// because that is where the API lives. Null renders a plain fallback.
+  final String? posterUrl;
+  final String? backdropUrl;
 
   String get title;
   DateTime get date;
@@ -24,15 +31,16 @@ sealed class CalendarEvent {
 
   /// Episode code + name (or year marker), for artwork-rich rows.
   String get subtitle;
-
-  /// Public artwork URLs (TMDB/fanart CDN remote urls), when the API included
-  /// them; null renders a plain fallback.
-  String? get posterUrl;
-  String? get backdropUrl;
 }
 
 class RadarrCalendarEvent extends CalendarEvent {
-  RadarrCalendarEvent(this.movie, super.instance, this.month);
+  RadarrCalendarEvent(
+    this.movie,
+    super.instance,
+    this.month, {
+    super.posterUrl,
+    super.backdropUrl,
+  });
   final RadarrMovie movie;
   final DateTime month;
 
@@ -76,16 +84,6 @@ class RadarrCalendarEvent extends CalendarEvent {
   @override
   String get subtitle => movie.year == null ? 'Movie' : '${movie.year} - Movie';
 
-  @override
-  String? get posterUrl => _image('poster');
-
-  @override
-  String? get backdropUrl => _image('fanart');
-
-  String? _image(String type) => movie.images
-      .firstWhereOrNull((RadarrImage i) => i.coverType == type)
-      ?.remoteUrl;
-
   static DateTime? _parseDate(String? s) {
     if (s == null || s.isEmpty) return null;
     return DateTime.tryParse(s)?.toLocal();
@@ -93,7 +91,12 @@ class RadarrCalendarEvent extends CalendarEvent {
 }
 
 class SonarrCalendarEvent extends CalendarEvent {
-  SonarrCalendarEvent(this.episode, super.instance);
+  SonarrCalendarEvent(
+    this.episode,
+    super.instance, {
+    super.posterUrl,
+    super.backdropUrl,
+  });
   final SonarrEpisode episode;
 
   @override
@@ -124,16 +127,6 @@ class SonarrCalendarEvent extends CalendarEvent {
     final String e = episode.episodeNumber.toString().padLeft(2, '0');
     return episode.title.isEmpty ? 'S${s}E$e' : 'S${s}E$e - ${episode.title}';
   }
-
-  @override
-  String? get posterUrl => _image('poster');
-
-  @override
-  String? get backdropUrl => _image('fanart');
-
-  String? _image(String type) => episode.series?.images
-      .firstWhereOrNull((SonarrImage i) => i.coverType == type)
-      ?.remoteUrl;
 }
 
 /// Aggregated calendar provider for all active Sonarr and Radarr instances.
@@ -150,48 +143,55 @@ final globalCalendarProvider =
     if (instance.kind == ServiceKind.radarr) {
       final AsyncValue<List<RadarrMovie>> state =
           ref.watch(radarrCalendarProvider((instance, month)));
+      final RadarrApi? api = ref.watch(radarrApiProvider(instance)).value;
+
+      RadarrCalendarEvent build(RadarrMovie m) => RadarrCalendarEvent(
+            m,
+            instance,
+            month,
+            posterUrl: radarrPosterUrl(api, m.images),
+            backdropUrl: radarrFanartUrl(api, m.images),
+          );
 
       if (state is AsyncLoading) {
         futures.add(
           ref
               .read(radarrCalendarProvider((instance, month)).future)
               .then((List<RadarrMovie> movies) {
-            allEvents.addAll(
-              movies.map(
-                  (RadarrMovie m) => RadarrCalendarEvent(m, instance, month)),
-            );
+            allEvents.addAll(movies.map(build));
           }).catchError((Object e) {
             // Ignore error
           }),
         );
       } else if (state is AsyncData<List<RadarrMovie>>) {
-        allEvents.addAll(
-          state.value
-              .map((RadarrMovie m) => RadarrCalendarEvent(m, instance, month)),
-        );
+        allEvents.addAll(state.value.map(build));
       }
     } else if (instance.kind == ServiceKind.sonarr) {
       final AsyncValue<List<SonarrEpisode>> state =
           ref.watch(sonarrCalendarProvider((instance, month)));
+      final SonarrApi? api = ref.watch(sonarrApiProvider(instance)).value;
+
+      SonarrCalendarEvent build(SonarrEpisode e) => SonarrCalendarEvent(
+            e,
+            instance,
+            posterUrl:
+                sonarrPosterUrl(api, e.series?.images ?? const <SonarrImage>[]),
+            backdropUrl:
+                sonarrFanartUrl(api, e.series?.images ?? const <SonarrImage>[]),
+          );
 
       if (state is AsyncLoading) {
         futures.add(
           ref
               .read(sonarrCalendarProvider((instance, month)).future)
               .then((List<SonarrEpisode> episodes) {
-            allEvents.addAll(
-              episodes
-                  .map((SonarrEpisode e) => SonarrCalendarEvent(e, instance)),
-            );
+            allEvents.addAll(episodes.map(build));
           }).catchError((Object e) {
             // Ignore error
           }),
         );
       } else if (state is AsyncData<List<SonarrEpisode>>) {
-        allEvents.addAll(
-          state.value
-              .map((SonarrEpisode e) => SonarrCalendarEvent(e, instance)),
-        );
+        allEvents.addAll(state.value.map(build));
       }
     }
   }

--- a/app/lib/src/screens/changelog_screen.dart
+++ b/app/lib/src/screens/changelog_screen.dart
@@ -14,6 +14,20 @@ class _Release {
 /// Newest first. Update alongside the version in the app's pubspec.
 const List<_Release> _releases = <_Release>[
   _Release(
+    version: '1.0.1',
+    changes: <String>[
+      'Security fix: 1.0.0 sent your Sonarr or Radarr API key to the artwork '
+          'sites TheTVDB, TMDB and Fanart.tv, as a header on the poster '
+          'requests made by the recently downloaded widget. Those keys grant '
+          'full control of the server. If you ran 1.0.0, consider rotating the '
+          'API key of every Sonarr and Radarr instance you use.',
+      'Posters and backdrops on the dashboard and in the calendar now load '
+          'from your own Sonarr and Radarr instances, which already cache '
+          'them, rather than from those artwork sites. They no longer see your '
+          'address or what you are browsing.',
+    ],
+  ),
+  _Release(
     version: '1.0.0',
     changes: <String>[
       'Dashboard board of at-a-glance widgets: active downloads, now streaming, '

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -180,7 +180,7 @@ class SettingsScreen extends ConsumerWidget {
           const ListTile(
             leading: Icon(Icons.info_outline),
             title: Text('Atrium'),
-            subtitle: Text('Version 1.0.0 • GPL-3.0-or-later'),
+            subtitle: Text('Version 1.0.1 • GPL-3.0-or-later'),
           ),
           ListTile(
             leading: const Icon(Icons.code),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.0.0+1
+version: 1.0.1+2
 
 environment:
   sdk: ^3.6.0

--- a/fastlane/metadata/android/en-US/changelogs/2.txt
+++ b/fastlane/metadata/android/en-US/changelogs/2.txt
@@ -1,0 +1,9 @@
+Security fix. Update if you ran 1.0.0.
+
+1.0.0 sent your Sonarr or Radarr API key to the artwork sites TheTVDB, TMDB and
+Fanart.tv, as a header on the poster requests the recently downloaded widget
+made. Those keys grant full control of the server. If you ran 1.0.0, consider
+rotating the API key of every Sonarr and Radarr instance you use.
+
+Posters and backdrops on the dashboard and in the calendar now load from your
+own instances, which already cache them, rather than from those artwork sites.


### PR DESCRIPTION
A security fix, worth landing promptly. 1.0.0 is published and one APK has
been downloaded.

## What was wrong

`recently_downloaded_widget.dart` attached the instance's api key as an
`X-Api-Key` header to image requests whose URL was the model's `remoteUrl`,
pointing at TheTVDB, TMDB or Fanart.tv. So a key granting full control of a
Sonarr or Radarr server was sent to a third-party CDN with no use for it.

It was the only place in the codebase sending headers with an image
request, and it was unnecessary regardless: `posterUrl()` already puts the
key in the query string, which is why nothing else does this.

## The wider fix

The dashboard widgets and the calendar read `remoteUrl` directly instead of
going through `posterUrl()`, so artwork came from those CDNs rather than the
instance that already caches it, and they saw the device IP and what was
being browsed. The upcoming widget leaked most, rendering a full-width
backdrop per row.

`CalendarEvent` now takes artwork URLs through its constructor, resolved in
`globalCalendarProvider` where the API is reachable, so the widgets stay
dumb. `arr_artwork.dart` holds the helpers and documents why `remoteUrl` is
the wrong field to reach for.

The three `preferRemote: true` sites in add-series and add-movie search are
untouched. The server has nothing cached for a title it has never seen.

## Disclosure

The in-app change log and the release notes both say plainly what happened
and advise rotating the api key of any instance that ran 1.0.0. Anyone on
1.0.0 has no other way to learn they should.

## Verified

* `flutter analyze` clean, 50 tests pass
* Built and installed on device; posters render from the instance
* `remoteUrl` no longer appears anywhere in `app/lib` outside the comment
  explaining why not to use it