### PR TITLE
Release 1.0.2: drop Google's dependency metadata blob, fix build_all

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -32,6 +32,16 @@ android {
         targetCompatibility = JavaVersion.VERSION_17
     }
 
+    // The Android Gradle Plugin otherwise writes an encrypted list of the
+    // dependency tree into the APK signing block, for Google Play Console to
+    // read. Nothing here is ever uploaded to Play, no build reads it back, and
+    // F-Droid refuses to publish an APK carrying an opaque blob it cannot
+    // inspect.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     defaultConfig {
         applicationId = "app.atrium"
         // local_auth + flutter_secure_storage need API 23+ (BiometricPrompt,

--- a/app/lib/src/screens/changelog_screen.dart
+++ b/app/lib/src/screens/changelog_screen.dart
@@ -14,6 +14,16 @@ class _Release {
 /// Newest first. Update alongside the version in the app's pubspec.
 const List<_Release> _releases = <_Release>[
   _Release(
+    version: '1.0.2',
+    changes: <String>[
+      'The Android build tools were writing an encrypted list of the app\'s '
+          'dependencies into every APK, in a form only Google Play can read. '
+          'Nothing sent it anywhere, but it has no business being in the app '
+          'and is gone.',
+      'Groundwork for the F-Droid listing.',
+    ],
+  ),
+  _Release(
     version: '1.0.1',
     changes: <String>[
       'Security fix: 1.0.0 sent your Sonarr or Radarr API key to the artwork '

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -180,7 +180,7 @@ class SettingsScreen extends ConsumerWidget {
           const ListTile(
             leading: Icon(Icons.info_outline),
             title: Text('Atrium'),
-            subtitle: Text('Version 1.0.1 • GPL-3.0-or-later'),
+            subtitle: Text('Version 1.0.2 • GPL-3.0-or-later'),
           ),
           ListTile(
             leading: const Icon(Icons.code),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.0.1+2
+version: 1.0.2+3
 
 environment:
   sdk: ^3.6.0

--- a/fastlane/metadata/android/en-US/changelogs/3.txt
+++ b/fastlane/metadata/android/en-US/changelogs/3.txt
@@ -1,0 +1,5 @@
+The Android build tools were writing an encrypted list of the app's dependencies
+into every APK, in a form only Google Play can read. Nothing ever sent it
+anywhere, but it has no business being in the app and is gone.
+
+Groundwork for the F-Droid listing.

--- a/tool/build_all.dart
+++ b/tool/build_all.dart
@@ -18,24 +18,28 @@ void main(List<String> args) async {
   final rootDir = Directory.current;
   final workspaceDirs = <Directory>[];
 
-  // Recursively find all package directories containing a pubspec.yaml with build_runner
+  // Recursively find all package directories containing a pubspec.yaml with
+  // build_runner. A recursive list() has already descended by the time it hands
+  // an entity back, so a directory cannot be pruned once it is seen; each
+  // pubspec is judged by its own path instead. Filtering the directory entry
+  // alone did nothing, because only files decide what gets added, which is how
+  // a PUB_CACHE inside the tree came to offer every downloaded dependency up as
+  // a package to build.
+  const skipSegments = {'build', 'ios', 'android'};
   await for (final entity
       in rootDir.list(recursive: true, followLinks: false)) {
-    if (entity is Directory) {
-      final name = entity.uri.pathSegments
-          .lastWhere((s) => s.isNotEmpty, orElse: () => '');
-      // Skip common hidden or build directories
-      if (name.startsWith('.') ||
-          name == 'build' ||
-          name == 'ios' ||
-          name == 'android') {
-        continue;
-      }
-    } else if (entity is File && entity.path.endsWith('pubspec.yaml')) {
-      final content = await entity.readAsString();
-      if (content.contains('build_runner:')) {
-        workspaceDirs.add(entity.parent);
-      }
+    if (entity is! File || !entity.path.endsWith('pubspec.yaml')) {
+      continue;
+    }
+    final segments = entity.parent.path
+        .replaceFirst(rootDir.path, '')
+        .split(Platform.pathSeparator);
+    if (segments.any((s) => s.startsWith('.') || skipSegments.contains(s))) {
+      continue;
+    }
+    final content = await entity.readAsString();
+    if (content.contains('build_runner:')) {
+      workspaceDirs.add(entity.parent);
     }
   }
 


### PR DESCRIPTION
Needed to get onto F-Droid, and worth having regardless.

## The APK carried a Google-only blob

The Android Gradle Plugin writes an encrypted manifest of the dependency
tree into the APK signing block, for Play Console to read. Confirmed
present in the published 1.0.0 and 1.0.1 APKs:

```
0x7109871a  v2 signature
0x504b4453  DEPENDENCY METADATA   <- this
0x42726577  padding
```

Nothing transmits it, so the no-telemetry claim was never affected. But
nothing here is ever uploaded to Play, no build reads it back, and F-Droid
refuses to publish an APK containing a blob it cannot inspect. Now disabled
via `dependenciesInfo`, and verified gone from all three ABIs.

## build_all walked into the pub cache

`tool/build_all.dart` finds packages by walking the tree, but its skip list
ran against directory entries while a recursive `list()` has already
descended, and only files decide what gets added. So the filter could never
exclude anything. With `PUB_CACHE` inside the checkout, as F-Droid's builder
sets it, build_all offered up 38 downloaded dependencies as packages and ran
build_runner inside them.

Latent until now because `PUB_CACHE` normally sits outside the tree. Proven
with a probe against a planted in-tree cache: old logic selected 20 with 2
leaks, fixed logic selects 18 with 0. It leaked `app/build/` too, so the
`build` filter was equally decorative.

## Verified

* `flutter analyze` clean, 50 tests pass
* All three ABIs build; signing block is now v2 signature + padding only
* F-Droid's own CI built this app successfully from the v1.0.1 tag, so the
  recipe itself is proven; these are the last two blockers