### PR TITLE
Release 1.0.5: F-Droid's version code scheme

### DIFF
--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.gradle.internal.api.ApkVariantOutputImpl
 import java.util.Properties
 
 // Release signing material, kept out of the repository. Create
@@ -108,4 +109,25 @@ kotlin {
 
 flutter {
     source = "../.."
+}
+
+// F-Droid's version code scheme for split APKs, which every Flutter app in
+// their repository follows. Flutter offsets the per-ABI version codes itself,
+// by +1000/+2000/+4000, but that behaviour has shifted between Flutter
+// releases, so the scheme is pinned here instead of inherited from whatever
+// the toolchain does this month.
+//
+// A build number of 6 gives 61, 62, 63. Keep this in step with the
+// VercodeOperation in fdroiddata's metadata/app.atrium.yml.
+val abiCodes = mapOf("armeabi-v7a" to 1, "arm64-v8a" to 2, "x86_64" to 3)
+android.applicationVariants.configureEach {
+    val variant = this
+    variant.outputs.forEach { output ->
+        val abiVersionCode =
+            abiCodes[output.filters.find { it.filterType == "ABI" }?.identifier]
+        if (abiVersionCode != null) {
+            (output as ApkVariantOutputImpl).versionCodeOverride =
+                variant.versionCode * 10 + abiVersionCode
+        }
+    }
 }

--- a/app/lib/src/screens/changelog_screen.dart
+++ b/app/lib/src/screens/changelog_screen.dart
@@ -14,6 +14,16 @@ class _Release {
 /// Newest first. Update alongside the version in the app's pubspec.
 const List<_Release> _releases = <_Release>[
   _Release(
+    version: '1.0.5',
+    changes: <String>[
+      'Nothing changes in the app itself. The internal build numbers now '
+          'follow the scheme F-Droid asks of Flutter apps. If you installed an '
+          'earlier release from GitHub, Android will refuse this as an update '
+          'and you will have to reinstall once; export your profiles from '
+          'Settings first. Nothing after this release is affected.',
+    ],
+  ),
+  _Release(
     version: '1.0.4',
     changes: <String>[
       'Nothing changes in the app itself. F-Droid could not quite reproduce '

--- a/app/lib/src/screens/settings_screen.dart
+++ b/app/lib/src/screens/settings_screen.dart
@@ -180,7 +180,7 @@ class SettingsScreen extends ConsumerWidget {
           const ListTile(
             leading: Icon(Icons.info_outline),
             title: Text('Atrium'),
-            subtitle: Text('Version 1.0.4 • GPL-3.0-or-later'),
+            subtitle: Text('Version 1.0.5 • GPL-3.0-or-later'),
           ),
           ListTile(
             leading: const Icon(Icons.code),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.0.4+5
+version: 1.0.5+6
 
 environment:
   sdk: ^3.6.0

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -58,8 +58,12 @@ this](#why-it-is-like-this) before changing any of it.
    have to keep matching the `binary:` URLs in fdroiddata's
    `metadata/app.atrium.yml`, or F-Droid cannot find them.
 
-8. **Bump fdroiddata.** `versionName`, `versionCode`, `commit`, `CurrentVersion`
-   and `CurrentVersionCode` in each of the three build blocks.
+8. **Bump fdroiddata.** `versionName`, `versionCode`, `commit` (a full commit
+   hash, not a tag), `CurrentVersion` and `CurrentVersionCode` in each of the
+   three build blocks. Version codes are `build number * 10 + abi`, where abi is
+   1 armeabi-v7a, 2 arm64-v8a, 3 x86_64: see the override at the foot of
+   `app/android/app/build.gradle.kts`, which must stay in step with the
+   `VercodeOperation` in their metadata.
 
 ## Why it is like this
 

--- a/fastlane/metadata/android/en-US/changelogs/6.txt
+++ b/fastlane/metadata/android/en-US/changelogs/6.txt
@@ -1,0 +1,6 @@
+Nothing changes in the app itself.
+
+The internal build numbers now follow the scheme F-Droid asks of Flutter apps.
+If you installed an earlier release from GitHub, Android will refuse this one as
+an update and you will have to reinstall once. Export your profiles from
+Settings first. Nothing after this release is affected.


### PR DESCRIPTION
No user-facing change, but see the caveat below: this one costs existing
GitHub installs a reinstall.

Addresses review on fdroid/fdroiddata!43077.

## Version codes

F-Droid asks Flutter apps to set the per-ABI version codes themselves rather
than inherit Flutter's automatic `+1000`/`+2000`/`+4000` offsets. Their
reasoning is sound: those offsets have shifted between Flutter releases, so
the scheme belongs to the app, not to whatever the toolchain does this month.
Every Flutter app in their repo does this; LocalSend's gradle carries the same
override under the comment "To comply with F-Droid version code schema".

Build 6 now gives 61 / 62 / 63. Verified against a real build, not assumed:

| APK | versionCode | versionName |
|---|---|---|
| armeabi-v7a | 61 | 1.0.5 |
| arm64-v8a | 62 | 1.0.5 |
| x86_64 | 63 | 1.0.5 |

**This is lower than the codes already published** (1005/2005/4005), so Android
will refuse it as an update for anyone who installed 1.0.0 to 1.0.4 from the
releases page. They have to uninstall and reinstall once. Both change logs say
so plainly and tell people to export their profiles first. Doing it now, days
in with a handful of downloads, costs less than doing it ever again.

## Also

The Flutter version is pinned at `.github/workflows/release.yml` and their
recipe will now extract it from there rather than hardcoding it, so the two
cannot drift.

`docs/RELEASING.md` records the scheme and that it must stay in step with the
`VercodeOperation` in their metadata.

## Reproducible builds are confirmed working

While this was being prepared, F-Droid's CI finished verifying 1.0.4:

```
08:54:07  INFO: ...successfully verified
09:11:50  INFO: ...successfully verified
09:29:17  INFO: ...successfully verified
```

All three ABIs. They rebuilt the tag on their own machines, copied this
project's signature onto their build, and apksigner confirmed it holds. So
F-Droid can ship APKs under this project's key rather than their own.

* `flutter analyze` clean, 50 tests pass