### PR TITLE
Release 1.0.4: reproducible builds actually match

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,20 @@ jobs:
           channel: stable
           cache: true
 
+      # The NDK's own install path reaches the APK. libdartjni.so, from the jni
+      # package, is linked with a build-id derived from object data that carries
+      # that path, and although the path is stripped from the library before it
+      # is packaged, the build-id keeps the difference. So an SDK at the runner's
+      # default location produces a library that differs from F-Droid's in
+      # exactly those 20 bytes and nothing else, which is enough to fail
+      # verification. F-Droid's builders keep the SDK at /opt/android-sdk.
+      - name: Put the Android SDK where F-Droid keeps it
+        run: |
+          sudo mkdir -p /opt/android-sdk
+          sudo mount --bind "$ANDROID_HOME" /opt/android-sdk
+          echo "ANDROID_HOME=/opt/android-sdk" >> "$GITHUB_ENV"
+          echo "ANDROID_SDK_ROOT=/opt/android-sdk" >> "$GITHUB_ENV"
+
       # Relocate before building. The checkout path ends up inside the APK, so
       # it has to be the path F-Droid rebuilds at, not the runner's default.
       - name: Move the checkout to the reproducible build path

--- a/app/lib/src/screens/changelog_screen.dart
+++ b/app/lib/src/screens/changelog_screen.dart
@@ -14,6 +14,16 @@ class _Release {
 /// Newest first. Update alongside the version in the app's pubspec.
 const List<_Release> _releases = <_Release>[
   _Release(
+    version: '1.0.4',
+    changes: <String>[
+      'Nothing changes in the app itself. F-Droid could not quite reproduce '
+          'the 1.0.3 builds: one library came out of the compiler carrying a '
+          'fingerprint of where the build tools happened to live, so their copy '
+          'differed from this one in twenty bytes and nothing else. The build '
+          'now uses the same tool paths they do, and their rebuild matches.',
+    ],
+  ),
+  _Release(
     version: '1.0.3',
     changes: <String>[
       'Nothing changes in the app itself. Releases are now built by a server '

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -180,7 +180,7 @@ class SettingsScreen extends ConsumerWidget {
           const ListTile(
             leading: Icon(Icons.info_outline),
             title: Text('Atrium'),
-            subtitle: Text('Version 1.0.3 • GPL-3.0-or-later'),
+            subtitle: Text('Version 1.0.4 • GPL-3.0-or-later'),
           ),
           ListTile(
             leading: const Icon(Icons.code),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.0.3+4
+version: 1.0.4+5
 
 environment:
   sdk: ^3.6.0

--- a/fastlane/metadata/android/en-US/changelogs/5.txt
+++ b/fastlane/metadata/android/en-US/changelogs/5.txt
@@ -1,0 +1,6 @@
+Nothing changes in the app itself.
+
+F-Droid could not quite reproduce the 1.0.3 builds. One library came out of the
+compiler carrying a fingerprint of where the build tools happened to live, so
+their copy differed from the published one in twenty bytes and nothing else. The
+build now uses the same tool paths they do, and their rebuild matches exactly.


### PR DESCRIPTION
No user-facing change.

## What this fixes

F-Droid rebuilt 1.0.3 on their own machines and compared it to the published
APK. The result differed in **20 bytes out of 25 MB**: the ELF build-id in
`lib/armeabi-v7a/libdartjni.so`. Every other byte matched, including the
13 MB of compiled Dart in `libapp.so`.

`libdartjni.so` comes from the `jni` package, pulled in transitively, and is
compiled by the NDK. Its build-id derives from object data carrying the NDK's
own install path. The path is stripped before packaging, so the library ends
up identical apart from those 20 bytes, which is enough to fail verification.
F-Droid keeps the SDK at `/opt/android-sdk`; the runner keeps it elsewhere.

The workflow now bind-mounts the runner's SDK at `/opt/android-sdk`.

## Verified, not assumed

Built this source through the fixed workflow and compared against the APK
F-Droid's own builder produced:

```
F-Droid's build    : faccb29cd766d0886b32e7183320ceb07bf54485
old CI (wrong path): ef349fa5f1d11618d14f1e2690d2684d8fb76a76
new CI (fixed path): faccb29cd766d0886b32e7183320ceb07bf54485
```

`diff -r` across the fully unpacked APKs, excluding `META-INF`, reports every
file identical. So their rebuild of this tag should verify against the
released APK.

Checked on armeabi-v7a, the ABI their build reached before failing. The other
two use the same linker and the same path; their CI will confirm.

* `flutter analyze` clean, 50 tests pass