### PR TITLE
Release 1.0.3: build releases in CI for reproducibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Release APKs
+
+# Builds the release APKs that get published to GitHub Releases.
+#
+# These builds are the reference F-Droid verifies against, so they have to be
+# byte-reproducible on their Debian builders. That constrains this workflow more
+# than a normal one:
+#
+#   * BUILD_DIR is load-bearing. Flutter writes the absolute path of
+#     .dart_tool/flutter_build/dart_plugin_registrant.dart into the AOT snapshot
+#     as a string constant, so a build at a different path produces a different
+#     APK. metadata/app.atrium.yml in fdroiddata moves its checkout to the same
+#     path. Change one and you must change the other.
+#   * Every toolchain version is pinned. A different Flutter, JDK or NDK emits
+#     different bytes.
+#   * The APKs land here unsigned. They are signed by hand afterwards, so the
+#     keystore never has to live in GitHub. See docs/RELEASING.md.
+#
+# Nothing here publishes on its own; it uploads artifacts to download, sign and
+# attach to a release.
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Must match the path fdroiddata's recipe builds at.
+  BUILD_DIR: /tmp/build
+  FLUTTER_VERSION: 3.41.9
+  JAVA_VERSION: '17'
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: ${{ env.FLUTTER_VERSION }}
+          channel: stable
+          cache: true
+
+      # Relocate before building. The checkout path ends up inside the APK, so
+      # it has to be the path F-Droid rebuilds at, not the runner's default.
+      - name: Move the checkout to the reproducible build path
+        run: |
+          mkdir -p "$(dirname "$BUILD_DIR")"
+          cp -a "$GITHUB_WORKSPACE" "$BUILD_DIR"
+
+      - name: Resolve dependencies
+        working-directory: ${{ env.BUILD_DIR }}/app
+        run: |
+          export PUB_CACHE="$(pwd)/.pub-cache"
+          flutter config --no-analytics
+          flutter pub get --enforce-lockfile
+
+      - name: Generate freezed and json_serializable sources
+        working-directory: ${{ env.BUILD_DIR }}
+        run: |
+          export PUB_CACHE="$BUILD_DIR/app/.pub-cache"
+          dart run tool/build_all.dart
+
+      - name: Build the release APKs
+        working-directory: ${{ env.BUILD_DIR }}/app
+        run: |
+          export PUB_CACHE="$(pwd)/.pub-cache"
+          flutter build apk --release --split-per-abi
+
+      # Prove the workflow did not quietly sign them. An APK with a signature
+      # here means key material leaked into CI, and it would also fail F-Droid's
+      # verification.
+      - name: Check the APKs are unsigned
+        working-directory: ${{ env.BUILD_DIR }}/app/build/app/outputs/flutter-apk
+        run: |
+          for apk in app-*-release.apk; do
+            if unzip -l "$apk" | grep -q 'META-INF/.*\.\(RSA\|DSA\|EC\|SF\)$'; then
+              echo "$apk carries a signature; it must be unsigned here"
+              exit 1
+            fi
+            echo "$apk is unsigned"
+          done
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-apks
+          path: ${{ env.BUILD_DIR }}/app/build/app/outputs/flutter-apk/app-*-release.apk
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -98,15 +98,25 @@ from the repository root, run:
 dart run tool/build_all.dart
 ```
 
-A release build is **unsigned** unless `app/android/key.properties` exists,
-and an unsigned APK will not install, so `flutter run --release` needs one.
-To sign with your own key, copy `key.properties.example` next to it and fill
-it in; the file and the keystore it points at are gitignored. Debug builds
-need none of this.
+Debug builds need no setup. To try a **release** build without a signing key
+of your own, sign it with the debug key:
 
-Leaving the build unsigned is deliberate: F-Droid verifies a release by
-copying the signature off the published APK onto its own build of the same
-source, which only works if that build carries no signature of its own.
+```sh
+flutter build apk --release -PdebugSignRelease=true
+```
+
+Without that flag a release build comes out **unsigned**, and an unsigned APK
+will not install. That is deliberate rather than an oversight: F-Droid
+verifies a release by copying the signature off the published APK onto its
+own build of the same source, which only works if its build carries no
+signature. So the flag must never be set for anything you publish.
+
+To sign with your own key instead, copy `app/android/key.properties.example`
+next to itself as `key.properties` and fill it in; that file and the keystore
+it points at are gitignored.
+
+Published releases are built by CI and signed by hand: see
+[docs/RELEASING.md](docs/RELEASING.md).
 
 ## Repo layout
 

--- a/README.md
+++ b/README.md
@@ -98,9 +98,15 @@ from the repository root, run:
 dart run tool/build_all.dart
 ```
 
-A release build is debug-signed unless `app/android/key.properties`
-exists. To sign with your own key, copy `key.properties.example` next to
-it and fill it in; the file and the keystore it points at are gitignored.
+A release build is **unsigned** unless `app/android/key.properties` exists,
+and an unsigned APK will not install, so `flutter run --release` needs one.
+To sign with your own key, copy `key.properties.example` next to it and fill
+it in; the file and the keystore it points at are gitignored. Debug builds
+need none of this.
+
+Leaving the build unsigned is deliberate: F-Droid verifies a release by
+copying the signature off the published APK onto its own build of the same
+source, which only works if that build carries no signature of its own.
 
 ## Repo layout
 

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -84,10 +84,17 @@ android {
             // No signing config at all leaves the APK unsigned. A config
             // carrying a null storeFile is rejected outright by the Android
             // Gradle Plugin, so the absence has to be expressed here.
-            signingConfig = if (hasReleaseSigning) {
-                signingConfigs.getByName("release")
-            } else {
-                null
+            signingConfig = when {
+                hasReleaseSigning -> signingConfigs.getByName("release")
+                // An unsigned APK cannot be installed, which is unhelpful when
+                // you only want to try a release build. Opt into the debug key
+                // with `flutter build apk --release -PdebugSignRelease=true`.
+                // Never set it for a published build: F-Droid rebuilds this
+                // source and needs the result unsigned to verify it against the
+                // released APK.
+                project.hasProperty("debugSignRelease") ->
+                    signingConfigs.getByName("debug")
+                else -> null
             }
         }
     }

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -2,9 +2,13 @@ import java.util.Properties
 
 // Release signing material, kept out of the repository. Create
 // android/key.properties (gitignored) from key.properties.example to sign a
-// release build. When it is absent - a fresh clone, CI, or the F-Droid builder,
-// which signs with its own key - the release build falls back to the debug key
-// so `flutter build` still works.
+// release build.
+//
+// When it is absent the release build is left UNSIGNED, rather than falling
+// back to the debug key. F-Droid verifies a release by copying the signature
+// off the published APK onto its own build of the same source, which only
+// works if its build carries no signature of its own. An unsigned APK cannot
+// be installed, so `flutter run --release` needs key.properties present.
 val keystorePropertiesFile = rootProject.file("key.properties")
 val keystoreProperties = Properties().apply {
     if (keystorePropertiesFile.exists()) {
@@ -77,10 +81,13 @@ android {
 
     buildTypes {
         release {
+            // No signing config at all leaves the APK unsigned. A config
+            // carrying a null storeFile is rejected outright by the Android
+            // Gradle Plugin, so the absence has to be expressed here.
             signingConfig = if (hasReleaseSigning) {
                 signingConfigs.getByName("release")
             } else {
-                signingConfigs.getByName("debug")
+                null
             }
         }
     }

--- a/app/lib/src/screens/changelog_screen.dart
+++ b/app/lib/src/screens/changelog_screen.dart
@@ -14,6 +14,15 @@ class _Release {
 /// Newest first. Update alongside the version in the app's pubspec.
 const List<_Release> _releases = <_Release>[
   _Release(
+    version: '1.0.3',
+    changes: <String>[
+      'Nothing changes in the app itself. Releases are now built by a server '
+          'rather than by hand, so that F-Droid can rebuild them and check they '
+          'match. That lets F-Droid ship the same signature this release page '
+          'uses, and means you can move between the two without reinstalling.',
+    ],
+  ),
+  _Release(
     version: '1.0.2',
     changes: <String>[
       'The Android build tools were writing an encrypted list of the app\'s '

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -180,7 +180,7 @@ class SettingsScreen extends ConsumerWidget {
           const ListTile(
             leading: Icon(Icons.info_outline),
             title: Text('Atrium'),
-            subtitle: Text('Version 1.0.2 • GPL-3.0-or-later'),
+            subtitle: Text('Version 1.0.3 • GPL-3.0-or-later'),
           ),
           ListTile(
             leading: const Icon(Icons.code),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.0.2+3
+version: 1.0.3+4
 
 environment:
   sdk: ^3.6.0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,98 @@
+# Releasing
+
+Releases are built by CI and signed by hand. The keystore never leaves the
+maintainer's machine, and it never goes into GitHub secrets.
+
+The APKs published here are the reference F-Droid rebuilds and verifies against,
+so this process is more constrained than it looks. Read [Why it is like
+this](#why-it-is-like-this) before changing any of it.
+
+## Cutting a release
+
+1. **Bump the version.** `app/pubspec.yaml` (`version: X.Y.Z+N`), the version
+   string in `app/lib/src/screens/settings_screen.dart`, a new entry in
+   `app/lib/src/screens/changelog_screen.dart`, and a new
+   `fastlane/metadata/android/en-US/changelogs/<N>.txt` named for the build
+   number, not the version.
+
+2. **Verify.** `flutter analyze` and `flutter test` from `app/`, both clean.
+
+3. **Merge to `main`** and tag it there:
+
+   ```sh
+   git tag vX.Y.Z origin/main
+   git push origin vX.Y.Z
+   ```
+
+   Pushing the tag triggers `.github/workflows/release.yml`, which builds the
+   three split APKs **unsigned** at `/tmp/build` and uploads them as the
+   `unsigned-apks` artifact.
+
+4. **Download the artifact** from the workflow run.
+
+5. **Sign each APK locally.** Use build-tools **34**, not the newest one:
+   apksigner 35 and later write APKs that F-Droid's `apksigcopier` cannot
+   verify, which silently breaks reproducible builds.
+
+   ```sh
+   # apksigner from build-tools 34 in the Android SDK; KEYSTORE is wherever you
+   # keep the release key, which is not in this repository.
+   for abi in arm64-v8a armeabi-v7a x86_64; do
+     apksigner sign --ks "$KEYSTORE" --ks-key-alias atrium \
+       --out "signed/app-$abi-release.apk" "unsigned/app-$abi-release.apk"
+   done
+   ```
+
+6. **Check what you signed** before it goes anywhere:
+
+   ```sh
+   apksigner verify --print-certs signed/app-arm64-v8a-release.apk
+   ```
+
+   It must report `CN=Atrium, O=Atrium` and SHA-256
+   `5ebad1ff2f9cdc63f28b364addf9e858330db26909d9eba8dfbccb998de37351`. A
+   different fingerprint means the wrong key, and shipping it would break
+   updates for everyone.
+
+7. **Publish** the release with all three signed APKs attached. The asset names
+   have to keep matching the `binary:` URLs in fdroiddata's
+   `metadata/app.atrium.yml`, or F-Droid cannot find them.
+
+8. **Bump fdroiddata.** `versionName`, `versionCode`, `commit`, `CurrentVersion`
+   and `CurrentVersionCode` in each of the three build blocks.
+
+## Why it is like this
+
+**The build path is part of the APK.** Flutter writes the absolute path of
+`.dart_tool/flutter_build/dart_plugin_registrant.dart` into the AOT snapshot as
+a string constant. Build at a different path and the bytes differ. There is no
+Dart equivalent of `--remap-path-prefix`; matching the path is the only known
+fix. This is why the workflow copies the checkout to `/tmp/build`, and why
+fdroiddata's recipe moves its checkout to exactly the same place. **Changing one
+without the other silently breaks verification.**
+
+**Which is also why releases cannot be built by hand any more.** A local build
+on another OS, or at any other path, can never match a Debian build at
+`/tmp/build`. Every published APK has to come out of the workflow.
+
+**The APKs are unsigned until step 5 on purpose.** F-Droid rebuilds the app from
+source on their own machines, then copies the signature off the published APK
+onto their build and asks apksigner to verify it. That only works if their build
+carries no signature, which is why `app/android/app/build.gradle.kts` attaches
+no signing config when `key.properties` is absent. It also means the keystore is
+only ever needed on one machine.
+
+**Everything is pinned.** Flutter, JDK and NDK versions all change the emitted
+bytes. The workflow pins them and fdroiddata's recipe pins the same ones. Bump
+them together or not at all.
+
+## If verification fails
+
+F-Droid's CI runs the comparison on every push to the merge request, so iterate
+there rather than by cutting releases. The usual suspects, roughly in order:
+
+- the build path drifted between the workflow and the recipe
+- a toolchain version differs (Flutter, JDK, NDK, build-tools)
+- the APK was signed with apksigner 35 or newer
+- the wrong artifact shape: F-Droid must build the same split as the `binary:`
+  URL points at, never a universal APK against split references

--- a/fastlane/metadata/android/en-US/changelogs/4.txt
+++ b/fastlane/metadata/android/en-US/changelogs/4.txt
@@ -1,0 +1,6 @@
+Nothing changes in the app itself.
+
+Releases are now built by a server rather than by hand, so that F-Droid can
+rebuild them and check they match. That lets F-Droid ship the same signature the
+GitHub release page uses, which means you can move between the two without
+uninstalling and losing your profiles.


### PR DESCRIPTION
No user-facing change. This is the groundwork F-Droid needs in the tag it
verifies.

## Why

F-Droid can distribute APKs carrying this project's signature instead of
their own, which lets a user move between the GitHub releases and F-Droid
without uninstalling. It has to be set up before the first F-Droid publish:
once they sign an app with their key, Android's signature check makes
switching impossible. Their MR template says so outright.

They verify by rebuilding the tag on their own machines and copying the
signature off the published APK onto their build. That imposes two things.

## Their build must be unsigned

`release` now attaches no signing config when `key.properties` is absent,
instead of falling back to the debug key. A config with a null `storeFile`
does not work: AGP rejects it with "SigningConfig 'release' is missing
required property 'storeFile'".

That would have left contributors unable to install a release build at all,
so `-PdebugSignRelease=true` opts into the debug key. It has to be asked for
explicitly, so a published build cannot pick it up by accident.

All three paths were checked against a real build:

| | |
|---|---|
| `key.properties` present | signed `CN=Atrium`, unchanged |
| absent, no flag | unsigned, no signing block |
| absent, `-PdebugSignRelease=true` | `CN=Android Debug`, installs |

## Their build must be byte-identical to ours

Flutter writes the absolute path of `dart_plugin_registrant.dart` into the
AOT snapshot as a string constant, so the build path is part of the APK.
There is no Dart equivalent of `--remap-path-prefix`; the only known fix is
building at the same path. `.github/workflows/release.yml` therefore builds
at `/tmp/build`, which fdroiddata's recipe will mirror, and pins Flutter and
the JDK.

A build on another OS, or at any other path, can never match, so published
APKs come out of CI from here on. The workflow leaves them unsigned and
uploads them to be signed separately, so no key material is needed in CI.
`docs/RELEASING.md` has the steps, including that apksigner 35 and newer
write APKs F-Droid cannot verify.

## Verified

* `flutter analyze` clean, 50 tests pass
* All three signing paths exercised against real APKs, signing blocks read
  back rather than assumed