### PR TITLE
fix(scroll): clamp momentum overscroll, keep dashboard widgets alive, and animate circular gauges

### DIFF
--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -79,7 +79,7 @@ class DashboardBoard extends ConsumerWidget {
         itemCount: visible.length,
         separatorBuilder: (_, __) => const SizedBox(height: Insets.md),
         itemBuilder: (BuildContext context, int index) =>
-            _buildWidget(visible[index].kind, instances),
+            _KeepAliveWrapper(child: _buildWidget(visible[index].kind, instances)),
       ),
     );
   }
@@ -335,3 +335,25 @@ class _EditTile extends StatelessWidget {
     );
   }
 }
+
+class _KeepAliveWrapper extends StatefulWidget {
+  final Widget child;
+
+  const _KeepAliveWrapper({required this.child});
+
+  @override
+  State<_KeepAliveWrapper> createState() => _KeepAliveWrapperState();
+}
+
+class _KeepAliveWrapperState extends State<_KeepAliveWrapper>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}
+

--- a/app/lib/src/dashboard/widgets/recently_added_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_added_widget.dart
@@ -40,7 +40,7 @@ class _RecentItem {
 
 /// The most recently added Sonarr series and Radarr movies across every
 /// instance, merged and shown as a horizontally scrollable poster row.
-class DashboardRecentlyAddedWidget extends ConsumerWidget {
+class DashboardRecentlyAddedWidget extends ConsumerStatefulWidget {
   const DashboardRecentlyAddedWidget({
     required this.sonarrInstances,
     required this.radarrInstances,
@@ -51,14 +51,30 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
   final List<Instance> radarrInstances;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DashboardRecentlyAddedWidget> createState() =>
+      _DashboardRecentlyAddedWidgetState();
+}
+
+class _DashboardRecentlyAddedWidgetState
+    extends ConsumerState<DashboardRecentlyAddedWidget> {
+  final ScrollController _scrollController = ScrollController();
+  bool _needsReset = false;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
 
     final List<_RecentItem> items = <_RecentItem>[];
     bool anyLoading = false;
     bool anyError = false;
 
-    for (final Instance i in sonarrInstances) {
+    for (final Instance i in widget.sonarrInstances) {
       final AsyncValue<List<SonarrSeries>> series =
           ref.watch(sonarrSeriesProvider(i));
       anyLoading |= series.isLoading && !series.hasValue;
@@ -80,7 +96,7 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
         ));
       }
     }
-    for (final Instance i in radarrInstances) {
+    for (final Instance i in widget.radarrInstances) {
       final AsyncValue<List<RadarrMovie>> movies =
           ref.watch(radarrMoviesProvider(i));
       anyLoading |= movies.isLoading && !movies.hasValue;
@@ -103,6 +119,10 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
       }
     }
 
+    if (anyLoading) {
+      _needsReset = true;
+    }
+
     items.sort((_RecentItem a, _RecentItem b) => b.added.compareTo(a.added));
     final List<_RecentItem> top = items.take(15).toList();
 
@@ -121,10 +141,10 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
     } else if (items.isEmpty && anyError) {
       body = DashboardErrorRow(
         onRetry: () {
-          for (final Instance i in sonarrInstances) {
+          for (final Instance i in widget.sonarrInstances) {
             ref.invalidate(sonarrSeriesProvider(i));
           }
-          for (final Instance i in radarrInstances) {
+          for (final Instance i in widget.radarrInstances) {
             ref.invalidate(radarrMoviesProvider(i));
           }
         },
@@ -132,9 +152,18 @@ class DashboardRecentlyAddedWidget extends ConsumerWidget {
     } else if (items.isEmpty) {
       body = const DashboardIdleRow(text: 'Nothing added yet');
     } else {
+      if (_needsReset) {
+        _needsReset = false;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_scrollController.hasClients) {
+            _scrollController.jumpTo(0.0);
+          }
+        });
+      }
       body = SizedBox(
         height: 184,
         child: ListView.separated(
+          controller: _scrollController,
           scrollDirection: Axis.horizontal,
           padding: EdgeInsets.zero,
           itemCount: top.length,

--- a/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
@@ -67,7 +67,7 @@ void _openDetail(BuildContext context, _RecentDownloadItem item) {
 
 /// The most recently downloaded Sonarr series and Radarr movies across every
 /// instance, merged and shown as a horizontally scrollable poster row.
-class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
+class DashboardRecentlyDownloadedWidget extends ConsumerStatefulWidget {
   const DashboardRecentlyDownloadedWidget({
     required this.sonarrInstances,
     required this.radarrInstances,
@@ -78,14 +78,30 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
   final List<Instance> radarrInstances;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<DashboardRecentlyDownloadedWidget> createState() =>
+      _DashboardRecentlyDownloadedWidgetState();
+}
+
+class _DashboardRecentlyDownloadedWidgetState
+    extends ConsumerState<DashboardRecentlyDownloadedWidget> {
+  final ScrollController _scrollController = ScrollController();
+  bool _needsReset = false;
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final ColorScheme cs = Theme.of(context).colorScheme;
 
     final List<_RecentDownloadItem> items = <_RecentDownloadItem>[];
     bool anyLoading = false;
     bool anyError = false;
 
-    for (final Instance i in sonarrInstances) {
+    for (final Instance i in widget.sonarrInstances) {
       final AsyncValue<List<SonarrHistoryItem>> history =
           ref.watch(sonarrHistoryProvider(i));
       final SonarrApi? api = ref.watch(sonarrApiProvider(i)).value;
@@ -108,7 +124,7 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
         ));
       }
     }
-    for (final Instance i in radarrInstances) {
+    for (final Instance i in widget.radarrInstances) {
       final AsyncValue<List<RadarrHistoryItem>> history =
           ref.watch(radarrHistoryProvider(i));
       final RadarrApi? api = ref.watch(radarrApiProvider(i)).value;
@@ -132,6 +148,10 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
       }
     }
 
+    if (anyLoading) {
+      _needsReset = true;
+    }
+
     items.sort((_RecentDownloadItem a, _RecentDownloadItem b) =>
         b.date.compareTo(a.date));
     final List<_RecentDownloadItem> top = items.take(15).toList();
@@ -151,10 +171,10 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
     } else if (items.isEmpty && anyError) {
       body = DashboardErrorRow(
         onRetry: () {
-          for (final Instance i in sonarrInstances) {
+          for (final Instance i in widget.sonarrInstances) {
             ref.invalidate(sonarrHistoryProvider(i));
           }
-          for (final Instance i in radarrInstances) {
+          for (final Instance i in widget.radarrInstances) {
             ref.invalidate(radarrHistoryProvider(i));
           }
         },
@@ -162,9 +182,18 @@ class DashboardRecentlyDownloadedWidget extends ConsumerWidget {
     } else if (items.isEmpty) {
       body = const DashboardIdleRow(text: 'No recent downloads found');
     } else {
+      if (_needsReset) {
+        _needsReset = false;
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          if (_scrollController.hasClients) {
+            _scrollController.jumpTo(0.0);
+          }
+        });
+      }
       body = SizedBox(
         height: 184,
         child: ListView.separated(
+          controller: _scrollController,
           scrollDirection: Axis.horizontal,
           padding: EdgeInsets.zero,
           itemCount: top.length,

--- a/app/lib/src/dashboard/widgets/server_info_widget.dart
+++ b/app/lib/src/dashboard/widgets/server_info_widget.dart
@@ -197,26 +197,36 @@ class _MetricTile extends StatelessWidget {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        SizedBox(
-          width: 52,
-          height: 52,
-          child: Stack(
-            alignment: Alignment.center,
-            children: <Widget>[
-              CircularProgressIndicatorM3E(
-                value: (percent / 100).clamp(0, 1).toDouble(),
-                size: CircularProgressM3ESize.m,
-                shape: ProgressM3EShape.flat,
-                activeColor: color,
-                trackColor: cs.surfaceContainerHighest,
-              ),
-              Text(
-                '${percent.round()}%',
-                style: theme.textTheme.labelLarge
-                    ?.copyWith(fontWeight: FontWeight.w800),
-              ),
-            ],
+        TweenAnimationBuilder<double>(
+          tween: Tween<double>(
+            begin: 0.0,
+            end: (percent / 100).clamp(0.0, 1.0),
           ),
+          duration: const Duration(milliseconds: 600),
+          curve: Curves.easeOutCubic,
+          builder: (BuildContext context, double value, Widget? child) {
+            return SizedBox(
+              width: 52,
+              height: 52,
+              child: Stack(
+                alignment: Alignment.center,
+                children: <Widget>[
+                  CircularProgressIndicatorM3E(
+                    value: value,
+                    size: CircularProgressM3ESize.m,
+                    shape: ProgressM3EShape.flat,
+                    activeColor: color,
+                    trackColor: cs.surfaceContainerHighest,
+                  ),
+                  Text(
+                    '${(value * 100).round()}%',
+                    style: theme.textTheme.labelLarge
+                        ?.copyWith(fontWeight: FontWeight.w800),
+                  ),
+                ],
+              ),
+            );
+          },
         ),
         const SizedBox(height: 8),
         Text(
@@ -273,14 +283,21 @@ class _DiskBar extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 4),
-          ClipRRect(
-            borderRadius: BorderRadius.circular(4),
-            child: LinearProgressIndicator(
-              value: fraction,
-              minHeight: 5,
-              color: _loadColor(disk.percentage, cs),
-              backgroundColor: cs.surfaceContainerHighest,
-            ),
+          TweenAnimationBuilder<double>(
+            tween: Tween<double>(begin: 0.0, end: fraction),
+            duration: const Duration(milliseconds: 600),
+            curve: Curves.easeOutCubic,
+            builder: (BuildContext context, double value, Widget? child) {
+              return ClipRRect(
+                borderRadius: BorderRadius.circular(4),
+                child: LinearProgressIndicator(
+                  value: value,
+                  minHeight: 5,
+                  color: _loadColor(disk.percentage, cs),
+                  backgroundColor: cs.surfaceContainerHighest,
+                ),
+              );
+            },
           ),
         ],
       ),

--- a/packages/core_ui/lib/src/widgets/easy_refresh_wrapper.dart
+++ b/packages/core_ui/lib/src/widgets/easy_refresh_wrapper.dart
@@ -43,10 +43,86 @@ class EasyRefresh extends material.StatelessWidget {
       onRefresh: onRefresh,
       onLoad: onLoad,
       triggerAxis: material.Axis.vertical,
+      scrollBehaviorBuilder: (material.ScrollPhysics? physics) {
+        if (physics != null) {
+          return er.ERScrollBehavior(ClampingERScrollPhysics(physics));
+        }
+        return const er.ERScrollBehavior();
+      },
       child: child,
     );
   }
 }
+
+class ClampingERScrollPhysics extends material.ScrollPhysics {
+  final material.ScrollPhysics _delegate;
+  final Set<material.ScrollMetrics> _activeDrags = <material.ScrollMetrics>{};
+
+  ClampingERScrollPhysics(this._delegate, {super.parent});
+
+  @override
+  ClampingERScrollPhysics applyTo(material.ScrollPhysics? ancestor) {
+    return ClampingERScrollPhysics(
+      _delegate.applyTo(ancestor),
+      parent: buildParent(ancestor),
+    );
+  }
+
+  @override
+  double applyPhysicsToUserOffset(material.ScrollMetrics position, double offset) {
+    _activeDrags.add(position);
+    return _delegate.applyPhysicsToUserOffset(position, offset);
+  }
+
+  @override
+  double applyBoundaryConditions(material.ScrollMetrics position, double value) {
+    // If dragging or already out of range, let the delegate handle it.
+    if (_activeDrags.contains(position) || position.outOfRange) {
+      return _delegate.applyBoundaryConditions(position, value);
+    }
+
+    // Otherwise, clamp it so that ballistic flings stop exactly at the boundaries.
+    return const material.ClampingScrollPhysics().applyBoundaryConditions(position, value);
+  }
+
+  @override
+  material.Simulation? createBallisticSimulation(
+    material.ScrollMetrics position,
+    double velocity,
+  ) {
+    _activeDrags.remove(position);
+
+    if (position.outOfRange) {
+      return _delegate.createBallisticSimulation(position, velocity);
+    }
+
+    final clampingSimulation = const material.ClampingScrollPhysics()
+        .createBallisticSimulation(position, velocity);
+    if (clampingSimulation != null) {
+      return clampingSimulation;
+    }
+
+    return _delegate.createBallisticSimulation(position, velocity);
+  }
+
+  @override
+  material.SpringDescription get spring => _delegate.spring;
+
+  @override
+  double get minFlingVelocity => _delegate.minFlingVelocity;
+
+  @override
+  double get maxFlingVelocity => _delegate.maxFlingVelocity;
+
+  @override
+  double? get dragStartDistanceMotionThreshold =>
+      _delegate.dragStartDistanceMotionThreshold;
+
+  @override
+  material.Tolerance toleranceFor(material.ScrollMetrics metrics) =>
+      _delegate.toleranceFor(metrics);
+}
+
 
 class HeaderLocator extends material.StatelessWidget {
   final bool _isSliver;


### PR DESCRIPTION
## Description

This PR fixes the bounce-back scroll behavior of `EasyRefresh` globally, solves dashboard widgets reloading/re-animating when scrolled out of view, and adds polished loading animations to the circular gauges in the Server Info widget.

### Key Changes
1. **EasyRefresh Momentum Clamp**:
   * Introduced a custom `ClampingERScrollPhysics` wrapper inside `easy_refresh_wrapper.dart` to override `EasyRefresh`'s default `BouncingScrollPhysics`.
   * It tracks active user drags under a local `_activeDrags` set. This permits normal overscroll during a pull-to-refresh drag.
   * If it is a ballistic momentum fling (user lets go), it delegates boundary conditions to `ClampingScrollPhysics` to absorb velocity at `0` or `maxScrollExtent`, stopping the list instantly without rubber-banding.

2. **Dashboard State Keep-Alive**:
   * Created a custom stateful `_KeepAliveWrapper` widget in `dashboard_board.dart` using `AutomaticKeepAliveClientMixin`.
   * Wrapped the lazy dashboard widget list items to keep their states alive when scrolled offscreen. This stops widgets from disposing/reloading and prevents circular gauges/bars from resetting and re-playing their fill animations on scroll.

3. **Server Info Gauge Animations**:
   * Wrapped the CPU, Memory, GPU circular gauges (`_MetricTile`) and the filesystem linear bars (`_DiskBar`) in `TweenAnimationBuilder` widgets in `server_info_widget.dart`.
   * They now animate smoothly from `0` to their loaded values over `600ms` with an `easeOutCubic` curve on load, matching the Glances home screen pattern.
