### PR TITLE
feat: add Speedtest Tracker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The central courtyard for your self-hosted media stack.
 One Android app that fronts Sonarr, Radarr, Prowlarr, Bazarr,
 Seerr, Tautulli, Jellyfin, Emby, Plex, qBittorrent,
-SABnzbd and Glances - and routes every request through the right URL
+SABnzbd, Glances and Speedtest Tracker - and routes every request through the right URL
 whether you're on the home Wi-Fi or out in the world.
 
 **[Website][site]** - screenshots and a tour, no install needed.
@@ -65,6 +65,7 @@ each one covers:
 | qBittorrent            | realtime list, add/manage, torrent detail                             |
 | SABnzbd                | queue control (history / categories / limits still to come)           |
 | Glances                | CPU/memory/network/disk monitoring                                    |
+| Speedtest Tracker      | latest result, history chart, dashboard, confirmed remote test runs   |
 
 ## Install
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Atrium - Status
 
-> Snapshot of what genuinely works and what is left, as of 2026-07-10.
+> Snapshot of what genuinely works and what is left, as of 2026-07-21.
 > Atrium is in early development and every module is still work in
 > progress; nothing here is a release promise.
 
@@ -74,6 +74,10 @@ Atrium is a **controller** app. Video playback was removed by design
   transport commands are exercised best-effort
 - **Glances**: per-instance polling, CPU/memory gauges, swap + per-core
   bars, network with interface pinning, disks, uptime
+- **Speedtest Tracker** (live-verified): authenticated 1.1+ result history,
+  latest metrics, combined download / upload chart, multi-instance dashboard
+  widget, and confirmed 1.6+ remote runs with queued/running/terminal-state
+  polling and automatic result refresh
 
 ## Partially done
 
@@ -82,7 +86,7 @@ Atrium is a **controller** app. Video playback was removed by design
 
 ## App-wide TODO
 
-1. A Wake-on-LAN dashboard widget (the board and its seven widgets ship
+1. A Wake-on-LAN dashboard widget (the board and its eight widgets ship
    in 1.0.0)
 2. iOS platform scaffold
 3. Live-stack testing of SABnzbd

--- a/app/android/app/build.gradle.kts
+++ b/app/android/app/build.gradle.kts
@@ -81,6 +81,12 @@ android {
     }
 
     buildTypes {
+        debug {
+            // Development builds coexist with the release app and are
+            // visually distinct during live-device testing.
+            applicationIdSuffix = ".debug"
+            manifestPlaceholders["appName"] = "Atrium Dev"
+        }
         release {
             // No signing config at all leaves the APK unsigned. A config
             // carrying a null storeFile is rejected outright by the Android

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -12,6 +12,7 @@ import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sabnzbd/service_sabnzbd.dart';
 import 'package:service_seerr/service_seerr.dart';
 import 'package:service_sonarr/service_sonarr.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
 import 'package:service_tautulli/service_tautulli.dart';
 
 import '../health_providers.dart';
@@ -23,6 +24,7 @@ import 'widgets/recently_added_widget.dart';
 import 'widgets/recently_downloaded_widget.dart';
 import 'widgets/requests_widget.dart';
 import 'widgets/server_info_widget.dart';
+import 'widgets/speedtest_results_widget.dart';
 import 'widgets/streams_widget.dart';
 import 'widgets/upcoming_widget.dart';
 
@@ -140,6 +142,10 @@ class DashboardBoard extends ConsumerWidget {
         return DashboardServerInfoWidget(
           instances: _byKind(instances, ServiceKind.glances),
         );
+      case DashboardWidgetKind.speedtestResults:
+        return DashboardSpeedtestResultsWidget(
+          instances: _byKind(instances, ServiceKind.speedtestTracker),
+        );
     }
   }
 
@@ -169,6 +175,8 @@ class DashboardBoard extends ConsumerWidget {
           ref.invalidate(seerrRequestsProvider(i));
         case ServiceKind.glances:
           ref.invalidate(glancesStatsProvider(i));
+        case ServiceKind.speedtestTracker:
+          ref.invalidate(speedtestOverviewProvider(i));
         default:
           break;
       }
@@ -201,7 +209,7 @@ class _EditBoard extends ConsumerWidget {
     return ReorderableListView(
       padding: Insets.page,
       buildDefaultDragHandles: false,
-      onReorder: (int oldIndex, int newIndex) => ref
+      onReorderItem: (int oldIndex, int newIndex) => ref
           .read(dashboardLayoutProvider.notifier)
           .moveEnabled(oldIndex, newIndex),
       footer: hidden.isEmpty
@@ -356,4 +364,3 @@ class _KeepAliveWrapperState extends State<_KeepAliveWrapper>
   @override
   bool get wantKeepAlive => true;
 }
-

--- a/app/lib/src/dashboard/dashboard_widget_kind.dart
+++ b/app/lib/src/dashboard/dashboard_widget_kind.dart
@@ -10,6 +10,7 @@ enum DashboardWidgetKind {
   recentlyDownloaded,
   requests,
   serverInfo,
+  speedtestResults,
 }
 
 extension DashboardWidgetKindX on DashboardWidgetKind {
@@ -21,6 +22,7 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.recentlyDownloaded => 'Recently downloaded',
         DashboardWidgetKind.requests => 'Requests',
         DashboardWidgetKind.serverInfo => 'Server info',
+        DashboardWidgetKind.speedtestResults => 'Speedtest results',
       };
 
   IconData get icon => switch (this) {
@@ -31,6 +33,7 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.recentlyDownloaded => Icons.history,
         DashboardWidgetKind.requests => Icons.bookmark_added_outlined,
         DashboardWidgetKind.serverInfo => Icons.memory,
+        DashboardWidgetKind.speedtestResults => Icons.speed_outlined,
       };
 
   /// Service kinds whose presence makes this widget "configured".
@@ -59,6 +62,9 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.requests => const <ServiceKind>[ServiceKind.seerr],
         DashboardWidgetKind.serverInfo => const <ServiceKind>[
             ServiceKind.glances
+          ],
+        DashboardWidgetKind.speedtestResults => const <ServiceKind>[
+            ServiceKind.speedtestTracker
           ],
       };
 }

--- a/app/lib/src/dashboard/widgets/speedtest_results_widget.dart
+++ b/app/lib/src/dashboard/widgets/speedtest_results_widget.dart
@@ -1,0 +1,266 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+class DashboardSpeedtestResultsWidget extends ConsumerWidget {
+  const DashboardSpeedtestResultsWidget({
+    required this.instances,
+    super.key,
+  });
+
+  final List<Instance> instances;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final Color accent = ServiceVisuals.accent(ServiceKind.speedtestTracker);
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.speedtestResults,
+      accent: accent,
+      onTap: instances.length == 1
+          ? () => _open(context, instances.first)
+          : null,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          for (int index = 0; index < instances.length; index++) ...<Widget>[
+            if (index > 0) const Divider(height: Insets.lg),
+            _SpeedtestInstanceBlock(
+              instance: instances[index],
+              showName: instances.length > 1,
+              onTap: instances.length > 1
+                  ? () => _open(context, instances[index])
+                  : null,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  void _open(BuildContext context, Instance instance) {
+    context.go(
+      AtriumRoutes.servicePath(instance.kind.name, instance.id),
+    );
+  }
+}
+
+class _SpeedtestInstanceBlock extends ConsumerWidget {
+  const _SpeedtestInstanceBlock({
+    required this.instance,
+    required this.showName,
+    required this.onTap,
+  });
+
+  final Instance instance;
+  final bool showName;
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final AsyncValue<SpeedtestOverview> overview =
+        ref.watch(speedtestOverviewProvider(instance));
+    return InkWell(
+      borderRadius: BorderRadius.circular(12),
+      onTap: onTap,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: Insets.xs),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            if (showName)
+              Padding(
+                padding: const EdgeInsets.only(bottom: Insets.sm),
+                child: Text(
+                  instance.name,
+                  style: Theme.of(context).textTheme.labelLarge?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+              ),
+            overview.when(
+              skipLoadingOnReload: true,
+              skipLoadingOnRefresh: true,
+              loading: () => const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(Insets.sm),
+                  child: SizedBox(
+                    width: 22,
+                    height: 22,
+                    child: CircularProgressIndicator(strokeWidth: 2.5),
+                  ),
+                ),
+              ),
+              error: (Object error, StackTrace _) => _DashboardError(
+                error: error,
+                onRetry: () =>
+                    ref.invalidate(speedtestOverviewProvider(instance)),
+              ),
+              data: (SpeedtestOverview data) => _DashboardResult(data: data),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DashboardResult extends StatelessWidget {
+  const _DashboardResult({required this.data});
+
+  final SpeedtestOverview data;
+
+  @override
+  Widget build(BuildContext context) {
+    final SpeedtestResult? result = data.latestCompleted;
+    final SpeedtestResult? latestAny = data.latestAny;
+    if (result == null) {
+      if (latestAny?.status.isInProgress ?? false) {
+        return const DashboardIdleRow(text: 'Latest speed test is running');
+      }
+      if (latestAny?.status.isFailure ?? false) {
+        return DashboardIdleRow(
+          text: 'Latest speed test ${latestAny!.status.label.toLowerCase()}',
+        );
+      }
+      return const DashboardIdleRow(text: 'No completed results');
+    }
+
+    final ThemeData theme = Theme.of(context);
+    final bool latestFailed = latestAny != null &&
+        latestAny.id != result.id &&
+        latestAny.status.isFailure;
+    final bool latestRunning = latestAny != null &&
+        latestAny.id != result.id &&
+        latestAny.status.isInProgress;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        if (latestFailed || latestRunning) ...<Widget>[
+          Row(
+            children: <Widget>[
+              Icon(
+                latestFailed ? Icons.warning_amber : Icons.schedule,
+                size: 17,
+                color: latestFailed
+                    ? theme.colorScheme.error
+                    : theme.colorScheme.tertiary,
+              ),
+              const SizedBox(width: Insets.xs),
+              Expanded(
+                child: Text(
+                  latestFailed
+                      ? 'Latest speed test ${latestAny.status.label.toLowerCase()}'
+                      : 'Latest speed test is ${latestAny.status.label.toLowerCase()}',
+                  style: theme.textTheme.labelSmall,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: Insets.sm),
+        ],
+        Row(
+          children: <Widget>[
+            Expanded(
+              child: _DashboardMetric(
+                label: 'Download',
+                value: formatSpeed(result.downloadBitsPerSecond),
+              ),
+            ),
+            Expanded(
+              child: _DashboardMetric(
+                label: 'Upload',
+                value: formatSpeed(result.uploadBitsPerSecond),
+              ),
+            ),
+            Expanded(
+              child: _DashboardMetric(
+                label: 'Ping',
+                value: formatMilliseconds(result.pingMilliseconds),
+              ),
+            ),
+            if (result.packetLossPercent != null)
+              Expanded(
+                child: _DashboardMetric(
+                  label: 'Loss',
+                  value: formatPacketLoss(result.packetLossPercent),
+                ),
+              ),
+          ],
+        ),
+        const SizedBox(height: Insets.sm),
+        Text(
+          <String>[
+            if (result.serverOrProvider != null) result.serverOrProvider!,
+            _formatTime(result.completedAt),
+          ].join(' · '),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatTime(DateTime? value) => value == null
+      ? 'Unknown time'
+      : DateFormat.MMMd().add_jm().format(
+            value.isUtc ? value.toLocal() : value,
+          );
+}
+
+class _DashboardMetric extends StatelessWidget {
+  const _DashboardMetric({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          Text(label, style: Theme.of(context).textTheme.labelSmall),
+        ],
+      );
+}
+
+class _DashboardError extends StatelessWidget {
+  const _DashboardError({required this.error, required this.onRetry});
+
+  final Object error;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final String message = error is SpeedtestTrackerException
+        ? (error as SpeedtestTrackerException).message
+        : 'Could not load Speedtest Tracker results.';
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(message, style: Theme.of(context).textTheme.bodySmall),
+        Align(
+          alignment: Alignment.centerRight,
+          child: TextButton(onPressed: onRetry, child: const Text('Retry')),
+        ),
+      ],
+    );
+  }
+}

--- a/app/lib/src/screens/instance_form_screen.dart
+++ b/app/lib/src/screens/instance_form_screen.dart
@@ -1,16 +1,42 @@
 import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
 import 'package:core_profile/core_profile.dart';
 import 'package:core_ui/core_ui.dart';
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+
+const String speedtestConnectionSuccessMessage =
+    'Connected with results:read. Run permission cannot be verified until used.';
+
+String speedtestConnectionErrorMessage(SpeedtestTrackerException error) =>
+    switch (error.kind) {
+      SpeedtestErrorKind.authentication =>
+        'The bearer token was rejected or lacks results:read.',
+      SpeedtestErrorKind.permission =>
+        'The API token does not have the required permission.',
+      SpeedtestErrorKind.unsupported =>
+        'Authenticated results require Speedtest Tracker 1.1 or newer.',
+      SpeedtestErrorKind.offline => 'Could not reach Speedtest Tracker.',
+      SpeedtestErrorKind.timeout =>
+        'Speedtest Tracker took too long to respond.',
+      SpeedtestErrorKind.server => 'Speedtest Tracker returned a server error.',
+      SpeedtestErrorKind.malformed =>
+        'Speedtest Tracker returned an unsupported response.',
+      SpeedtestErrorKind.notFound =>
+        'The requested Speedtest Tracker result was not found.',
+      SpeedtestErrorKind.other =>
+        'Speedtest Tracker returned an unexpected response.',
+    };
 
 /// Add / edit an instance. When [instanceId] is null this is an "add" form;
 /// otherwise it pre-fills from the existing instance.
 ///
 /// The auth fields shown depend on the selected [ServiceKind]'s auth style:
-/// api-key services show one field; user/pass services show two; Plex shows a
-/// token field.
+/// API-key and bearer-token services show one field; user/pass services show
+/// two; Plex shows a token field.
 class InstanceFormScreen extends ConsumerStatefulWidget {
   const InstanceFormScreen({this.instanceId, super.key});
 
@@ -32,6 +58,9 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
   /// qBittorrent 5.2+ supports both username/password and API-key auth; this
   /// tracks which the user picked (qBit only).
   bool _qbitUseApiKey = false;
+  bool _testingConnection = false;
+  bool _connectionTestFailed = false;
+  String? _connectionTestMessage;
   final TextEditingController _pollingInterval =
       TextEditingController(text: '5');
 
@@ -86,6 +115,7 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
   InstanceAuth _buildAuth() {
     return switch (_kind.authStyle) {
       AuthStyle.apiKey => InstanceAuth.apiKey(apiKey: _apiKey.text.trim()),
+      AuthStyle.bearerToken => InstanceAuth.apiKey(apiKey: _apiKey.text.trim()),
       AuthStyle.plexToken => InstanceAuth.plexToken(token: _apiKey.text.trim()),
       AuthStyle.userPass => InstanceAuth.userPass(
           username: _username.text.trim(),
@@ -102,6 +132,33 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
     };
   }
 
+  Instance _buildInstance(String id) => Instance(
+        id: id,
+        name: _name.text.trim(),
+        kind: _kind,
+        localUrl: _localUrl.text.trim(),
+        externalUrl: _externalUrl.text.trim(),
+        urlMode: _urlMode,
+        auth: _buildAuth(),
+        allowSelfSignedCerts: _allowSelfSigned,
+        pollingIntervalSeconds: int.tryParse(_pollingInterval.text.trim()) ?? 5,
+      );
+
+  void _clearConnectionTest(String _) {
+    setState(() {
+      _connectionTestMessage = null;
+      _connectionTestFailed = false;
+    });
+  }
+
+  bool get _warnAboutExternalHttp {
+    if (_kind != ServiceKind.speedtestTracker) {
+      return false;
+    }
+    final Uri? uri = Uri.tryParse(_externalUrl.text.trim());
+    return uri != null && uri.scheme.toLowerCase() == 'http';
+  }
+
   Future<void> _save() async {
     if (!_formKey.currentState!.validate()) {
       return;
@@ -115,20 +172,62 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
 
     final String id = widget.instanceId ??
         ref.read(profileRepositoryProvider).newInstanceId();
-    final Instance instance = Instance(
-      id: id,
-      name: _name.text.trim(),
-      kind: _kind,
-      localUrl: _localUrl.text.trim(),
-      externalUrl: _externalUrl.text.trim(),
-      urlMode: _urlMode,
-      auth: _buildAuth(),
-      allowSelfSignedCerts: _allowSelfSigned,
-      pollingIntervalSeconds: int.tryParse(_pollingInterval.text.trim()) ?? 5,
-    );
+    final Instance instance = _buildInstance(id);
     await controller.upsertInstance(profile.id, instance);
     if (mounted) {
       context.pop();
+    }
+  }
+
+  Future<void> _testSpeedtestConnection() async {
+    if (!_formKey.currentState!.validate()) {
+      return;
+    }
+    setState(() {
+      _testingConnection = true;
+      _connectionTestFailed = false;
+      _connectionTestMessage = null;
+    });
+    final Instance candidate = _buildInstance(
+      widget.instanceId ?? 'speedtest-connection-test',
+    );
+    Dio? dio;
+    try {
+      dio = await ref.read(dioFactoryProvider).create(
+            candidate,
+            globalHeaders: ref.read(globalHeadersProvider),
+          );
+      final SpeedtestTrackerApi api = SpeedtestTrackerApi(dio);
+      await api.checkHealth();
+      await api.listResults(pageSize: 1);
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _connectionTestMessage = speedtestConnectionSuccessMessage;
+      });
+    } on SpeedtestTrackerException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _connectionTestFailed = true;
+        _connectionTestMessage = speedtestConnectionErrorMessage(error);
+      });
+    } on Object {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _connectionTestFailed = true;
+        _connectionTestMessage =
+            'Could not test the Speedtest Tracker connection.';
+      });
+    } finally {
+      dio?.close(force: true);
+      if (mounted) {
+        setState(() => _testingConnection = false);
+      }
     }
   }
 
@@ -187,8 +286,10 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
                     leadingIcon: _buildServiceIcon(k),
                   ),
               ],
-              onSelected: (ServiceKind? k) =>
-                  setState(() => _kind = k ?? _kind),
+              onSelected: (ServiceKind? k) => setState(() {
+                _kind = k ?? _kind;
+                _connectionTestMessage = null;
+              }),
             ),
             const SizedBox(height: Insets.md),
             TextFormField(
@@ -213,24 +314,50 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
               decoration: InputDecoration(
                 border: const OutlineInputBorder(),
                 labelText: 'Local URL',
-                hintText: 'http://192.168.1.10:${_kind.defaultPort}',
+                hintText: _kind.defaultPort == null
+                    ? 'http://192.168.1.10'
+                    : 'http://192.168.1.10:${_kind.defaultPort}',
               ),
               keyboardType: TextInputType.url,
               autocorrect: false,
+              onChanged: _clearConnectionTest,
               validator: _validateUrlsTogether,
             ),
             const SizedBox(height: Insets.md),
             TextFormField(
               controller: _externalUrl,
-              decoration: const InputDecoration(
-                border: OutlineInputBorder(),
+              decoration: InputDecoration(
+                border: const OutlineInputBorder(),
                 labelText: 'External URL',
-                hintText: 'https://sonarr.example.com',
+                hintText: _kind == ServiceKind.speedtestTracker
+                    ? 'https://speedtest.example.com'
+                    : 'https://sonarr.example.com',
               ),
               keyboardType: TextInputType.url,
               autocorrect: false,
+              onChanged: _clearConnectionTest,
               validator: _validateUrlsTogether,
             ),
+            if (_warnAboutExternalHttp) ...<Widget>[
+              const SizedBox(height: Insets.sm),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Icon(
+                    Icons.warning_amber_rounded,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                  const SizedBox(width: Insets.sm),
+                  const Expanded(
+                    child: Text(
+                      'An external or Tailscale HTTP URL does not protect the '
+                      'bearer token with TLS. Use HTTPS when possible.',
+                    ),
+                  ),
+                ],
+              ),
+            ],
             const SizedBox(height: Insets.md),
             DropdownMenu<UrlMode>(
               initialSelection: _urlMode,
@@ -250,8 +377,10 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
                   label: 'Always external',
                 ),
               ],
-              onSelected: (UrlMode? m) =>
-                  setState(() => _urlMode = m ?? _urlMode),
+              onSelected: (UrlMode? m) => setState(() {
+                _urlMode = m ?? _urlMode;
+                _connectionTestMessage = null;
+              }),
             ),
             const SizedBox(height: Insets.lg),
             Text(
@@ -268,8 +397,46 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
                 'Skip TLS validation for this instance only.',
               ),
               value: _allowSelfSigned,
-              onChanged: (bool v) => setState(() => _allowSelfSigned = v),
+              onChanged: (bool v) => setState(() {
+                _allowSelfSigned = v;
+                _connectionTestMessage = null;
+              }),
             ),
+            if (_kind == ServiceKind.speedtestTracker) ...<Widget>[
+              const SizedBox(height: Insets.sm),
+              OutlinedButton.icon(
+                onPressed: _testingConnection ? null : _testSpeedtestConnection,
+                icon: _testingConnection
+                    ? const SizedBox(
+                        width: 18,
+                        height: 18,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Icon(Icons.cable_outlined),
+                label: Text(
+                  _testingConnection ? 'Testing...' : 'Test connection',
+                ),
+              ),
+              if (_connectionTestMessage != null) ...<Widget>[
+                const SizedBox(height: Insets.sm),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Icon(
+                      _connectionTestFailed
+                          ? Icons.error_outline
+                          : Icons.check_circle_outline,
+                      size: 18,
+                      color: _connectionTestFailed
+                          ? Theme.of(context).colorScheme.error
+                          : Theme.of(context).colorScheme.primary,
+                    ),
+                    const SizedBox(width: Insets.sm),
+                    Expanded(child: Text(_connectionTestMessage!)),
+                  ],
+                ),
+              ],
+            ],
             if (_kind == ServiceKind.glances) ...<Widget>[
               const SizedBox(height: Insets.lg),
               Text(
@@ -317,6 +484,23 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
               labelText: 'API key',
             ),
             autocorrect: false,
+            validator: (String? v) =>
+                (v == null || v.trim().isEmpty) ? 'Required' : null,
+          ),
+        ];
+      case AuthStyle.bearerToken:
+        return <Widget>[
+          TextFormField(
+            controller: _apiKey,
+            decoration: const InputDecoration(
+              border: OutlineInputBorder(),
+              labelText: 'Bearer API token',
+              helperText: 'Requires results:read; speedtests:run is optional.',
+            ),
+            obscureText: true,
+            autocorrect: false,
+            enableSuggestions: false,
+            onChanged: _clearConnectionTest,
             validator: (String? v) =>
                 (v == null || v.trim().isEmpty) ? 'Required' : null,
           ),
@@ -431,8 +615,8 @@ class _InstanceFormScreenState extends ConsumerState<InstanceFormScreen> {
   }
 
   Widget _buildServiceIcon(ServiceKind kind, {double size = 24}) {
-    if (kind.name == 'sabnzbd') {
-      return Icon(Icons.cloud_download_outlined, size: size);
+    if (kind == ServiceKind.sabnzbd || kind == ServiceKind.speedtestTracker) {
+      return Icon(ServiceVisuals.icon(kind), size: size);
     }
     return Image.asset(
       'assets/service_icons/${kind.name}.png',

--- a/app/lib/src/screens/reorder_sidebar_screen.dart
+++ b/app/lib/src/screens/reorder_sidebar_screen.dart
@@ -69,11 +69,10 @@ class _ReorderSidebarScreenState extends ConsumerState<ReorderSidebarScreen> {
                 Expanded(
                   child: ReorderableListView.builder(
                     itemCount: _localInstances!.length,
-                    onReorder: (int oldIndex, int newIndex) {
+                    // Flutter 3.44 deprecates onReorder in favor of this
+                    // callback, which already adjusts newIndex after removal.
+                    onReorderItem: (int oldIndex, int newIndex) {
                       setState(() {
-                        if (oldIndex < newIndex) {
-                          newIndex -= 1;
-                        }
                         final Instance item =
                             _localInstances!.removeAt(oldIndex);
                         _localInstances!.insert(newIndex, item);

--- a/app/lib/src/screens/service_detail_screen.dart
+++ b/app/lib/src/screens/service_detail_screen.dart
@@ -16,6 +16,7 @@ import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sabnzbd/service_sabnzbd.dart';
 import 'package:service_glances/service_glances.dart';
 import 'package:service_sonarr/service_sonarr.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
 import 'package:service_tautulli/service_tautulli.dart';
 
 import 'dashboard_screen.dart';
@@ -243,6 +244,7 @@ class _ServiceDetailScreenState extends ConsumerState<ServiceDetailScreen> {
       ServiceKind.qbittorrent => QbittorrentHome(instance: instance),
       ServiceKind.sabnzbd => SabnzbdHome(instance: instance),
       ServiceKind.glances => GlancesHome(instance: instance),
+      ServiceKind.speedtestTracker => SpeedtestTrackerHome(instance: instance),
     };
   }
 }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   service_sabnzbd:
   service_sonarr:
   service_glances:
+  service_speedtest_tracker:
   service_tautulli:
   url_launcher: ^6.3.2
 dev_dependencies:

--- a/app/test/dashboard_layout_test.dart
+++ b/app/test/dashboard_layout_test.dart
@@ -98,7 +98,7 @@ void main() {
       // Hide one widget so enabled != full list.
       controller.setEnabled(DashboardWidgetKind.streams, false);
       // Enabled order is now: downloads, upcoming, recentlyAdded,
-      // recentlyDownloaded, requests, serverInfo.
+      // recentlyDownloaded, requests, serverInfo, speedtestResults.
       controller.moveEnabled(0, 2); // drag downloads down two slots
       final List<DashboardWidgetKind> enabled = container
           .read(dashboardLayoutProvider)
@@ -112,6 +112,7 @@ void main() {
         DashboardWidgetKind.recentlyDownloaded,
         DashboardWidgetKind.requests,
         DashboardWidgetKind.serverInfo,
+        DashboardWidgetKind.speedtestResults,
       ]);
       // The disabled widget is still present, at the end.
       final List<DashboardWidgetConfig> all =

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -452,14 +452,14 @@ void main() {
       ],
       const DashboardBoard(),
     );
-    // All seven widgets are arrangeable in edit mode, configured or not.
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(7));
+    // All eight widgets are arrangeable in edit mode, configured or not.
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(8));
     expect(find.text('Hidden'), findsNothing);
     // Hide the first widget -> it moves to the Hidden section.
     await tester.tap(find.byIcon(Icons.visibility_off_outlined).first);
     await tester.pump();
     expect(find.text('Hidden'), findsOneWidget);
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(6));
+    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(7));
     expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
   });
 }

--- a/app/test/speedtest_connection_security_test.dart
+++ b/app/test/speedtest_connection_security_test.dart
@@ -1,0 +1,62 @@
+import 'package:atrium/src/screens/instance_form_screen.dart';
+import 'package:core_models/core_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('connection-test messages never expose exception contents', () {
+    const String token = 'placeholder-token-must-never-appear';
+    for (final SpeedtestErrorKind kind in SpeedtestErrorKind.values) {
+      final String message = speedtestConnectionErrorMessage(
+        SpeedtestTrackerException(kind, 'Upstream echoed $token'),
+      );
+      expect(message, isNot(contains(token)));
+    }
+    expect(speedtestConnectionSuccessMessage, isNot(contains(token)));
+  });
+
+  testWidgets('bearer field stays obscured and external HTTP shows a warning',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(900, 1400);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      const ProviderScope(
+        child: MaterialApp(home: InstanceFormScreen()),
+      ),
+    );
+
+    await tester.tap(find.byType(DropdownMenu<ServiceKind>));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Speedtest Tracker - Internet performance'));
+    await tester.pumpAndSettle();
+
+    final Finder bearerField = find.ancestor(
+      of: find.text('Bearer API token'),
+      matching: find.byType(TextFormField),
+    );
+    expect(bearerField, findsOneWidget);
+    final EditableText bearerEditable = tester.widget<EditableText>(
+      find.descendant(of: bearerField, matching: find.byType(EditableText)),
+    );
+    expect(bearerEditable.obscureText, isTrue);
+    expect(find.byIcon(Icons.visibility), findsNothing);
+    expect(find.byIcon(Icons.visibility_off), findsNothing);
+
+    final Finder externalField = find.ancestor(
+      of: find.text('External URL'),
+      matching: find.byType(TextFormField),
+    );
+    await tester.enterText(externalField, 'http://tracker.example.test');
+    await tester.pump();
+
+    expect(
+      find.textContaining('does not protect the bearer token with TLS'),
+      findsOneWidget,
+    );
+    expect(find.textContaining('placeholder-token'), findsNothing);
+  });
+}

--- a/app/test/speedtest_results_widget_test.dart
+++ b/app/test/speedtest_results_widget_test.dart
@@ -1,0 +1,299 @@
+import 'dart:async';
+
+import 'package:atrium/src/dashboard/dashboard_board.dart';
+import 'package:atrium/src/dashboard/widgets/speedtest_results_widget.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_router/core_router.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+
+void main() {
+  testWidgets('dashboard renders multiple instances and opens the tapped one',
+      (WidgetTester tester) async {
+    final Instance first = _instance('first', 'Home tracker');
+    final Instance second = _instance('second', 'Remote tracker');
+    final GoRouter router = GoRouter(
+      initialLocation: '/',
+      routes: <RouteBase>[
+        GoRoute(
+          path: '/',
+          builder: (BuildContext context, GoRouterState state) =>
+              DashboardSpeedtestResultsWidget(
+            instances: <Instance>[first, second],
+          ),
+        ),
+        GoRoute(
+          path: AtriumRoutes.service,
+          builder: (BuildContext context, GoRouterState state) => Text(
+            'Opened ${state.pathParameters['instanceId']}',
+          ),
+        ),
+      ],
+    );
+    addTearDown(router.dispose);
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          speedtestOverviewProvider(first).overrideWith(
+            (Ref ref) async => _overview(1),
+          ),
+          speedtestOverviewProvider(second).overrideWith(
+            (Ref ref) async => _overview(2),
+          ),
+        ],
+        child: MaterialApp.router(
+          theme: AtriumTheme.light(null),
+          routerConfig: router,
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Speedtest results'), findsOneWidget);
+    expect(find.text('Home tracker'), findsOneWidget);
+    expect(find.text('Remote tracker'), findsOneWidget);
+    expect(find.text('800 Mbps'), findsNWidgets(2));
+    expect(find.text('200 Mbps'), findsNWidgets(2));
+    expect(find.text('12.4 ms'), findsNWidgets(2));
+    expect(find.text('0.5%'), findsNWidgets(2));
+
+    await tester.tap(find.text('Remote tracker'));
+    await tester.pumpAndSettle();
+    expect(find.text('Opened second'), findsOneWidget);
+  });
+
+  testWidgets('dashboard board registers the widget for a configured instance',
+      (WidgetTester tester) async {
+    final Instance instance = _instance('board', 'Board tracker');
+    await _pumpWidget(
+      tester,
+      <Override>[
+        activeInstancesProvider.overrideWithValue(<Instance>[instance]),
+        speedtestOverviewProvider(instance).overrideWith(
+          (Ref ref) async => _overview(1),
+        ),
+      ],
+      const DashboardBoard(),
+      pumps: 3,
+    );
+
+    expect(find.text('Speedtest results'), findsOneWidget);
+    expect(find.text('800 Mbps'), findsOneWidget);
+  });
+
+  testWidgets('dashboard distinguishes auth and malformed response errors',
+      (WidgetTester tester) async {
+    final Instance auth = _instance('auth', 'Auth tracker');
+    final Instance malformed = _instance('malformed', 'Malformed tracker');
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: <Override>[
+          speedtestOverviewProvider(auth).overrideWith(
+            (Ref ref) async => throw const SpeedtestTrackerException(
+              SpeedtestErrorKind.authentication,
+              'The bearer token was rejected.',
+            ),
+          ),
+          speedtestOverviewProvider(malformed).overrideWith(
+            (Ref ref) async => throw const SpeedtestTrackerException(
+              SpeedtestErrorKind.malformed,
+              'The result history response is unsupported.',
+            ),
+          ),
+        ],
+        child: MaterialApp(
+          theme: AtriumTheme.light(null),
+          home: Scaffold(
+            body: DashboardSpeedtestResultsWidget(
+              instances: <Instance>[auth, malformed],
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('The bearer token was rejected.'), findsOneWidget);
+    expect(
+      find.text('The result history response is unsupported.'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('dashboard shows latest failed state over completed metrics',
+      (WidgetTester tester) async {
+    final Instance instance = _instance('failed', 'Failed tracker');
+    final SpeedtestResult completed = _completed(1);
+    final SpeedtestOverview overview = SpeedtestOverview(
+      latestAny: const SpeedtestResult(
+        id: 2,
+        status: SpeedtestResultStatus.failed,
+      ),
+      completedResults: <SpeedtestResult>[completed],
+    );
+
+    await _pumpWidget(
+      tester,
+      <Override>[
+        speedtestOverviewProvider(instance).overrideWith(
+          (Ref ref) async => overview,
+        ),
+      ],
+      DashboardSpeedtestResultsWidget(instances: <Instance>[instance]),
+    );
+
+    expect(find.text('Latest speed test failed'), findsOneWidget);
+    expect(find.text('800 Mbps'), findsOneWidget);
+  });
+
+  testWidgets('dashboard renders loading, empty, running, and offline states',
+      (WidgetTester tester) async {
+    final Instance loading = _instance('loading', 'Loading tracker');
+    final Instance empty = _instance('empty', 'Empty tracker');
+    final Instance running = _instance('running', 'Running tracker');
+    final Instance offline = _instance('offline', 'Offline tracker');
+    final Completer<SpeedtestOverview> pending = Completer<SpeedtestOverview>();
+
+    await _pumpWidget(
+      tester,
+      <Override>[
+        speedtestOverviewProvider(loading).overrideWith(
+          (Ref ref) => pending.future,
+        ),
+        speedtestOverviewProvider(empty).overrideWith(
+          (Ref ref) async => const SpeedtestOverview(
+            latestAny: null,
+            completedResults: <SpeedtestResult>[],
+          ),
+        ),
+        speedtestOverviewProvider(running).overrideWith(
+          (Ref ref) async => const SpeedtestOverview(
+            latestAny: SpeedtestResult(
+              id: 9,
+              status: SpeedtestResultStatus.running,
+            ),
+            completedResults: <SpeedtestResult>[],
+          ),
+        ),
+        speedtestOverviewProvider(offline).overrideWith(
+          (Ref ref) async => throw const SpeedtestTrackerException(
+            SpeedtestErrorKind.offline,
+            'Could not reach Speedtest Tracker.',
+          ),
+        ),
+      ],
+      DashboardSpeedtestResultsWidget(
+        instances: <Instance>[loading, empty, running, offline],
+      ),
+      pumps: 2,
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    expect(find.text('No completed results'), findsOneWidget);
+    expect(find.text('Latest speed test is running'), findsOneWidget);
+    expect(find.text('Could not reach Speedtest Tracker.'), findsOneWidget);
+  });
+
+  testWidgets('full service page renders latest, chart, and history',
+      (WidgetTester tester) async {
+    tester.view.physicalSize = const Size(900, 1600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    final Instance instance = _instance('home', 'Home tracker');
+    final List<SpeedtestResult> results = <SpeedtestResult>[
+      _completed(2, measuredAt: DateTime(2026, 7, 20, 12)),
+      _completed(1, measuredAt: DateTime(2026, 7, 19, 12)),
+    ];
+
+    await _pumpWidget(
+      tester,
+      <Override>[
+        speedtestOverviewProvider(instance).overrideWith(
+          (Ref ref) async => SpeedtestOverview(
+            latestAny: results.first,
+            completedResults: results,
+          ),
+        ),
+        speedtestHistoryProvider(
+          (instance: instance, page: 1, pageSize: 25),
+        ).overrideWith(
+          (Ref ref) async => SpeedtestResultsPage(
+            results: results,
+            page: 1,
+            hasMore: false,
+          ),
+        ),
+      ],
+      SpeedtestTrackerHome(instance: instance),
+      pumps: 3,
+    );
+
+    expect(find.text('Latest result'), findsOneWidget);
+    expect(find.text('Download and upload history'), findsOneWidget);
+    expect(find.text('Recent history'), findsOneWidget);
+    expect(find.text('Download'), findsWidgets);
+    expect(find.text('Upload'), findsWidgets);
+    expect(find.text('Run test'), findsOneWidget);
+  });
+}
+
+Instance _instance(String id, String name) => Instance(
+      id: id,
+      name: name,
+      kind: ServiceKind.speedtestTracker,
+      localUrl: 'https://tracker.example.test',
+      externalUrl: '',
+      urlMode: UrlMode.forceLocal,
+      auth: const InstanceAuth.apiKey(apiKey: 'placeholder-token'),
+    );
+
+SpeedtestOverview _overview(int id) {
+  final SpeedtestResult result = _completed(id);
+  return SpeedtestOverview(
+    latestAny: result,
+    completedResults: <SpeedtestResult>[result],
+  );
+}
+
+SpeedtestResult _completed(int id, {DateTime? measuredAt}) => SpeedtestResult(
+      id: id,
+      status: SpeedtestResultStatus.completed,
+      downloadBitsPerSecond: 800000000,
+      uploadBitsPerSecond: 200000000,
+      pingMilliseconds: 12.4,
+      packetLossPercent: 0.5,
+      server: const SpeedtestServer(name: 'Example server'),
+      isp: 'Example Fiber',
+      measuredAt: measuredAt ?? DateTime(2026, 7, 20, 12),
+    );
+
+Future<void> _pumpWidget(
+  WidgetTester tester,
+  List<Override> overrides,
+  Widget child, {
+  int pumps = 2,
+}) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: overrides,
+      child: MaterialApp(
+        theme: AtriumTheme.light(null),
+        home: Scaffold(body: child),
+      ),
+    ),
+  );
+  for (int index = 0; index < pumps; index++) {
+    await tester.pump();
+  }
+}

--- a/packages/core_models/lib/src/instance.dart
+++ b/packages/core_models/lib/src/instance.dart
@@ -15,8 +15,10 @@ part 'instance.g.dart';
 ///
 /// Users may have multiple instances of the same [kind] (e.g., two Sonarrs:
 /// "Home" and "Seedbox"); each is a separate [Instance] with its own [id].
-@freezed
+@Freezed(toStringOverride: false)
 abstract class Instance with _$Instance {
+  const Instance._();
+
   const factory Instance({
     /// Stable identifier, generated once at create time. Used as the key for
     /// secret storage and Riverpod scoping. Never reuse.
@@ -59,6 +61,30 @@ abstract class Instance with _$Instance {
 
   factory Instance.fromJson(Map<String, dynamic> json) =>
       _$InstanceFromJson(json);
+
+  /// A diagnostic representation that deliberately excludes credentials and
+  /// custom-header values. URLs with embedded user information are redacted.
+  @override
+  String toString() => 'Instance('
+      'id: $id, '
+      'name: $name, '
+      'kind: $kind, '
+      'localUrl: ${_redactUrlUserInfo(localUrl)}, '
+      'externalUrl: ${_redactUrlUserInfo(externalUrl)}, '
+      'urlMode: $urlMode, '
+      'auth: $auth, '
+      'allowSelfSignedCerts: $allowSelfSignedCerts, '
+      'pollingIntervalSeconds: $pollingIntervalSeconds, '
+      'customHeaderNames: ${customHeaders.keys.toList(growable: false)}'
+      ')';
+}
+
+String _redactUrlUserInfo(String raw) {
+  final Uri? uri = Uri.tryParse(raw);
+  if (uri == null || uri.userInfo.isEmpty) {
+    return raw;
+  }
+  return uri.replace(userInfo: '***redacted***').toString();
 }
 
 /// Decodes [ServiceKind], migrating the legacy `overseerr` value to

--- a/packages/core_models/lib/src/instance_auth.dart
+++ b/packages/core_models/lib/src/instance_auth.dart
@@ -21,8 +21,10 @@ part 'instance_auth.g.dart';
 /// stripped before the model is written to a Hive box; the storage layer
 /// holds them in the platform secure store (Android Keystore via
 /// flutter_secure_storage) keyed by `instance.id`.
-@freezed
+@Freezed(toStringOverride: false)
 sealed class InstanceAuth with _$InstanceAuth {
+  const InstanceAuth._();
+
   /// Static API key in a header or query param. Used by every *arr service,
   /// Seerr / Jellyseerr, Tautulli, and SABnzbd.
   const factory InstanceAuth.apiKey({required String apiKey}) =
@@ -48,4 +50,15 @@ sealed class InstanceAuth with _$InstanceAuth {
 
   factory InstanceAuth.fromJson(Map<String, dynamic> json) =>
       _$InstanceAuthFromJson(json);
+
+  /// Never include secret material in diagnostics, provider labels, or logs.
+  @override
+  String toString() => switch (this) {
+        InstanceAuthApiKey() => 'InstanceAuth.apiKey(***redacted***)',
+        InstanceAuthUserPass(:final String username) =>
+          'InstanceAuth.userPass(username: $username, password: ***redacted***)',
+        InstanceAuthPlex() => 'InstanceAuth.plexToken(***redacted***)',
+        InstanceAuthCookie(:final String username) =>
+          'InstanceAuth.cookieLogin(username: $username, password: ***redacted***)',
+      };
 }

--- a/packages/core_models/lib/src/service_kind.dart
+++ b/packages/core_models/lib/src/service_kind.dart
@@ -16,6 +16,7 @@ enum ServiceKind {
   qbittorrent,
   sabnzbd,
   glances,
+  speedtestTracker,
 }
 
 /// Static metadata about a [ServiceKind] - display name, default port, the
@@ -37,6 +38,7 @@ extension ServiceKindX on ServiceKind {
         ServiceKind.qbittorrent => 'qBittorrent',
         ServiceKind.sabnzbd => 'SABnzbd',
         ServiceKind.glances => 'Glances',
+        ServiceKind.speedtestTracker => 'Speedtest Tracker',
       };
 
   /// One-line role description.
@@ -53,11 +55,12 @@ extension ServiceKindX on ServiceKind {
         ServiceKind.qbittorrent => 'Torrent client',
         ServiceKind.sabnzbd => 'Usenet client',
         ServiceKind.glances => 'System monitor',
+        ServiceKind.speedtestTracker => 'Internet performance',
       };
 
   /// Vendor-default port. Used as a hint when the user is entering a URL
   /// without one.
-  int get defaultPort => switch (this) {
+  int? get defaultPort => switch (this) {
         ServiceKind.sonarr => 8989,
         ServiceKind.radarr => 7878,
         ServiceKind.prowlarr => 9696,
@@ -70,6 +73,7 @@ extension ServiceKindX on ServiceKind {
         ServiceKind.qbittorrent => 8080,
         ServiceKind.sabnzbd => 8080,
         ServiceKind.glances => 61208,
+        ServiceKind.speedtestTracker => null,
       };
 
   /// What auth flow the service uses by default. Some services (Jellyfin) can
@@ -87,6 +91,7 @@ extension ServiceKindX on ServiceKind {
         ServiceKind.plex => AuthStyle.plexToken,
         ServiceKind.qbittorrent => AuthStyle.cookieLogin,
         ServiceKind.glances => AuthStyle.none,
+        ServiceKind.speedtestTracker => AuthStyle.bearerToken,
       };
 
   /// Broad role of the service in the stack - used for grouping in the
@@ -107,6 +112,7 @@ extension ServiceKindX on ServiceKind {
         ServiceKind.sabnzbd =>
           ServiceRole.downloader,
         ServiceKind.glances => ServiceRole.analytics,
+        ServiceKind.speedtestTracker => ServiceRole.analytics,
       };
 }
 
@@ -114,6 +120,9 @@ extension ServiceKindX on ServiceKind {
 enum AuthStyle {
   /// Static API key passed in a header or query param.
   apiKey,
+
+  /// Static API token passed in an `Authorization: Bearer` header.
+  bearerToken,
 
   /// Username + password login that returns a session token.
   userPass,

--- a/packages/core_models/test/credential_redaction_test.dart
+++ b/packages/core_models/test/credential_redaction_test.dart
@@ -1,0 +1,38 @@
+import 'package:core_models/core_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  const String token = 'placeholder-token-must-never-appear';
+
+  test('InstanceAuth toString redacts every credential variant', () {
+    const List<InstanceAuth> values = <InstanceAuth>[
+      InstanceAuth.apiKey(apiKey: token),
+      InstanceAuth.userPass(username: 'user', password: token),
+      InstanceAuth.plexToken(token: token),
+      InstanceAuth.cookieLogin(username: 'user', password: token),
+    ];
+
+    for (final InstanceAuth auth in values) {
+      expect(auth.toString(), isNot(contains(token)));
+      expect(auth.toString(), contains('***redacted***'));
+    }
+  });
+
+  test('Instance toString redacts auth, URL user info, and header values', () {
+    const Instance instance = Instance(
+      id: 'redaction-test',
+      name: 'Tracker',
+      kind: ServiceKind.speedtestTracker,
+      localUrl: 'https://user:$token@tracker.example.test',
+      externalUrl: 'https://tracker.example.test',
+      urlMode: UrlMode.forceLocal,
+      auth: InstanceAuth.apiKey(apiKey: token),
+      customHeaders: <String, String>{'X-Private': token},
+    );
+
+    final String diagnostic = instance.toString();
+    expect(diagnostic, isNot(contains(token)));
+    expect(diagnostic, contains('***redacted***'));
+    expect(diagnostic, contains('X-Private'));
+  });
+}

--- a/packages/core_models/test/profile_compat_test.dart
+++ b/packages/core_models/test/profile_compat_test.dart
@@ -83,6 +83,26 @@ void main() {
     expect(instance.customHeaders, const <String, String>{});
   });
 
+  test('Speedtest Tracker instance round-trips by stable enum name', () {
+    const Instance instance = Instance(
+      id: 'speedtest-1',
+      name: 'Home speed',
+      kind: ServiceKind.speedtestTracker,
+      localUrl: 'https://speedtest.example.test',
+      externalUrl: '',
+      urlMode: UrlMode.auto,
+      auth: InstanceAuth.apiKey(apiKey: ''),
+    );
+
+    final Map<String, dynamic> json = jsonDecode(
+      jsonEncode(instance.toJson()),
+    ) as Map<String, dynamic>;
+    final Instance decoded = Instance.fromJson(json);
+
+    expect(json['kind'], 'speedtestTracker');
+    expect(decoded.kind, ServiceKind.speedtestTracker);
+  });
+
   test('WolDevice.fromJson fills broadcast and port defaults', () {
     final WolDevice device = WolDevice.fromJson(<String, dynamic>{
       'id': 'w1',

--- a/packages/core_models/test/service_kind_test.dart
+++ b/packages/core_models/test/service_kind_test.dart
@@ -1,0 +1,17 @@
+import 'package:core_models/core_models.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Speedtest Tracker is registered as bearer-auth Analytics service', () {
+    expect(ServiceKind.values.last, ServiceKind.speedtestTracker);
+    expect(ServiceKind.speedtestTracker.displayName, 'Speedtest Tracker');
+    expect(ServiceKind.speedtestTracker.role, ServiceRole.analytics);
+    expect(ServiceKind.speedtestTracker.authStyle, AuthStyle.bearerToken);
+    expect(ServiceKind.speedtestTracker.defaultPort, isNull);
+  });
+
+  test('existing services retain their default ports', () {
+    expect(ServiceKind.sonarr.defaultPort, 8989);
+    expect(ServiceKind.glances.defaultPort, 61208);
+  });
+}

--- a/packages/core_networking/lib/src/auth_interceptor.dart
+++ b/packages/core_networking/lib/src/auth_interceptor.dart
@@ -9,6 +9,7 @@ import 'package:dio/dio.dart';
 /// |--------------------------|---------------------------------------------|
 /// | *arr family, Seerr   | `X-Api-Key` header                          |
 /// | SABnzbd, Tautulli        | `?apikey=` query param                      |
+/// | Speedtest Tracker        | `Authorization: Bearer ...`                 |
 /// | Plex                     | `X-Plex-Token` header                       |
 /// | Jellyfin / Emby          | `X-Emby-Authorization` (token only after login) |
 /// | qBittorrent              | `Cookie: SID=...` after `/api/v2/auth/login`    |
@@ -31,6 +32,9 @@ class AuthInterceptor extends Interceptor {
     switch (auth) {
       case InstanceAuthApiKey(:final String apiKey):
         switch (kind) {
+          case ServiceKind.speedtestTracker:
+            options.headers['Authorization'] = 'Bearer $apiKey';
+            options.headers['Accept'] = 'application/json';
           case ServiceKind.sabnzbd || ServiceKind.tautulli:
             options.queryParameters['apikey'] = apiKey;
             // Tautulli's endpoints all require `cmd=` too - that's the

--- a/packages/core_networking/lib/src/connection_resolver.dart
+++ b/packages/core_networking/lib/src/connection_resolver.dart
@@ -1,11 +1,15 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:core_models/core_models.dart';
 import 'package:dio/dio.dart';
+import 'package:dio/io.dart';
 import 'package:meta/meta.dart';
 
 import 'network_fingerprint.dart';
+
+typedef ProbeClientFactory = Dio Function(bool allowSelfSignedCerts);
 
 /// Picks between the LAN URL and WAN URL of an [Instance] for outgoing
 /// requests.
@@ -27,15 +31,20 @@ class ConnectionResolver {
   ConnectionResolver({
     required Connectivity connectivity,
     Dio? probeClient,
+    ProbeClientFactory? probeClientFactory,
     ConnectionCacheStore? cacheStore,
     this.probeTimeout = const Duration(milliseconds: 1500),
     this.cacheTtl = const Duration(minutes: 5),
   })  : _connectivity = connectivity,
         _store = cacheStore,
-        _probeClient = probeClient ?? _buildProbeClient();
+        _sharedProbeClient = probeClient,
+        _probeClientFactory = probeClientFactory ??
+            ((bool allowSelfSignedCerts) =>
+                probeClient ?? _buildProbeClient(allowSelfSignedCerts));
 
   final Connectivity _connectivity;
-  final Dio _probeClient;
+  final Dio? _sharedProbeClient;
+  final ProbeClientFactory _probeClientFactory;
 
   /// Optional persistence for verdicts across cold starts. Null = in-memory
   /// only (the resolver works fine without it).
@@ -73,7 +82,7 @@ class ConnectionResolver {
   /// Release resources. Call on app dispose.
   Future<void> dispose() async {
     await _connectivitySub?.cancel();
-    _probeClient.close(force: true);
+    _sharedProbeClient?.close(force: true);
   }
 
   /// Resolve the URL to use for [instance] right now. Always returns a
@@ -117,7 +126,10 @@ class ConnectionResolver {
           return restored.useLocal ? local : external;
         }
 
-        final bool reachable = await _probe(local);
+        final bool reachable = await _probe(
+          local,
+          allowSelfSignedCerts: instance.allowSelfSignedCerts,
+        );
         final _CacheEntry entry = _CacheEntry(
           useLocal: reachable,
           expiresAt: DateTime.now().add(cacheTtl),
@@ -142,9 +154,13 @@ class ConnectionResolver {
     _store?.deleteWhereKeyStartsWith(prefix);
   }
 
-  Future<bool> _probe(Uri url) async {
+  Future<bool> _probe(
+    Uri url, {
+    required bool allowSelfSignedCerts,
+  }) async {
+    final Dio client = _probeClientFactory(allowSelfSignedCerts);
     try {
-      final Response<dynamic> response = await _probeClient.requestUri(
+      final Response<dynamic> response = await client.requestUri(
         url,
         options: Options(
           method: 'GET',
@@ -158,6 +174,10 @@ class ConnectionResolver {
       return response.statusCode != null;
     } on Exception {
       return false;
+    } finally {
+      if (!identical(client, _sharedProbeClient)) {
+        client.close(force: true);
+      }
     }
   }
 
@@ -176,8 +196,8 @@ class ConnectionResolver {
     }
   }
 
-  static Dio _buildProbeClient() {
-    return Dio(
+  static Dio _buildProbeClient(bool allowSelfSignedCerts) {
+    final Dio dio = Dio(
       BaseOptions(
         connectTimeout: const Duration(milliseconds: 1500),
         sendTimeout: const Duration(milliseconds: 1500),
@@ -185,6 +205,14 @@ class ConnectionResolver {
         followRedirects: false,
       ),
     );
+    if (allowSelfSignedCerts) {
+      final IOHttpClientAdapter adapter =
+          dio.httpClientAdapter as IOHttpClientAdapter;
+      adapter.createHttpClient = () => HttpClient()
+        ..badCertificateCallback =
+            (X509Certificate _, String __, int ___) => true;
+    }
+    return dio;
   }
 
   @visibleForTesting

--- a/packages/core_networking/lib/src/networking_providers.dart
+++ b/packages/core_networking/lib/src/networking_providers.dart
@@ -40,8 +40,10 @@ final StateProvider<Map<String, String>> globalHeadersProvider =
 /// A [Dio] bound to a specific [Instance], with the right base URL and auth
 /// wired in. Cached per instance value; closed automatically when no longer
 /// watched.
-final instanceDioProvider =
-    FutureProvider.family<Dio, Instance>((Ref ref, Instance instance) async {
+final instanceDioProvider = FutureProvider.autoDispose.family<Dio, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
   final Map<String, String> global = ref.watch(globalHeadersProvider);
   final Dio dio = await ref
       .watch(dioFactoryProvider)

--- a/packages/core_networking/lib/src/service_health.dart
+++ b/packages/core_networking/lib/src/service_health.dart
@@ -56,6 +56,8 @@ enum _HealthMode {
       return (path: 'api/v2/app/version', mode: _HealthMode.reachable);
     case ServiceKind.glances:
       return (path: 'api/4/core', mode: _HealthMode.authed);
+    case ServiceKind.speedtestTracker:
+      return (path: 'api/v1/results?page[size]=1', mode: _HealthMode.authed);
   }
 }
 
@@ -83,11 +85,16 @@ class HealthProbe {
         cfg.path,
         options: Options(
           validateStatus: (_) => true,
+          followRedirects: false,
           receiveTimeout: const Duration(seconds: 8),
         ),
       );
       final int status = resp.statusCode ?? 0;
-      return _interpret(status, cfg.mode);
+      return interpretServiceHealthResponse(
+        instance.kind,
+        status,
+        resp.data,
+      );
     } on DioException {
       return Health.error;
     } on Object {
@@ -96,26 +103,40 @@ class HealthProbe {
       dio?.close(force: true);
     }
   }
+}
 
-  Health _interpret(int status, _HealthMode mode) {
-    if (status == 0) {
-      return Health.error;
-    }
-    switch (mode) {
-      case _HealthMode.authed:
-        if (status >= 200 && status < 300) {
-          return Health.ok;
-        }
-        if (status == 401 || status == 403) {
+/// Interprets a completed HTTP health response without retaining or exposing
+/// its body. Public for focused tests; callers should normally use
+/// [HealthProbe].
+Health interpretServiceHealthResponse(
+  ServiceKind kind,
+  int status,
+  Object? data,
+) {
+  if (status == 0) {
+    return Health.error;
+  }
+  final _HealthMode mode = _config(kind).mode;
+  switch (mode) {
+    case _HealthMode.authed:
+      if (status >= 200 && status < 300) {
+        if (kind == ServiceKind.speedtestTracker &&
+            !_isSpeedtestResultsEnvelope(data)) {
+          // The host answered, but not with the authenticated API contract.
           return Health.warning;
         }
-        // 5xx = reachable but unhealthy; 4xx (e.g. 404 wrong path) = warning.
-        return Health.warning;
-      case _HealthMode.publicEndpoint:
-        return (status >= 200 && status < 300) ? Health.ok : Health.error;
-      case _HealthMode.reachable:
-        // Any HTTP status proves the host answered.
         return Health.ok;
-    }
+      }
+      // 401/403, API-level 4xx, redirects, and 5xx all prove the host answered
+      // while indicating credentials, compatibility, or server health needs
+      // attention.
+      return Health.warning;
+    case _HealthMode.publicEndpoint:
+      return (status >= 200 && status < 300) ? Health.ok : Health.error;
+    case _HealthMode.reachable:
+      return Health.ok;
   }
 }
+
+bool _isSpeedtestResultsEnvelope(Object? data) =>
+    data is Map && data['data'] is List;

--- a/packages/core_networking/test/auth_interceptor_test.dart
+++ b/packages/core_networking/test/auth_interceptor_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Speedtest Tracker token is sent only as a bearer header', () async {
+    const String token = 'placeholder-token-not-a-secret';
+    final _RecordingAdapter adapter = _RecordingAdapter();
+    final Dio dio = Dio(BaseOptions(baseUrl: 'https://tracker.example.test/'))
+      ..httpClientAdapter = adapter
+      ..interceptors.add(
+        const AuthInterceptor(
+          kind: ServiceKind.speedtestTracker,
+          auth: InstanceAuth.apiKey(apiKey: token),
+        ),
+      );
+
+    await dio.get<dynamic>('api/v1/results');
+
+    final RequestOptions request = adapter.request!;
+    expect(request.headers['Authorization'], 'Bearer $token');
+    expect(request.headers['Accept'], 'application/json');
+    expect(request.queryParameters.values, isNot(contains(token)));
+    expect(request.uri.toString(), isNot(contains(token)));
+  });
+}
+
+class _RecordingAdapter implements HttpClientAdapter {
+  RequestOptions? request;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    request = options;
+    return ResponseBody.fromString(
+      jsonEncode(<String, dynamic>{'data': <dynamic>[]}),
+      200,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/packages/core_networking/test/connection_resolver_test.dart
+++ b/packages/core_networking/test/connection_resolver_test.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('auto local probe receives the per-instance self-signed opt-in',
+      () async {
+    final List<bool> selfSignedChoices = <bool>[];
+    final ConnectionResolver resolver = ConnectionResolver(
+      connectivity: Connectivity(),
+      probeClientFactory: (bool allowSelfSignedCerts) {
+        selfSignedChoices.add(allowSelfSignedCerts);
+        return Dio()..httpClientAdapter = _ReachableAdapter();
+      },
+    );
+    addTearDown(resolver.dispose);
+    const Instance instance = Instance(
+      id: 'self-signed-probe',
+      name: 'Tracker',
+      kind: ServiceKind.speedtestTracker,
+      localUrl: 'https://tracker.lan',
+      externalUrl: 'https://tracker.example.test',
+      urlMode: UrlMode.auto,
+      auth: InstanceAuth.apiKey(apiKey: 'placeholder-token'),
+      allowSelfSignedCerts: true,
+    );
+
+    final Uri selected = await resolver.resolve(instance);
+
+    expect(selected, Uri.parse('https://tracker.lan'));
+    expect(selfSignedChoices, <bool>[true]);
+  });
+}
+
+class _ReachableAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async =>
+      ResponseBody.fromString(
+        jsonEncode(<String, dynamic>{'message': 'reachable'}),
+        200,
+        headers: <String, List<String>>{
+          Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+        },
+      );
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/packages/core_networking/test/service_health_test.dart
+++ b/packages/core_networking/test/service_health_test.dart
@@ -1,0 +1,48 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Speedtest Tracker authenticated health', () {
+    test('recognizable results JSON is online', () {
+      expect(
+        interpretServiceHealthResponse(
+          ServiceKind.speedtestTracker,
+          200,
+          <String, dynamic>{'data': <dynamic>[], 'meta': <String, dynamic>{}},
+        ),
+        Health.ok,
+      );
+    });
+
+    test('HTML and malformed successful responses are warnings', () {
+      for (final Object? body in <Object?>[
+        '<html>Sign in</html>',
+        <String, dynamic>{'message': 'Login required'},
+        null,
+      ]) {
+        expect(
+          interpretServiceHealthResponse(
+            ServiceKind.speedtestTracker,
+            200,
+            body,
+          ),
+          Health.warning,
+        );
+      }
+    });
+
+    test('reachable API errors and redirects are warnings', () {
+      for (final int status in <int>[301, 401, 403, 404, 422, 503]) {
+        expect(
+          interpretServiceHealthResponse(
+            ServiceKind.speedtestTracker,
+            status,
+            'potentially sensitive response body',
+          ),
+          Health.warning,
+        );
+      }
+    });
+  });
+}

--- a/packages/core_ui/lib/src/service_visuals.dart
+++ b/packages/core_ui/lib/src/service_visuals.dart
@@ -20,6 +20,7 @@ abstract final class ServiceVisuals {
         ServiceKind.qbittorrent => Icons.cloud_download_outlined,
         ServiceKind.sabnzbd => Icons.downloading_outlined,
         ServiceKind.glances => Icons.memory_outlined,
+        ServiceKind.speedtestTracker => Icons.speed_outlined,
       };
 
   static Color accent(ServiceKind kind) => switch (kind) {
@@ -35,6 +36,7 @@ abstract final class ServiceVisuals {
         ServiceKind.qbittorrent => const Color(0xFF2F67BA),
         ServiceKind.sabnzbd => const Color(0xFFFFD24D),
         ServiceKind.glances => const Color(0xFF10B981),
+        ServiceKind.speedtestTracker => const Color(0xFF2563EB),
       };
 
   /// Human label for a [ServiceRole] section header.

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -771,10 +771,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1167,26 +1167,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,8 @@ publish_to: none
 description: >
   Workspace root for Atrium - a Flutter mobile controller for a full
   self-hosted media stack (Sonarr / Radarr / Prowlarr / Bazarr / Overseerr
-  / Tautulli / Jellyfin / Emby / Plex / qBittorrent / SABnzbd). Individual
+  / Tautulli / Jellyfin / Emby / Plex / qBittorrent / SABnzbd / Glances /
+  Speedtest Tracker). Individual
   packages live under app/, packages/, and services/.
 
 environment:
@@ -36,3 +37,4 @@ workspace:
   - services/service_qbittorrent
   - services/service_sabnzbd
   - services/service_glances
+  - services/service_speedtest_tracker

--- a/services/service_speedtest_tracker/lib/service_speedtest_tracker.dart
+++ b/services/service_speedtest_tracker/lib/service_speedtest_tracker.dart
@@ -1,0 +1,6 @@
+library;
+
+export 'src/models/speedtest_tracker_models.dart';
+export 'src/speedtest_tracker_api.dart';
+export 'src/speedtest_tracker_home.dart';
+export 'src/speedtest_tracker_providers.dart';

--- a/services/service_speedtest_tracker/lib/src/models/speedtest_tracker_models.dart
+++ b/services/service_speedtest_tracker/lib/src/models/speedtest_tracker_models.dart
@@ -1,0 +1,353 @@
+enum SpeedtestResultStatus {
+  waiting,
+  started,
+  checking,
+  running,
+  benchmarking,
+  completed,
+  failed,
+  skipped,
+  unknown,
+}
+
+extension SpeedtestResultStatusX on SpeedtestResultStatus {
+  bool get isInProgress => switch (this) {
+        SpeedtestResultStatus.waiting ||
+        SpeedtestResultStatus.started ||
+        SpeedtestResultStatus.checking ||
+        SpeedtestResultStatus.running ||
+        SpeedtestResultStatus.benchmarking =>
+          true,
+        _ => false,
+      };
+
+  bool get isFailure =>
+      this == SpeedtestResultStatus.failed ||
+      this == SpeedtestResultStatus.skipped;
+
+  String get label => switch (this) {
+        SpeedtestResultStatus.waiting => 'Waiting',
+        SpeedtestResultStatus.started => 'Started',
+        SpeedtestResultStatus.checking => 'Checking',
+        SpeedtestResultStatus.running => 'Running',
+        SpeedtestResultStatus.benchmarking => 'Benchmarking',
+        SpeedtestResultStatus.completed => 'Completed',
+        SpeedtestResultStatus.failed => 'Failed',
+        SpeedtestResultStatus.skipped => 'Skipped',
+        SpeedtestResultStatus.unknown => 'Unknown',
+      };
+}
+
+class SpeedtestProtocolException implements Exception {
+  const SpeedtestProtocolException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => 'SpeedtestProtocolException: $message';
+}
+
+class SpeedtestServer {
+  const SpeedtestServer({
+    this.id,
+    this.name,
+    this.host,
+    this.location,
+    this.country,
+  });
+
+  final String? id;
+  final String? name;
+  final String? host;
+  final String? location;
+  final String? country;
+
+  String? get displayName => _firstNonEmpty(<String?>[name, host]);
+
+  String? get displayLocation {
+    final List<String> parts = <String>[
+      if (location != null && location!.isNotEmpty) location!,
+      if (country != null && country!.isNotEmpty) country!,
+    ];
+    return parts.isEmpty ? null : parts.join(', ');
+  }
+}
+
+class SpeedtestResult {
+  const SpeedtestResult({
+    required this.id,
+    required this.status,
+    this.downloadBitsPerSecond,
+    this.uploadBitsPerSecond,
+    this.pingMilliseconds,
+    this.jitterMilliseconds,
+    this.packetLossPercent,
+    this.healthy,
+    this.server,
+    this.isp,
+    this.createdAt,
+    this.updatedAt,
+    this.measuredAt,
+    this.message,
+    this.resultUrl,
+  });
+
+  factory SpeedtestResult.fromJson(Object? value) {
+    final Map<String, dynamic> json = _asStringMap(value);
+    final int? id = _asInt(json['id']);
+    final String? statusValue = _asString(json['status']);
+    if (id == null || statusValue == null) {
+      throw const SpeedtestProtocolException(
+        'A result is missing its id or status.',
+      );
+    }
+
+    final Map<String, dynamic> raw = _optionalMap(json['data']);
+    final Map<String, dynamic> rawPing = _optionalMap(raw['ping']);
+    final Map<String, dynamic> rawServer = _optionalMap(
+      raw['server'] ?? json['server'],
+    );
+    final Map<String, dynamic> rawResult = _optionalMap(raw['result']);
+
+    return SpeedtestResult(
+      id: id,
+      status: _parseStatus(statusValue),
+      downloadBitsPerSecond: _bitsPerSecond(
+        bits: json['download_bits'],
+        bytes: json['download'] ?? _optionalMap(raw['download'])['bandwidth'],
+      ),
+      uploadBitsPerSecond: _bitsPerSecond(
+        bits: json['upload_bits'],
+        bytes: json['upload'] ?? _optionalMap(raw['upload'])['bandwidth'],
+      ),
+      pingMilliseconds: _asDouble(json['ping']) ??
+          _asDouble(rawPing['latency'] ?? rawPing['iqm']),
+      jitterMilliseconds: _asDouble(
+        json['jitter'] ?? rawPing['jitter'],
+      ),
+      packetLossPercent: _asDouble(
+        json['packet_loss'] ?? raw['packetLoss'],
+      ),
+      healthy: _asBool(json['healthy']),
+      server: rawServer.isEmpty
+          ? null
+          : SpeedtestServer(
+              id: _asString(rawServer['id']),
+              name: _asString(rawServer['name']),
+              host: _asString(rawServer['host']),
+              location: _asString(rawServer['location']),
+              country: _asString(rawServer['country']),
+            ),
+      isp: _asString(json['isp'] ?? raw['isp']),
+      createdAt: _asDateTime(json['created_at']),
+      updatedAt: _asDateTime(json['updated_at']),
+      measuredAt: _asDateTime(raw['timestamp']),
+      message: _asString(
+        json['message'] ?? json['comments'] ?? raw['message'] ?? raw['error'],
+      ),
+      resultUrl: _asString(json['result_url'] ?? rawResult['url']),
+    );
+  }
+
+  final int id;
+  final SpeedtestResultStatus status;
+  final double? downloadBitsPerSecond;
+  final double? uploadBitsPerSecond;
+  final double? pingMilliseconds;
+  final double? jitterMilliseconds;
+  final double? packetLossPercent;
+  final bool? healthy;
+  final SpeedtestServer? server;
+  final String? isp;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? measuredAt;
+  final String? message;
+  final String? resultUrl;
+
+  DateTime? get completedAt => measuredAt ?? updatedAt ?? createdAt;
+
+  String? get serverOrProvider =>
+      _firstNonEmpty(<String?>[server?.displayName, isp]);
+}
+
+class SpeedtestResultsPage {
+  const SpeedtestResultsPage({
+    required this.results,
+    required this.page,
+    required this.hasMore,
+  });
+
+  factory SpeedtestResultsPage.fromJson(
+    Object? value, {
+    required int requestedPage,
+    required int pageSize,
+  }) {
+    final Map<String, dynamic> json = _asStringMap(value);
+    final Object? data = json['data'];
+    if (data is! List<dynamic>) {
+      throw const SpeedtestProtocolException(
+        'The result history response does not contain a data list.',
+      );
+    }
+    final List<SpeedtestResult> results = <SpeedtestResult>[
+      for (final Object? row in data) SpeedtestResult.fromJson(row),
+    ];
+    final Map<String, dynamic> meta = _optionalMap(json['meta']);
+    final Map<String, dynamic> links = _optionalMap(json['links']);
+    final int page = _asInt(
+          meta['current_page'] ??
+              _optionalMap(meta['page'])['current'] ??
+              _optionalMap(meta['page'])['number'],
+        ) ??
+        requestedPage;
+    final int? lastPage = _asInt(
+      meta['last_page'] ?? _optionalMap(meta['page'])['last'],
+    );
+    final bool hasMore = links['next'] != null ||
+        (lastPage != null ? page < lastPage : results.length >= pageSize);
+    return SpeedtestResultsPage(
+      results: results,
+      page: page,
+      hasMore: hasMore,
+    );
+  }
+
+  final List<SpeedtestResult> results;
+  final int page;
+  final bool hasMore;
+}
+
+class SpeedtestOverview {
+  const SpeedtestOverview({
+    required this.latestAny,
+    required this.completedResults,
+  });
+
+  final SpeedtestResult? latestAny;
+  final List<SpeedtestResult> completedResults;
+
+  SpeedtestResult? get latestCompleted =>
+      completedResults.isEmpty ? null : completedResults.first;
+}
+
+String formatSpeed(double? bitsPerSecond) {
+  if (bitsPerSecond == null) {
+    return '—';
+  }
+  if (bitsPerSecond >= 1000000000) {
+    final double value = bitsPerSecond / 1000000000;
+    return '${value.toStringAsFixed(value >= 10 ? 1 : 2)} Gbps';
+  }
+  final double value = bitsPerSecond / 1000000;
+  return '${value.toStringAsFixed(value >= 100 ? 0 : 1)} Mbps';
+}
+
+String formatMilliseconds(double? milliseconds) => milliseconds == null
+    ? '—'
+    : '${milliseconds.toStringAsFixed(milliseconds >= 100 ? 0 : 1)} ms';
+
+String formatPacketLoss(double? percent) => percent == null
+    ? '—'
+    : '${percent.toStringAsFixed(percent >= 10 ? 0 : 1)}%';
+
+SpeedtestResultStatus _parseStatus(String value) =>
+    switch (value.toLowerCase()) {
+      'waiting' => SpeedtestResultStatus.waiting,
+      'started' => SpeedtestResultStatus.started,
+      'checking' => SpeedtestResultStatus.checking,
+      'running' => SpeedtestResultStatus.running,
+      'benchmarking' => SpeedtestResultStatus.benchmarking,
+      'completed' => SpeedtestResultStatus.completed,
+      'failed' => SpeedtestResultStatus.failed,
+      'skipped' => SpeedtestResultStatus.skipped,
+      _ => SpeedtestResultStatus.unknown,
+    };
+
+double? _bitsPerSecond({required Object? bits, required Object? bytes}) {
+  final double? explicitBits = _asDouble(bits);
+  if (explicitBits != null) {
+    return explicitBits;
+  }
+  final double? rawBytes = _asDouble(bytes);
+  return rawBytes == null ? null : rawBytes * 8;
+}
+
+Map<String, dynamic> _asStringMap(Object? value) {
+  if (value is! Map) {
+    throw const SpeedtestProtocolException('Expected a JSON object.');
+  }
+  return <String, dynamic>{
+    for (final MapEntry<dynamic, dynamic> entry in value.entries)
+      if (entry.key is String) entry.key as String: entry.value,
+  };
+}
+
+Map<String, dynamic> _optionalMap(Object? value) {
+  if (value is! Map) {
+    return const <String, dynamic>{};
+  }
+  return <String, dynamic>{
+    for (final MapEntry<dynamic, dynamic> entry in value.entries)
+      if (entry.key is String) entry.key as String: entry.value,
+  };
+}
+
+String? _asString(Object? value) {
+  if (value == null) {
+    return null;
+  }
+  final String result = value.toString().trim();
+  return result.isEmpty ? null : result;
+}
+
+String? _firstNonEmpty(List<String?> values) {
+  for (final String? value in values) {
+    if (value != null && value.isNotEmpty) {
+      return value;
+    }
+  }
+  return null;
+}
+
+double? _asDouble(Object? value) {
+  double? parsed;
+  if (value is num) {
+    parsed = value.toDouble();
+  } else if (value is String) {
+    parsed = double.tryParse(value);
+  }
+  return parsed != null && parsed.isFinite && parsed >= 0 ? parsed : null;
+}
+
+int? _asInt(Object? value) {
+  if (value is int) {
+    return value;
+  }
+  if (value is num) {
+    return value.toInt();
+  }
+  return value is String ? int.tryParse(value) : null;
+}
+
+bool? _asBool(Object? value) {
+  if (value is bool) {
+    return value;
+  }
+  if (value is num) {
+    return value != 0;
+  }
+  if (value is String) {
+    return switch (value.toLowerCase()) {
+      'true' || '1' => true,
+      'false' || '0' => false,
+      _ => null,
+    };
+  }
+  return null;
+}
+
+DateTime? _asDateTime(Object? value) {
+  final String? raw = _asString(value);
+  return raw == null ? null : DateTime.tryParse(raw);
+}

--- a/services/service_speedtest_tracker/lib/src/speedtest_tracker_api.dart
+++ b/services/service_speedtest_tracker/lib/src/speedtest_tracker_api.dart
@@ -1,0 +1,241 @@
+import 'package:dio/dio.dart';
+
+import 'models/speedtest_tracker_models.dart';
+
+enum SpeedtestErrorKind {
+  authentication,
+  permission,
+  unsupported,
+  offline,
+  timeout,
+  server,
+  malformed,
+  notFound,
+  other,
+}
+
+class SpeedtestTrackerException implements Exception {
+  const SpeedtestTrackerException(
+    this.kind,
+    this.message, {
+    this.statusCode,
+  });
+
+  final SpeedtestErrorKind kind;
+  final String message;
+  final int? statusCode;
+
+  @override
+  String toString() => 'SpeedtestTrackerException: $message';
+}
+
+class SpeedtestTrackerApi {
+  SpeedtestTrackerApi(this._dio) {
+    // A bearer credential must never ride a redirect to another origin.
+    // Callers use only relative paths against this client's configured base.
+    _dio.options.followRedirects = false;
+  }
+
+  final Dio _dio;
+
+  Future<void> checkHealth() async {
+    try {
+      await _dio.get<dynamic>('api/healthcheck');
+    } on DioException catch (error) {
+      throw _mapDio(error, operation: _Operation.health);
+    }
+  }
+
+  Future<SpeedtestResultsPage> listResults({
+    int page = 1,
+    int pageSize = 25,
+    SpeedtestResultStatus? status,
+  }) async {
+    try {
+      final Response<dynamic> response = await _dio.get<dynamic>(
+        'api/v1/results',
+        queryParameters: <String, dynamic>{
+          if (status != null) 'filter[status]': status.name,
+          'sort': '-created_at',
+          'page': page,
+          'page[number]': page,
+          'page[size]': pageSize,
+          'per_page': pageSize,
+        },
+      );
+      final SpeedtestResultsPage parsed = SpeedtestResultsPage.fromJson(
+        response.data,
+        requestedPage: page,
+        pageSize: pageSize,
+      );
+      if (status == null) {
+        return parsed;
+      }
+      return SpeedtestResultsPage(
+        results: <SpeedtestResult>[
+          for (final SpeedtestResult result in parsed.results)
+            if (result.status == status) result,
+        ],
+        page: parsed.page,
+        hasMore: parsed.hasMore,
+      );
+    } on SpeedtestProtocolException catch (error) {
+      throw SpeedtestTrackerException(
+        SpeedtestErrorKind.malformed,
+        error.message,
+      );
+    } on DioException catch (error) {
+      throw _mapDio(error, operation: _Operation.list);
+    }
+  }
+
+  Future<SpeedtestResult> getResult(int id) async {
+    try {
+      final Response<dynamic> response =
+          await _dio.get<dynamic>('api/v1/results/$id');
+      return SpeedtestResult.fromJson(_unwrapData(response.data));
+    } on SpeedtestProtocolException catch (error) {
+      throw SpeedtestTrackerException(
+        SpeedtestErrorKind.malformed,
+        error.message,
+      );
+    } on DioException catch (error) {
+      throw _mapDio(error, operation: _Operation.result);
+    }
+  }
+
+  Future<SpeedtestResult> runSpeedtest() async {
+    try {
+      final Response<dynamic> response = await _dio.post<dynamic>(
+        'api/v1/speedtests/run',
+        data: const <String, dynamic>{},
+      );
+      return SpeedtestResult.fromJson(_unwrapData(response.data));
+    } on SpeedtestProtocolException catch (error) {
+      throw SpeedtestTrackerException(
+        SpeedtestErrorKind.malformed,
+        error.message,
+      );
+    } on DioException catch (error) {
+      throw _mapDio(error, operation: _Operation.run);
+    }
+  }
+}
+
+enum _Operation { health, list, result, run }
+
+Object? _unwrapData(Object? response) {
+  if (response is Map && response['data'] != null) {
+    return response['data'];
+  }
+  return response;
+}
+
+SpeedtestTrackerException _mapDio(
+  DioException error, {
+  required _Operation operation,
+}) {
+  if (error.type == DioExceptionType.connectionTimeout ||
+      error.type == DioExceptionType.sendTimeout ||
+      error.type == DioExceptionType.receiveTimeout) {
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.timeout,
+      'Speedtest Tracker took too long to respond.',
+    );
+  }
+  if (error.type == DioExceptionType.badCertificate) {
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.offline,
+      'The TLS certificate is not trusted. Enable self-signed certificates '
+      'only if you trust this server.',
+    );
+  }
+  if (error.type == DioExceptionType.connectionError) {
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.offline,
+      'Could not reach Speedtest Tracker.',
+    );
+  }
+  final int? status = error.response?.statusCode;
+  if (status != null && status >= 300 && status < 400) {
+    return SpeedtestTrackerException(
+      SpeedtestErrorKind.other,
+      'Speedtest Tracker returned a redirect (HTTP $status). Atrium will not '
+      'follow redirects for authenticated requests.',
+      statusCode: status,
+    );
+  }
+  if (status == 401) {
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.authentication,
+      'The bearer token was rejected. Check the configured API token.',
+      statusCode: 401,
+    );
+  }
+  if (status == 403) {
+    if (operation == _Operation.run) {
+      return const SpeedtestTrackerException(
+        SpeedtestErrorKind.permission,
+        'The API token lacks the speedtests:run ability.',
+        statusCode: 403,
+      );
+    }
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.authentication,
+      'The API token lacks the results:read ability.',
+      statusCode: 403,
+    );
+  }
+  if (status == 404) {
+    return switch (operation) {
+      _Operation.run => const SpeedtestTrackerException(
+          SpeedtestErrorKind.unsupported,
+          'Remote test execution requires Speedtest Tracker 1.6 or newer.',
+          statusCode: 404,
+        ),
+      _Operation.list => const SpeedtestTrackerException(
+          SpeedtestErrorKind.unsupported,
+          'Authenticated results require Speedtest Tracker 1.1 or newer.',
+          statusCode: 404,
+        ),
+      _Operation.result => const SpeedtestTrackerException(
+          SpeedtestErrorKind.notFound,
+          'The queued speed test result is no longer available.',
+          statusCode: 404,
+        ),
+      _Operation.health => const SpeedtestTrackerException(
+          SpeedtestErrorKind.other,
+          'The Speedtest Tracker health endpoint was not found.',
+          statusCode: 404,
+        ),
+    };
+  }
+  if (status == 406) {
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.other,
+      'Speedtest Tracker rejected the required JSON response format (HTTP 406).',
+      statusCode: 406,
+    );
+  }
+  if (status == 422) {
+    return const SpeedtestTrackerException(
+      SpeedtestErrorKind.other,
+      'Speedtest Tracker rejected the request parameters (HTTP 422).',
+      statusCode: 422,
+    );
+  }
+  if (status != null && status >= 500) {
+    return SpeedtestTrackerException(
+      SpeedtestErrorKind.server,
+      'Speedtest Tracker returned a server error (HTTP $status).',
+      statusCode: status,
+    );
+  }
+  return SpeedtestTrackerException(
+    SpeedtestErrorKind.other,
+    status == null
+        ? 'Speedtest Tracker returned an unexpected network error.'
+        : 'Speedtest Tracker returned an unexpected response (HTTP $status).',
+    statusCode: status,
+  );
+}

--- a/services/service_speedtest_tracker/lib/src/speedtest_tracker_home.dart
+++ b/services/service_speedtest_tracker/lib/src/speedtest_tracker_home.dart
@@ -1,0 +1,421 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models/speedtest_tracker_models.dart';
+import 'speedtest_tracker_api.dart';
+import 'speedtest_tracker_providers.dart';
+import 'widgets/speedtest_history_chart.dart';
+import 'widgets/speedtest_result_views.dart';
+
+class SpeedtestTrackerHome extends ConsumerStatefulWidget {
+  const SpeedtestTrackerHome({required this.instance, super.key});
+
+  final Instance instance;
+
+  @override
+  ConsumerState<SpeedtestTrackerHome> createState() =>
+      _SpeedtestTrackerHomeState();
+}
+
+class _SpeedtestTrackerHomeState extends ConsumerState<SpeedtestTrackerHome> {
+  static const int _historyPageSize = 25;
+  int _loadedPages = 1;
+
+  SpeedtestHistoryQuery _query(int page) => (
+        instance: widget.instance,
+        page: page,
+        pageSize: _historyPageSize,
+      );
+
+  @override
+  Widget build(BuildContext context) {
+    final AsyncValue<SpeedtestOverview> overview =
+        ref.watch(speedtestOverviewProvider(widget.instance));
+    final SpeedtestRunState runState =
+        ref.watch(speedtestRunControllerProvider(widget.instance));
+
+    return AsyncValueView<SpeedtestOverview>(
+      value: overview,
+      onRetry: () => ref.invalidate(speedtestOverviewProvider(widget.instance)),
+      data: (SpeedtestOverview data) {
+        final _HistorySnapshot history = _watchHistory();
+        return EasyRefresh(
+          header: const ClassicHeader(
+            dragText: 'Pull to refresh',
+            armedText: 'Release ready',
+            readyText: 'Refreshing...',
+            processingText: 'Refreshing...',
+            processedText: 'Succeeded',
+            failedText: 'Failed',
+            messageText: 'Last updated at %T',
+          ),
+          footer: history.hasMore
+              ? const ClassicFooter(
+                  dragText: 'Pull to load more',
+                  armedText: 'Release ready',
+                  readyText: 'Loading...',
+                  processingText: 'Loading...',
+                  processedText: 'Loaded',
+                  failedText: 'Failed',
+                  noMoreText: 'No more results',
+                  messageText: 'Last updated at %T',
+                )
+              : null,
+          onRefresh: _refresh,
+          onLoad: history.hasMore ? _loadMore : null,
+          child: ListView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            padding: Insets.page,
+            children: <Widget>[
+              _RunAction(
+                instance: widget.instance,
+                state: runState,
+                onRun: _confirmRun,
+              ),
+              ..._statusBanners(data, runState),
+              const SizedBox(height: Insets.md),
+              if (data.latestCompleted case final SpeedtestResult result)
+                SpeedtestLatestCard(result: result)
+              else
+                const _SectionCard(
+                  title: 'Latest result',
+                  child: EmptyView(
+                    icon: Icons.speed_outlined,
+                    title: 'No completed results',
+                    message: 'Completed speed tests will appear here.',
+                  ),
+                ),
+              const SizedBox(height: Insets.md),
+              _SectionCard(
+                title: 'Download and upload history',
+                child: SpeedtestHistoryChart(
+                  results: data.completedResults,
+                ),
+              ),
+              const SizedBox(height: Insets.md),
+              _SectionCard(
+                title: 'Recent history',
+                child: _HistoryBody(
+                  snapshot: history,
+                  onRetry: () => ref.invalidate(
+                    speedtestHistoryProvider(_query(history.failedPage ?? 1)),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  _HistorySnapshot _watchHistory() {
+    final List<SpeedtestResult> results = <SpeedtestResult>[];
+    final Set<int> ids = <int>{};
+    bool loading = false;
+    bool hasMore = true;
+    Object? error;
+    int? failedPage;
+    for (int page = 1; page <= _loadedPages; page++) {
+      final AsyncValue<SpeedtestResultsPage> value =
+          ref.watch(speedtestHistoryProvider(_query(page)));
+      loading |= value.isLoading && !value.hasValue;
+      if (value.hasError) {
+        error = value.error;
+        failedPage = page;
+      }
+      final SpeedtestResultsPage? data = value.value;
+      if (data != null) {
+        hasMore = data.hasMore;
+        for (final SpeedtestResult result in data.results) {
+          if (ids.add(result.id)) {
+            results.add(result);
+          }
+        }
+      }
+    }
+    return _HistorySnapshot(
+      results: results,
+      loading: loading,
+      hasMore: hasMore,
+      error: error,
+      failedPage: failedPage,
+    );
+  }
+
+  List<Widget> _statusBanners(
+    SpeedtestOverview overview,
+    SpeedtestRunState runState,
+  ) {
+    final ColorScheme colors = Theme.of(context).colorScheme;
+    if (runState.phase != SpeedtestRunPhase.idle) {
+      final bool busy = runState.isBusy;
+      final bool success = runState.phase == SpeedtestRunPhase.completed;
+      final bool warning = runState.phase == SpeedtestRunPhase.timedOut ||
+          runState.phase == SpeedtestRunPhase.indeterminate;
+      final String message = runState.message ??
+          runState.result?.status.label ??
+          switch (runState.phase) {
+            SpeedtestRunPhase.checking =>
+              'Checking for an active speed test...',
+            SpeedtestRunPhase.submitting => 'Queuing speed test...',
+            SpeedtestRunPhase.reconciling =>
+              'Checking whether the speed test was accepted...',
+            SpeedtestRunPhase.queued => 'Speed test queued...',
+            SpeedtestRunPhase.running => 'Speed test running...',
+            _ => 'Speed test status unavailable.',
+          };
+      return <Widget>[
+        const SizedBox(height: Insets.md),
+        SpeedtestRunBanner(
+          icon: success
+              ? Icons.check_circle_outline
+              : warning
+                  ? Icons.schedule
+                  : Icons.error_outline,
+          message: message,
+          color: success
+              ? colors.primary
+              : busy
+                  ? colors.tertiary
+                  : colors.error,
+          busy: busy,
+        ),
+      ];
+    }
+
+    final SpeedtestResult? latest = overview.latestAny;
+    if (latest == null || latest.status == SpeedtestResultStatus.completed) {
+      return const <Widget>[];
+    }
+    if (latest.status.isInProgress) {
+      return <Widget>[
+        const SizedBox(height: Insets.md),
+        SpeedtestRunBanner(
+          icon: Icons.speed,
+          message:
+              'The latest speed test is ${latest.status.label.toLowerCase()}.',
+          color: colors.tertiary,
+          busy: true,
+        ),
+      ];
+    }
+    return <Widget>[
+      const SizedBox(height: Insets.md),
+      SpeedtestRunBanner(
+        icon: Icons.warning_amber,
+        message: latest.status == SpeedtestResultStatus.unknown
+            ? 'The latest test has a status this Atrium version does not understand.'
+            : 'The latest speed test ${latest.status.label.toLowerCase()}.',
+        color: colors.error,
+      ),
+    ];
+  }
+
+  Future<void> _confirmRun() async {
+    final SpeedtestRunState current =
+        ref.read(speedtestRunControllerProvider(widget.instance));
+    final bool retryingIndeterminate =
+        current.phase == SpeedtestRunPhase.indeterminate;
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext dialogContext) => AlertDialog(
+        title: Text(
+          retryingIndeterminate ? 'Run another speed test?' : 'Run speed test?',
+        ),
+        content: Text(
+          retryingIndeterminate
+              ? 'Atrium could not confirm the previous submission. Running '
+                  'again may create a duplicate and can use significant bandwidth.'
+              : 'This can use significant bandwidth. Run permission cannot be '
+                  'verified until Speedtest Tracker receives the request.',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(dialogContext).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(dialogContext).pop(true),
+            child: const Text('Run test'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed == true) {
+      await ref
+          .read(speedtestRunControllerProvider(widget.instance).notifier)
+          .run(confirmIndeterminateRetry: retryingIndeterminate);
+    }
+  }
+
+  Future<void> _refresh() async {
+    if (mounted) {
+      setState(() => _loadedPages = 1);
+    }
+    ref.invalidate(speedtestOverviewProvider(widget.instance));
+    ref.invalidate(speedtestHistoryProvider);
+    await Future.wait(<Future<Object?>>[
+      ref.read(speedtestOverviewProvider(widget.instance).future),
+      ref.read(speedtestHistoryProvider(_query(1)).future),
+    ]);
+  }
+
+  Future<void> _loadMore() async {
+    final SpeedtestResultsPage current =
+        await ref.read(speedtestHistoryProvider(_query(_loadedPages)).future);
+    if (!current.hasMore || !mounted) {
+      return;
+    }
+    setState(() => _loadedPages++);
+    await ref.read(speedtestHistoryProvider(_query(_loadedPages)).future);
+  }
+}
+
+class _RunAction extends StatelessWidget {
+  const _RunAction({
+    required this.instance,
+    required this.state,
+    required this.onRun,
+  });
+
+  final Instance instance;
+  final SpeedtestRunState state;
+  final VoidCallback onRun;
+
+  @override
+  Widget build(BuildContext context) => Row(
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  'Internet performance',
+                  style: Theme.of(context).textTheme.titleLarge,
+                ),
+                Text(
+                  'Results from ${instance.name}',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          FilledButton.icon(
+            onPressed:
+                state.isBusy || state.isDisabledForSession ? null : onRun,
+            icon: state.isBusy
+                ? const SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.play_arrow),
+            label: Text(state.isBusy ? 'Running' : 'Run test'),
+          ),
+        ],
+      );
+}
+
+class _SectionCard extends StatelessWidget {
+  const _SectionCard({required this.title, required this.child});
+
+  final String title;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) => Card(
+        elevation: 0,
+        color: Theme.of(context).colorScheme.surfaceContainerLow,
+        child: Padding(
+          padding: const EdgeInsets.all(Insets.lg),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(title, style: Theme.of(context).textTheme.titleMedium),
+              const SizedBox(height: Insets.md),
+              child,
+            ],
+          ),
+        ),
+      );
+}
+
+class _HistoryBody extends StatelessWidget {
+  const _HistoryBody({required this.snapshot, required this.onRetry});
+
+  final _HistorySnapshot snapshot;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    if (snapshot.results.isEmpty && snapshot.loading) {
+      return const Center(
+        child: Padding(
+          padding: EdgeInsets.all(Insets.lg),
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+    if (snapshot.results.isEmpty && snapshot.error != null) {
+      return ErrorView(
+        message: _errorMessage(snapshot.error!),
+        onRetry: onRetry,
+      );
+    }
+    if (snapshot.results.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: Insets.lg),
+        child: Center(child: Text('No completed results yet.')),
+      );
+    }
+    return Column(
+      children: <Widget>[
+        for (final SpeedtestResult result in snapshot.results)
+          SpeedtestResultTile(
+            result: result,
+            onTap: () => showSpeedtestResultDetails(context, result),
+          ),
+        if (snapshot.loading)
+          const Padding(
+            padding: EdgeInsets.all(Insets.md),
+            child: CircularProgressIndicator(),
+          ),
+        if (snapshot.error != null)
+          Padding(
+            padding: const EdgeInsets.only(top: Insets.sm),
+            child: ErrorView(
+              title: 'Could not load more results',
+              message: _errorMessage(snapshot.error!),
+              onRetry: onRetry,
+            ),
+          ),
+      ],
+    );
+  }
+
+  String _errorMessage(Object error) {
+    if (error is SpeedtestTrackerException) {
+      return error.message;
+    }
+    return 'Speedtest Tracker returned an unexpected error.';
+  }
+}
+
+class _HistorySnapshot {
+  const _HistorySnapshot({
+    required this.results,
+    required this.loading,
+    required this.hasMore,
+    required this.error,
+    required this.failedPage,
+  });
+
+  final List<SpeedtestResult> results;
+  final bool loading;
+  final bool hasMore;
+  final Object? error;
+  final int? failedPage;
+}

--- a/services/service_speedtest_tracker/lib/src/speedtest_tracker_providers.dart
+++ b/services/service_speedtest_tracker/lib/src/speedtest_tracker_providers.dart
@@ -1,0 +1,470 @@
+import 'dart:async';
+
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'models/speedtest_tracker_models.dart';
+import 'speedtest_tracker_api.dart';
+
+typedef SpeedtestHistoryQuery = ({
+  Instance instance,
+  int page,
+  int pageSize,
+});
+
+final speedtestTrackerApiProvider =
+    FutureProvider.autoDispose.family<SpeedtestTrackerApi, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  return SpeedtestTrackerApi(dio);
+});
+
+final speedtestOverviewProvider =
+    FutureProvider.autoDispose.family<SpeedtestOverview, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final SpeedtestTrackerApi api =
+      await ref.watch(speedtestTrackerApiProvider(instance).future);
+  final List<SpeedtestResultsPage> pages = await Future.wait(
+    <Future<SpeedtestResultsPage>>[
+      api.listResults(pageSize: 1),
+      api.listResults(
+        pageSize: 30,
+        status: SpeedtestResultStatus.completed,
+      ),
+    ],
+  );
+  return SpeedtestOverview(
+    latestAny: pages.first.results.isEmpty ? null : pages.first.results.first,
+    completedResults: pages.last.results,
+  );
+});
+
+final speedtestHistoryProvider = FutureProvider.autoDispose
+    .family<SpeedtestResultsPage, SpeedtestHistoryQuery>((
+  Ref ref,
+  SpeedtestHistoryQuery query,
+) async {
+  final SpeedtestTrackerApi api =
+      await ref.watch(speedtestTrackerApiProvider(query.instance).future);
+  return api.listResults(
+    page: query.page,
+    pageSize: query.pageSize,
+    status: SpeedtestResultStatus.completed,
+  );
+});
+
+final speedtestRunPollIntervalProvider =
+    Provider<Duration>((Ref ref) => const Duration(seconds: 3));
+
+final speedtestRunMaxPollsProvider = Provider<int>((Ref ref) => 100);
+
+final speedtestRunReconcileMaxPollsProvider = Provider<int>((Ref ref) => 10);
+
+final speedtestRunClockProvider =
+    Provider<DateTime Function()>((Ref ref) => DateTime.now);
+
+enum SpeedtestRunPhase {
+  idle,
+  checking,
+  submitting,
+  reconciling,
+  queued,
+  running,
+  completed,
+  failed,
+  timedOut,
+  indeterminate,
+  permissionDenied,
+  unsupported,
+}
+
+class SpeedtestRunState {
+  const SpeedtestRunState({
+    this.phase = SpeedtestRunPhase.idle,
+    this.result,
+    this.message,
+  });
+
+  final SpeedtestRunPhase phase;
+  final SpeedtestResult? result;
+  final String? message;
+
+  bool get isBusy => switch (phase) {
+        SpeedtestRunPhase.checking ||
+        SpeedtestRunPhase.submitting ||
+        SpeedtestRunPhase.reconciling ||
+        SpeedtestRunPhase.queued ||
+        SpeedtestRunPhase.running =>
+          true,
+        _ => false,
+      };
+
+  bool get isDisabledForSession =>
+      phase == SpeedtestRunPhase.permissionDenied ||
+      phase == SpeedtestRunPhase.unsupported;
+}
+
+class _SessionRestriction {
+  const _SessionRestriction({
+    required this.instanceSignature,
+    required this.phase,
+    required this.message,
+  });
+
+  final int instanceSignature;
+  final SpeedtestRunPhase phase;
+  final String message;
+}
+
+final NotifierProvider<_SpeedtestRunSessionRestrictions,
+        Map<String, _SessionRestriction>> _speedtestRunSessionRestrictions =
+    NotifierProvider<_SpeedtestRunSessionRestrictions,
+        Map<String, _SessionRestriction>>(
+  _SpeedtestRunSessionRestrictions.new,
+);
+
+class _SpeedtestRunSessionRestrictions
+    extends Notifier<Map<String, _SessionRestriction>> {
+  @override
+  Map<String, _SessionRestriction> build() =>
+      const <String, _SessionRestriction>{};
+
+  _SessionRestriction? forInstance(Instance instance) {
+    final _SessionRestriction? restriction = state[instance.id];
+    return restriction?.instanceSignature == _instanceSignature(instance)
+        ? restriction
+        : null;
+  }
+
+  void restrict(
+    Instance instance,
+    SpeedtestRunPhase phase,
+    String message,
+  ) {
+    state = <String, _SessionRestriction>{
+      ...state,
+      instance.id: _SessionRestriction(
+        instanceSignature: _instanceSignature(instance),
+        phase: phase,
+        message: message,
+      ),
+    };
+  }
+}
+
+int _instanceSignature(Instance instance) => Object.hash(
+      instance.localUrl,
+      instance.externalUrl,
+      instance.urlMode,
+      instance.auth,
+      instance.allowSelfSignedCerts,
+      Object.hashAll(
+        instance.customHeaders.entries.map(
+          (MapEntry<String, String> entry) =>
+              Object.hash(entry.key, entry.value),
+        ),
+      ),
+    );
+
+final speedtestRunControllerProvider = NotifierProvider.autoDispose
+    .family<SpeedtestRunController, SpeedtestRunState, Instance>(
+  SpeedtestRunController.new,
+);
+
+class SpeedtestRunController extends Notifier<SpeedtestRunState> {
+  SpeedtestRunController(this.instance);
+
+  final Instance instance;
+  bool _disposed = false;
+  late Completer<void> _disposeSignal;
+
+  @override
+  SpeedtestRunState build() {
+    _disposed = false;
+    _disposeSignal = Completer<void>();
+    ref.onDispose(() {
+      _disposed = true;
+      if (!_disposeSignal.isCompleted) {
+        _disposeSignal.complete();
+      }
+    });
+    ref.listen<AsyncValue<SpeedtestTrackerApi>>(
+      speedtestTrackerApiProvider(instance),
+      (_, __) {},
+    );
+    final _SessionRestriction? restriction = ref
+        .read(_speedtestRunSessionRestrictions.notifier)
+        .forInstance(instance);
+    return restriction == null
+        ? const SpeedtestRunState()
+        : SpeedtestRunState(
+            phase: restriction.phase,
+            message: restriction.message,
+          );
+  }
+
+  Future<void> run({bool confirmIndeterminateRetry = false}) async {
+    if (state.phase == SpeedtestRunPhase.indeterminate &&
+        !confirmIndeterminateRetry) {
+      return;
+    }
+    if (state.isBusy || state.isDisabledForSession) {
+      return;
+    }
+    state = const SpeedtestRunState(phase: SpeedtestRunPhase.checking);
+    try {
+      final SpeedtestTrackerApi api =
+          await ref.read(speedtestTrackerApiProvider(instance).future);
+      final SpeedtestResultsPage latest = await api.listResults(pageSize: 10);
+      if (_disposed) {
+        return;
+      }
+      final Set<int> baselineIds = <int>{
+        for (final SpeedtestResult result in latest.results) result.id,
+      };
+      final SpeedtestResult? active = _firstInProgress(latest.results);
+      if (active != null) {
+        state = SpeedtestRunState(
+          phase: SpeedtestRunPhase.running,
+          result: active,
+          message:
+              'A speed test is already ${active.status.label.toLowerCase()}.',
+        );
+        await _poll(api, active.id);
+        return;
+      }
+
+      state = const SpeedtestRunState(phase: SpeedtestRunPhase.submitting);
+      final DateTime submittedAt =
+          ref.read(speedtestRunClockProvider)().toUtc();
+      SpeedtestResult queued;
+      try {
+        queued = await api.runSpeedtest();
+      } on SpeedtestTrackerException catch (error) {
+        if (_isAmbiguousSubmission(error)) {
+          await _reconcileSubmission(
+            api,
+            submittedAt: submittedAt,
+            baselineIds: baselineIds,
+          );
+          return;
+        }
+        rethrow;
+      }
+      if (_disposed) {
+        return;
+      }
+      if (_applyResult(queued)) {
+        await _poll(api, queued.id);
+      }
+    } on SpeedtestTrackerException catch (error) {
+      if (!_disposed) {
+        _setError(error);
+      }
+    } on Object {
+      if (!_disposed) {
+        state = const SpeedtestRunState(
+          phase: SpeedtestRunPhase.failed,
+          message: 'The speed test could not be started.',
+        );
+      }
+    }
+  }
+
+  Future<void> _reconcileSubmission(
+    SpeedtestTrackerApi api, {
+    required DateTime submittedAt,
+    required Set<int> baselineIds,
+  }) async {
+    state = const SpeedtestRunState(
+      phase: SpeedtestRunPhase.reconciling,
+      message: 'The run response was interrupted. Checking whether the speed '
+          'test was accepted...',
+    );
+    final Duration interval = ref.read(speedtestRunPollIntervalProvider);
+    final int maxPolls = ref.read(speedtestRunReconcileMaxPollsProvider);
+    for (int attempt = 0; attempt < maxPolls; attempt++) {
+      if (_disposed) {
+        return;
+      }
+      try {
+        final SpeedtestResultsPage latest = await api.listResults(pageSize: 10);
+        final SpeedtestResult? adopted = _newResultAfter(
+          latest.results,
+          submittedAt: submittedAt,
+          baselineIds: baselineIds,
+        );
+        if (adopted != null) {
+          if (_applyResult(adopted)) {
+            await _poll(api, adopted.id);
+          }
+          return;
+        }
+      } on SpeedtestTrackerException catch (error) {
+        if (!_isTransient(error)) {
+          _setError(error);
+          return;
+        }
+      }
+      if (attempt + 1 < maxPolls) {
+        if (!await _waitOrDispose(interval)) {
+          return;
+        }
+      }
+    }
+    if (_disposed) {
+      return;
+    }
+    state = const SpeedtestRunState(
+      phase: SpeedtestRunPhase.indeterminate,
+      message: 'Atrium could not confirm whether the speed test was accepted. '
+          'Running again may create a duplicate and requires confirmation.',
+    );
+    _refreshResults();
+  }
+
+  Future<void> _poll(SpeedtestTrackerApi api, int resultId) async {
+    final Duration interval = ref.read(speedtestRunPollIntervalProvider);
+    final int maxPolls = ref.read(speedtestRunMaxPollsProvider);
+    for (int attempt = 0; attempt < maxPolls; attempt++) {
+      if (_disposed) {
+        return;
+      }
+      if (!await _waitOrDispose(interval)) {
+        return;
+      }
+      try {
+        final SpeedtestResult result = await api.getResult(resultId);
+        if (!_applyResult(result)) {
+          return;
+        }
+      } on SpeedtestTrackerException catch (error) {
+        if (_isTransient(error)) {
+          continue;
+        }
+        _setError(error);
+        return;
+      }
+    }
+    state = SpeedtestRunState(
+      phase: SpeedtestRunPhase.timedOut,
+      result: state.result,
+      message: 'The test may still be running. Refresh results to check it.',
+    );
+    _refreshResults();
+  }
+
+  void _setError(SpeedtestTrackerException error) {
+    if (_disposed) {
+      return;
+    }
+    final SpeedtestRunPhase phase = switch (error.kind) {
+      SpeedtestErrorKind.permission => SpeedtestRunPhase.permissionDenied,
+      SpeedtestErrorKind.unsupported => SpeedtestRunPhase.unsupported,
+      _ => SpeedtestRunPhase.failed,
+    };
+    state = SpeedtestRunState(
+      phase: phase,
+      result: state.result,
+      message: error.message,
+    );
+    if (phase == SpeedtestRunPhase.permissionDenied ||
+        phase == SpeedtestRunPhase.unsupported) {
+      ref.read(_speedtestRunSessionRestrictions.notifier).restrict(
+            instance,
+            phase,
+            error.message,
+          );
+    }
+  }
+
+  bool _applyResult(SpeedtestResult result) {
+    if (_disposed) {
+      return false;
+    }
+    if (result.status == SpeedtestResultStatus.completed) {
+      state = SpeedtestRunState(
+        phase: SpeedtestRunPhase.completed,
+        result: result,
+        message: 'Speed test completed.',
+      );
+      _refreshResults();
+      return false;
+    }
+    if (result.status.isFailure ||
+        result.status == SpeedtestResultStatus.unknown) {
+      state = SpeedtestRunState(
+        phase: SpeedtestRunPhase.failed,
+        result: result,
+        message: result.message ??
+            (result.status == SpeedtestResultStatus.unknown
+                ? 'Speedtest Tracker returned an unsupported test status.'
+                : 'The speed test ${result.status.label.toLowerCase()}.'),
+      );
+      _refreshResults();
+      return false;
+    }
+    state = SpeedtestRunState(
+      phase: result.status == SpeedtestResultStatus.waiting
+          ? SpeedtestRunPhase.queued
+          : SpeedtestRunPhase.running,
+      result: result,
+    );
+    return true;
+  }
+
+  void _refreshResults() {
+    if (_disposed) {
+      return;
+    }
+    ref.invalidate(speedtestOverviewProvider(instance));
+    ref.invalidate(speedtestHistoryProvider);
+  }
+
+  Future<bool> _waitOrDispose(Duration duration) async {
+    await Future.any(<Future<void>>[
+      Future<void>.delayed(duration),
+      _disposeSignal.future,
+    ]);
+    return !_disposed;
+  }
+}
+
+SpeedtestResult? _firstInProgress(List<SpeedtestResult> results) {
+  for (final SpeedtestResult result in results) {
+    if (result.status.isInProgress) {
+      return result;
+    }
+  }
+  return null;
+}
+
+SpeedtestResult? _newResultAfter(
+  List<SpeedtestResult> results, {
+  required DateTime submittedAt,
+  required Set<int> baselineIds,
+}) {
+  for (final SpeedtestResult result in results) {
+    final DateTime? createdAt = result.createdAt;
+    if (!baselineIds.contains(result.id) &&
+        createdAt != null &&
+        !createdAt.toUtc().isBefore(submittedAt)) {
+      return result;
+    }
+  }
+  return null;
+}
+
+bool _isTransient(SpeedtestTrackerException error) =>
+    error.kind == SpeedtestErrorKind.offline ||
+    error.kind == SpeedtestErrorKind.timeout ||
+    error.kind == SpeedtestErrorKind.server;
+
+bool _isAmbiguousSubmission(SpeedtestTrackerException error) =>
+    _isTransient(error) ||
+    (error.kind == SpeedtestErrorKind.other && error.statusCode == null);

--- a/services/service_speedtest_tracker/lib/src/widgets/speedtest_history_chart.dart
+++ b/services/service_speedtest_tracker/lib/src/widgets/speedtest_history_chart.dart
@@ -1,0 +1,359 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/speedtest_tracker_models.dart';
+
+class SpeedtestHistoryChart extends StatelessWidget {
+  const SpeedtestHistoryChart({required this.results, super.key});
+
+  final List<SpeedtestResult> results;
+
+  @override
+  Widget build(BuildContext context) {
+    final List<SpeedtestResult> points = <SpeedtestResult>[
+      for (final SpeedtestResult result in results.reversed)
+        if (_isUsableSpeed(result.downloadBitsPerSecond) ||
+            _isUsableSpeed(result.uploadBitsPerSecond))
+          result,
+    ];
+    if (points.length < 2) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Center(child: Text('Run at least two tests to draw a history.')),
+      );
+    }
+
+    final DateFormat dateFormat = DateFormat.MMMd();
+    final String startDate = _dateLabel(points.first.completedAt, dateFormat);
+    final String endDate = _dateLabel(points.last.completedAt, dateFormat);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        _SeriesChart(
+          metric: _HistoryMetric.download,
+          results: points,
+          color: Theme.of(context).colorScheme.primary,
+          gridColor: Theme.of(context).colorScheme.outlineVariant,
+          startDate: startDate,
+          endDate: endDate,
+        ),
+        const SizedBox(height: 20),
+        _SeriesChart(
+          metric: _HistoryMetric.upload,
+          results: points,
+          color: Theme.of(context).colorScheme.tertiary,
+          gridColor: Theme.of(context).colorScheme.outlineVariant,
+          startDate: startDate,
+          endDate: endDate,
+        ),
+      ],
+    );
+  }
+
+  String _dateLabel(DateTime? date, DateFormat format) =>
+      date == null ? 'Unknown' : format.format(date);
+}
+
+enum _HistoryMetric { download, upload }
+
+extension on _HistoryMetric {
+  String get title => switch (this) {
+        _HistoryMetric.download => 'Download history',
+        _HistoryMetric.upload => 'Upload history',
+      };
+
+  double? valueOf(SpeedtestResult result) => switch (this) {
+        _HistoryMetric.download => result.downloadBitsPerSecond,
+        _HistoryMetric.upload => result.uploadBitsPerSecond,
+      };
+}
+
+class _SeriesChart extends StatelessWidget {
+  const _SeriesChart({
+    required this.metric,
+    required this.results,
+    required this.color,
+    required this.gridColor,
+    required this.startDate,
+    required this.endDate,
+  });
+
+  static const double _axisWidth = 48;
+  static const double _axisGap = 8;
+
+  final _HistoryMetric metric;
+  final List<SpeedtestResult> results;
+  final Color color;
+  final Color gridColor;
+  final String startDate;
+  final String endDate;
+
+  @override
+  Widget build(BuildContext context) {
+    final _SeriesScale scale = _SeriesScale.fromResults(results, metric);
+    final TextStyle? axisStyle = Theme.of(context).textTheme.labelSmall;
+    return Semantics(
+      container: true,
+      excludeSemantics: true,
+      label: scale.hasValues
+          ? '${metric.title} chart from $startDate to $endDate, scale zero, '
+              'midpoint ${scale.midpointLabel}, maximum '
+              '${scale.maximumLabel} ${scale.unit}'
+          : 'No usable ${metric.title.toLowerCase()} data',
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Wrap(
+            spacing: 8,
+            runSpacing: 2,
+            crossAxisAlignment: WrapCrossAlignment.center,
+            children: <Widget>[
+              Text(
+                metric.title,
+                style: Theme.of(context).textTheme.titleSmall,
+              ),
+              Text(scale.unit, style: axisStyle),
+            ],
+          ),
+          const SizedBox(height: 8),
+          if (scale.hasValues) ...<Widget>[
+            SizedBox(
+              height: 112,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: <Widget>[
+                  SizedBox(
+                    width: _axisWidth,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      crossAxisAlignment: CrossAxisAlignment.end,
+                      children: <Widget>[
+                        _AxisLabel(scale.maximumLabel, style: axisStyle),
+                        _AxisLabel(scale.midpointLabel, style: axisStyle),
+                        _AxisLabel('0', style: axisStyle),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: _axisGap),
+                  Expanded(
+                    child: CustomPaint(
+                      painter: _SeriesPainter(
+                        results: results,
+                        metric: metric,
+                        maximumBitsPerSecond: scale.maximumBitsPerSecond,
+                        color: color,
+                        gridColor: gridColor,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 6),
+            Padding(
+              padding: const EdgeInsets.only(left: _axisWidth + _axisGap),
+              child: Row(
+                children: <Widget>[
+                  Expanded(
+                    child: Text(
+                      startDate,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: axisStyle,
+                    ),
+                  ),
+                  Expanded(
+                    child: Text(
+                      endDate,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.end,
+                      style: axisStyle,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ] else
+            Padding(
+              padding: const EdgeInsets.symmetric(vertical: 28),
+              child:
+                  Center(child: Text('No ${metric.title.toLowerCase()} data')),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _AxisLabel extends StatelessWidget {
+  const _AxisLabel(this.value, {required this.style});
+
+  final String value;
+  final TextStyle? style;
+
+  @override
+  Widget build(BuildContext context) => SizedBox(
+        width: double.infinity,
+        child: FittedBox(
+          fit: BoxFit.scaleDown,
+          alignment: Alignment.centerRight,
+          child: Text(value, maxLines: 1, style: style),
+        ),
+      );
+}
+
+class _SeriesPainter extends CustomPainter {
+  const _SeriesPainter({
+    required this.results,
+    required this.metric,
+    required this.maximumBitsPerSecond,
+    required this.color,
+    required this.gridColor,
+  });
+
+  final List<SpeedtestResult> results;
+  final _HistoryMetric metric;
+  final double maximumBitsPerSecond;
+  final Color color;
+  final Color gridColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (maximumBitsPerSecond <= 0 || size.width <= 0 || size.height <= 0) {
+      return;
+    }
+
+    final Paint grid = Paint()
+      ..color = gridColor
+      ..strokeWidth = 1;
+    for (int i = 0; i <= 2; i++) {
+      final double y = (size.height - 1) * i / 2 + 0.5;
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), grid);
+    }
+    final Paint line = Paint()
+      ..color = color
+      ..strokeWidth = 2.5
+      ..style = PaintingStyle.stroke
+      ..strokeCap = StrokeCap.round
+      ..strokeJoin = StrokeJoin.round;
+    final Paint dot = Paint()..color = color;
+    final Path path = Path();
+    bool started = false;
+    for (int i = 0; i < results.length; i++) {
+      final double? raw = metric.valueOf(results[i]);
+      if (!_isUsableSpeed(raw)) {
+        started = false;
+        continue;
+      }
+      final double x = size.width * i / (results.length - 1);
+      final double normalized = (raw! / maximumBitsPerSecond).clamp(0, 1);
+      final double y = size.height - (normalized * (size.height - 4)) - 2;
+      if (started) {
+        path.lineTo(x, y);
+      } else {
+        path.moveTo(x, y);
+        started = true;
+      }
+      canvas.drawCircle(Offset(x, y), 2.5, dot);
+    }
+    canvas.drawPath(path, line);
+  }
+
+  @override
+  bool shouldRepaint(_SeriesPainter oldDelegate) =>
+      oldDelegate.results != results ||
+      oldDelegate.metric != metric ||
+      oldDelegate.maximumBitsPerSecond != maximumBitsPerSecond ||
+      oldDelegate.color != color ||
+      oldDelegate.gridColor != gridColor;
+}
+
+class _SeriesScale {
+  const _SeriesScale({
+    required this.hasValues,
+    required this.unit,
+    required this.maximumDisplayValue,
+    required this.maximumBitsPerSecond,
+  });
+
+  factory _SeriesScale.fromResults(
+    List<SpeedtestResult> results,
+    _HistoryMetric metric,
+  ) {
+    bool hasValues = false;
+    double maximum = 0;
+    for (final SpeedtestResult result in results) {
+      final double? value = metric.valueOf(result);
+      if (_isUsableSpeed(value)) {
+        hasValues = true;
+        maximum = math.max(maximum, value!);
+      }
+    }
+    final bool useGbps = maximum >= 1000000000;
+    final double divisor = useGbps ? 1000000000 : 1000000;
+    final double roundedMaximum = _roundedUpperBound(maximum / divisor);
+    return _SeriesScale(
+      hasValues: hasValues,
+      unit: useGbps ? 'Gbps' : 'Mbps',
+      maximumDisplayValue: roundedMaximum,
+      maximumBitsPerSecond: roundedMaximum * divisor,
+    );
+  }
+
+  final bool hasValues;
+  final String unit;
+  final double maximumDisplayValue;
+  final double maximumBitsPerSecond;
+
+  String get maximumLabel => _formatAxisValue(maximumDisplayValue);
+  String get midpointLabel => _formatAxisValue(maximumDisplayValue / 2);
+}
+
+bool _isUsableSpeed(double? value) =>
+    value != null && value.isFinite && value >= 0;
+
+double _roundedUpperBound(double value) {
+  if (!value.isFinite || value <= 0) {
+    return 1;
+  }
+  final double magnitude = math
+      .pow(
+        10,
+        (math.log(value) / math.ln10).floor(),
+      )
+      .toDouble();
+  final double fraction = value / magnitude;
+  const List<double> preferredFractions = <double>[
+    1,
+    1.25,
+    1.5,
+    2,
+    2.5,
+    3,
+    4,
+    5,
+  ];
+  for (final double preferred in preferredFractions) {
+    if (fraction <= preferred) {
+      return preferred * magnitude;
+    }
+  }
+  return fraction.ceilToDouble() * magnitude;
+}
+
+String _formatAxisValue(double value) {
+  final int decimals = value >= 100
+      ? 0
+      : value >= 10
+          ? 1
+          : 2;
+  final String fixed = value.toStringAsFixed(decimals);
+  if (!fixed.contains('.')) {
+    return fixed;
+  }
+  return fixed.replaceFirst(RegExp(r'\.?0+$'), '');
+}

--- a/services/service_speedtest_tracker/lib/src/widgets/speedtest_result_views.dart
+++ b/services/service_speedtest_tracker/lib/src/widgets/speedtest_result_views.dart
@@ -1,0 +1,335 @@
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../models/speedtest_tracker_models.dart';
+
+class SpeedtestLatestCard extends StatelessWidget {
+  const SpeedtestLatestCard({required this.result, super.key});
+
+  final SpeedtestResult result;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final String serverAndProvider = <String>[
+      if (result.server?.displayName != null) result.server!.displayName!,
+      if (result.server?.displayLocation != null)
+        result.server!.displayLocation!,
+      if (result.isp != null) result.isp!,
+    ].join(' · ');
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surfaceContainerLow,
+      child: Padding(
+        padding: const EdgeInsets.all(Insets.lg),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child:
+                      Text('Latest result', style: theme.textTheme.titleMedium),
+                ),
+                if (result.healthy != null)
+                  Chip(
+                    avatar: Icon(
+                      result.healthy! ? Icons.check_circle : Icons.warning,
+                      size: 17,
+                    ),
+                    label: Text(result.healthy! ? 'Healthy' : 'Unhealthy'),
+                    visualDensity: VisualDensity.compact,
+                  ),
+              ],
+            ),
+            const SizedBox(height: Insets.md),
+            Row(
+              children: <Widget>[
+                Expanded(
+                  child: _Metric(
+                    icon: Icons.download,
+                    label: 'Download',
+                    value: formatSpeed(result.downloadBitsPerSecond),
+                    color: theme.colorScheme.primary,
+                  ),
+                ),
+                const SizedBox(width: Insets.sm),
+                Expanded(
+                  child: _Metric(
+                    icon: Icons.upload,
+                    label: 'Upload',
+                    value: formatSpeed(result.uploadBitsPerSecond),
+                    color: theme.colorScheme.tertiary,
+                  ),
+                ),
+                const SizedBox(width: Insets.sm),
+                Expanded(
+                  child: _Metric(
+                    icon: Icons.network_ping,
+                    label: 'Ping',
+                    value: formatMilliseconds(result.pingMilliseconds),
+                    color: theme.colorScheme.secondary,
+                  ),
+                ),
+              ],
+            ),
+            if (result.jitterMilliseconds != null ||
+                result.packetLossPercent != null) ...<Widget>[
+              const SizedBox(height: Insets.md),
+              Wrap(
+                spacing: Insets.sm,
+                runSpacing: Insets.sm,
+                children: <Widget>[
+                  if (result.jitterMilliseconds != null)
+                    _InfoChip(
+                      icon: Icons.timeline,
+                      text:
+                          'Jitter ${formatMilliseconds(result.jitterMilliseconds)}',
+                    ),
+                  if (result.packetLossPercent != null)
+                    _InfoChip(
+                      icon: Icons.signal_wifi_bad,
+                      text:
+                          'Loss ${formatPacketLoss(result.packetLossPercent)}',
+                    ),
+                ],
+              ),
+            ],
+            if (serverAndProvider.isNotEmpty) ...<Widget>[
+              const SizedBox(height: Insets.md),
+              Text(serverAndProvider, style: theme.textTheme.bodyMedium),
+            ],
+            const SizedBox(height: 4),
+            Text(
+              formatResultTime(result.completedAt),
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class SpeedtestResultTile extends StatelessWidget {
+  const SpeedtestResultTile({
+    required this.result,
+    required this.onTap,
+    super.key,
+  });
+
+  final SpeedtestResult result;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) => Card(
+        margin: const EdgeInsets.only(bottom: Insets.sm),
+        elevation: 0,
+        child: ListTile(
+          onTap: onTap,
+          leading: const Icon(Icons.speed_outlined),
+          title: Text(
+            '${formatSpeed(result.downloadBitsPerSecond)} ↓  '
+            '${formatSpeed(result.uploadBitsPerSecond)} ↑',
+          ),
+          subtitle: Text(
+            <String>[
+              formatMilliseconds(result.pingMilliseconds),
+              if (result.serverOrProvider != null) result.serverOrProvider!,
+              formatResultTime(result.completedAt),
+            ].join(' · '),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          trailing: const Icon(Icons.chevron_right),
+        ),
+      );
+}
+
+class SpeedtestRunBanner extends StatelessWidget {
+  const SpeedtestRunBanner({
+    required this.icon,
+    required this.message,
+    required this.color,
+    this.busy = false,
+    super.key,
+  });
+
+  final IconData icon;
+  final String message;
+  final Color color;
+  final bool busy;
+
+  @override
+  Widget build(BuildContext context) => Container(
+        padding: const EdgeInsets.all(Insets.md),
+        decoration: BoxDecoration(
+          color: color.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Row(
+          children: <Widget>[
+            if (busy)
+              SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  color: color,
+                ),
+              )
+            else
+              Icon(icon, size: 20, color: color),
+            const SizedBox(width: Insets.sm),
+            Expanded(child: Text(message)),
+          ],
+        ),
+      );
+}
+
+void showSpeedtestResultDetails(
+  BuildContext context,
+  SpeedtestResult result,
+) {
+  showModalBottomSheet<void>(
+    context: context,
+    useRootNavigator: true,
+    showDragHandle: true,
+    isScrollControlled: true,
+    builder: (BuildContext context) => SafeArea(
+      child: SingleChildScrollView(
+        padding: const EdgeInsets.fromLTRB(
+          Insets.lg,
+          0,
+          Insets.lg,
+          Insets.xl,
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              'Speedtest result',
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: Insets.md),
+            _DetailRow(label: 'Status', value: result.status.label),
+            _DetailRow(
+              label: 'Download',
+              value: formatSpeed(result.downloadBitsPerSecond),
+            ),
+            _DetailRow(
+              label: 'Upload',
+              value: formatSpeed(result.uploadBitsPerSecond),
+            ),
+            _DetailRow(
+              label: 'Ping',
+              value: formatMilliseconds(result.pingMilliseconds),
+            ),
+            if (result.jitterMilliseconds != null)
+              _DetailRow(
+                label: 'Jitter',
+                value: formatMilliseconds(result.jitterMilliseconds),
+              ),
+            if (result.packetLossPercent != null)
+              _DetailRow(
+                label: 'Packet loss',
+                value: formatPacketLoss(result.packetLossPercent),
+              ),
+            if (result.server?.displayName != null)
+              _DetailRow(label: 'Server', value: result.server!.displayName!),
+            if (result.server?.displayLocation != null)
+              _DetailRow(
+                label: 'Location',
+                value: result.server!.displayLocation!,
+              ),
+            if (result.isp != null)
+              _DetailRow(label: 'Provider', value: result.isp!),
+            _DetailRow(
+              label: 'Completed',
+              value: formatResultTime(result.completedAt),
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}
+
+String formatResultTime(DateTime? value) => value == null
+    ? 'Unknown time'
+    : DateFormat.yMMMd().add_jm().format(
+          value.isUtc ? value.toLocal() : value,
+        );
+
+class _Metric extends StatelessWidget {
+  const _Metric({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) => Column(
+        children: <Widget>[
+          Icon(icon, color: color),
+          const SizedBox(height: 6),
+          Text(
+            value,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          Text(label, style: Theme.of(context).textTheme.labelSmall),
+        ],
+      );
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) => Chip(
+        avatar: Icon(icon, size: 16),
+        label: Text(text),
+        visualDensity: VisualDensity.compact,
+      );
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.label, required this.value});
+
+  final String label;
+  final String value;
+
+  @override
+  Widget build(BuildContext context) => Padding(
+        padding: const EdgeInsets.symmetric(vertical: Insets.sm),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            SizedBox(
+              width: 105,
+              child: Text(
+                label,
+                style: Theme.of(context).textTheme.labelLarge,
+              ),
+            ),
+            Expanded(child: Text(value)),
+          ],
+        ),
+      );
+}

--- a/services/service_speedtest_tracker/pubspec.yaml
+++ b/services/service_speedtest_tracker/pubspec.yaml
@@ -1,0 +1,23 @@
+name: service_speedtest_tracker
+description: Speedtest Tracker API client and UI screens for Atrium.
+publish_to: none
+resolution: workspace
+
+environment:
+  sdk: ^3.6.0
+  flutter: ^3.27.0
+
+dependencies:
+  core_models:
+  core_networking:
+  core_ui:
+  dio: ^5.7.0
+  flutter:
+    sdk: flutter
+  flutter_riverpod: ^3.3.2
+  intl: ^0.20.1
+
+dev_dependencies:
+  flutter_lints: ^6.0.0
+  flutter_test:
+    sdk: flutter

--- a/services/service_speedtest_tracker/test/fixtures/speedtest_responses.dart
+++ b/services/service_speedtest_tracker/test/fixtures/speedtest_responses.dart
@@ -1,0 +1,69 @@
+const Map<String, dynamic> currentResult = <String, dynamic>{
+  'id': 42,
+  'service': 'ookla',
+  'ping': '12.4',
+  'download': 100000000,
+  'upload': 25000000,
+  'download_bits': 800000000,
+  'healthy': true,
+  'status': 'completed',
+  'data': <String, dynamic>{
+    'isp': 'Example Fiber',
+    'timestamp': '2026-07-20T18:15:00Z',
+    'packetLoss': 0.5,
+    'ping': <String, dynamic>{
+      'latency': 12.4,
+      'jitter': 1.8,
+      'low': 10.1,
+      'high': 20.2,
+    },
+    'server': <String, dynamic>{
+      'id': 1234,
+      'name': 'Example Speedtest',
+      'host': 'speed.example.test',
+      'location': 'Seattle, WA',
+      'country': 'United States',
+    },
+    'result': <String, dynamic>{
+      'url': 'https://www.speedtest.net/result/c/example-result',
+    },
+  },
+  'created_at': '2026-07-20 18:14:40',
+  'updated_at': '2026-07-20 18:15:10',
+};
+
+const Map<String, dynamic> legacyResult = <String, dynamic>{
+  'id': '7',
+  'ping': 25,
+  'download': '12500000',
+  'upload': '6250000',
+  'status': 'completed',
+  'created_at': '2024-01-02 03:04:05',
+};
+
+const Map<String, dynamic> runningResult = <String, dynamic>{
+  'id': 43,
+  'status': 'running',
+  'created_at': '2026-07-20 18:20:00',
+};
+
+Map<String, dynamic> resultEnvelope(Map<String, dynamic> result) =>
+    <String, dynamic>{'data': result, 'message': 'ok'};
+
+Map<String, dynamic> resultPage(
+  List<Map<String, dynamic>> results, {
+  int currentPage = 1,
+  int lastPage = 1,
+}) =>
+    <String, dynamic>{
+      'data': results,
+      'links': <String, dynamic>{
+        'next': currentPage < lastPage
+            ? 'https://tracker.example.test/api/v1/results?page=2'
+            : null,
+      },
+      'meta': <String, dynamic>{
+        'current_page': currentPage,
+        'last_page': lastPage,
+      },
+    };

--- a/services/service_speedtest_tracker/test/speedtest_tracker_api_test.dart
+++ b/services/service_speedtest_tracker/test/speedtest_tracker_api_test.dart
@@ -1,0 +1,293 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+
+import 'fixtures/speedtest_responses.dart';
+import 'support/fake_http_client_adapter.dart';
+
+const String placeholderToken = 'placeholder-speedtest-token';
+
+void main() {
+  test('lists completed results with compatible pagination and bearer auth',
+      () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (
+        status: 200,
+        data: resultPage(<Map<String, dynamic>>[currentResult]),
+      ),
+    );
+    final Dio dio = _dio(adapter);
+    final SpeedtestResultsPage page =
+        await SpeedtestTrackerApi(dio).listResults(
+      page: 2,
+      status: SpeedtestResultStatus.completed,
+    );
+
+    expect(page.results, hasLength(1));
+    final RequestOptions request = adapter.requests.single;
+    expect(request.path, 'api/v1/results');
+    expect(request.queryParameters['filter[status]'], 'completed');
+    expect(request.queryParameters['sort'], '-created_at');
+    expect(request.queryParameters['page'], 2);
+    expect(request.queryParameters['page[number]'], 2);
+    expect(request.queryParameters['page[size]'], 25);
+    expect(request.queryParameters['per_page'], 25);
+    expect(request.headers['Authorization'], 'Bearer $placeholderToken');
+    expect(request.headers['Accept'], 'application/json');
+    expect(request.uri.toString(), isNot(contains(placeholderToken)));
+    expect(request.followRedirects, isFalse);
+  });
+
+  test('does not follow redirects or authenticate a redirected host', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (status: 302, data: null),
+      headersFactory: (RequestOptions _) => <String, List<String>>{
+        'location': <String>[
+          'https://redirected.example.test/api/v1/results',
+        ],
+      },
+    );
+
+    await expectLater(
+      SpeedtestTrackerApi(_dio(adapter)).listResults(),
+      throwsA(
+        isA<SpeedtestTrackerException>()
+            .having(
+              (SpeedtestTrackerException error) => error.statusCode,
+              'status',
+              302,
+            )
+            .having(
+              (SpeedtestTrackerException error) => error.toString(),
+              'safe message',
+              isNot(contains(placeholderToken)),
+            ),
+      ),
+    );
+
+    expect(adapter.requests, hasLength(1));
+    expect(adapter.requests.single.uri.host, 'tracker.example.test');
+    expect(adapter.requests.single.followRedirects, isFalse);
+  });
+
+  test('parses a queued run response without reporting completion', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (
+        status: 201,
+        data: resultEnvelope(runningResult),
+      ),
+    );
+    final SpeedtestResult result =
+        await SpeedtestTrackerApi(_dio(adapter)).runSpeedtest();
+
+    expect(adapter.requests.single.method, 'POST');
+    expect(result.status, SpeedtestResultStatus.running);
+    expect(result.status, isNot(SpeedtestResultStatus.completed));
+  });
+
+  test('connection health succeeds without probing run permission', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (
+        status: 200,
+        data: <String, dynamic>{'message': 'OK'},
+      ),
+    );
+
+    await SpeedtestTrackerApi(_dio(adapter)).checkHealth();
+
+    expect(adapter.requests.single.path, 'api/healthcheck');
+    expect(adapter.requests.single.method, 'GET');
+  });
+
+  test('connection failures are reported as offline', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.connectionError,
+        message: 'placeholder low-level error',
+      ),
+    );
+
+    await expectLater(
+      SpeedtestTrackerApi(_dio(adapter)).checkHealth(),
+      throwsA(
+        isA<SpeedtestTrackerException>().having(
+          (SpeedtestTrackerException error) => error.kind,
+          'kind',
+          SpeedtestErrorKind.offline,
+        ),
+      ),
+    );
+  });
+
+  test('read authentication failures identify the configured token problem',
+      () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (status: 401, data: null),
+    );
+
+    await expectLater(
+      SpeedtestTrackerApi(_dio(adapter)).listResults(),
+      throwsA(
+        isA<SpeedtestTrackerException>().having(
+          (SpeedtestTrackerException error) => error.kind,
+          'kind',
+          SpeedtestErrorKind.authentication,
+        ),
+      ),
+    );
+  });
+
+  test('maps run permission errors and never leaks the token', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (
+        status: 403,
+        data: <String, dynamic>{
+          'message': 'Denied $placeholderToken',
+        },
+      ),
+    );
+
+    await expectLater(
+      SpeedtestTrackerApi(_dio(adapter)).runSpeedtest(),
+      throwsA(
+        isA<SpeedtestTrackerException>()
+            .having(
+              (SpeedtestTrackerException error) => error.kind,
+              'kind',
+              SpeedtestErrorKind.permission,
+            )
+            .having(
+              (SpeedtestTrackerException error) => error.toString(),
+              'safe message',
+              isNot(contains(placeholderToken)),
+            ),
+      ),
+    );
+  });
+
+  test('maps unsupported read and run endpoints separately', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (status: 404, data: null),
+    );
+    final SpeedtestTrackerApi api = SpeedtestTrackerApi(_dio(adapter));
+
+    await expectLater(
+      api.listResults(),
+      throwsA(
+        isA<SpeedtestTrackerException>().having(
+          (SpeedtestTrackerException error) => error.message,
+          'read message',
+          contains('1.1'),
+        ),
+      ),
+    );
+    await expectLater(
+      api.runSpeedtest(),
+      throwsA(
+        isA<SpeedtestTrackerException>().having(
+          (SpeedtestTrackerException error) => error.message,
+          'run message',
+          contains('1.6'),
+        ),
+      ),
+    );
+  });
+
+  test('maps a missing polled result without disabling the installation',
+      () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (status: 404, data: null),
+    );
+
+    await expectLater(
+      SpeedtestTrackerApi(_dio(adapter)).getResult(123),
+      throwsA(
+        isA<SpeedtestTrackerException>()
+            .having(
+              (SpeedtestTrackerException error) => error.kind,
+              'kind',
+              SpeedtestErrorKind.notFound,
+            )
+            .having(
+              (SpeedtestTrackerException error) => error.message,
+              'message',
+              isNot(contains('1.1')),
+            ),
+      ),
+    );
+  });
+
+  test('maps run 401, 406, and 422 to safe useful messages', () async {
+    for (final (int, SpeedtestErrorKind, String) expectation
+        in <(int, SpeedtestErrorKind, String)>[
+      (401, SpeedtestErrorKind.authentication, 'bearer token'),
+      (406, SpeedtestErrorKind.other, 'JSON'),
+      (422, SpeedtestErrorKind.other, 'parameters'),
+    ]) {
+      final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+        (RequestOptions options) => (
+          status: expectation.$1,
+          data: <String, dynamic>{
+            'message': 'Upstream echoed $placeholderToken',
+          },
+        ),
+      );
+
+      await expectLater(
+        SpeedtestTrackerApi(_dio(adapter)).runSpeedtest(),
+        throwsA(
+          isA<SpeedtestTrackerException>()
+              .having(
+                (SpeedtestTrackerException error) => error.kind,
+                'kind',
+                expectation.$2,
+              )
+              .having(
+                (SpeedtestTrackerException error) => error.message,
+                'useful message',
+                contains(expectation.$3),
+              )
+              .having(
+                (SpeedtestTrackerException error) => error.toString(),
+                'safe message',
+                isNot(contains(placeholderToken)),
+              ),
+        ),
+      );
+    }
+  });
+
+  test('maps malformed successful responses', () async {
+    final FakeHttpClientAdapter adapter = FakeHttpClientAdapter(
+      (RequestOptions options) => (
+        status: 200,
+        data: <String, dynamic>{'unexpected': true},
+      ),
+    );
+    await expectLater(
+      SpeedtestTrackerApi(_dio(adapter)).listResults(),
+      throwsA(
+        isA<SpeedtestTrackerException>().having(
+          (SpeedtestTrackerException error) => error.kind,
+          'kind',
+          SpeedtestErrorKind.malformed,
+        ),
+      ),
+    );
+  });
+}
+
+Dio _dio(FakeHttpClientAdapter adapter) {
+  final Dio dio = Dio(BaseOptions(baseUrl: 'https://tracker.example.test/'));
+  dio.httpClientAdapter = adapter;
+  dio.interceptors.add(
+    const AuthInterceptor(
+      kind: ServiceKind.speedtestTracker,
+      auth: InstanceAuth.apiKey(apiKey: placeholderToken),
+    ),
+  );
+  return dio;
+}

--- a/services/service_speedtest_tracker/test/speedtest_tracker_models_test.dart
+++ b/services/service_speedtest_tracker/test/speedtest_tracker_models_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+
+import 'fixtures/speedtest_responses.dart';
+
+void main() {
+  group('SpeedtestResult', () {
+    test('parses current payload and optional nested measurements', () {
+      final SpeedtestResult result = SpeedtestResult.fromJson(currentResult);
+
+      expect(result.id, 42);
+      expect(result.status, SpeedtestResultStatus.completed);
+      expect(result.downloadBitsPerSecond, 800000000);
+      expect(result.uploadBitsPerSecond, 200000000);
+      expect(result.pingMilliseconds, 12.4);
+      expect(result.jitterMilliseconds, 1.8);
+      expect(result.packetLossPercent, 0.5);
+      expect(result.healthy, isTrue);
+      expect(result.server?.displayName, 'Example Speedtest');
+      expect(result.server?.displayLocation, 'Seattle, WA, United States');
+      expect(result.isp, 'Example Fiber');
+      expect(result.completedAt, DateTime.parse('2026-07-20T18:15:00Z'));
+    });
+
+    test('supports legacy byte-per-second values and missing optionals', () {
+      final SpeedtestResult result = SpeedtestResult.fromJson(legacyResult);
+
+      expect(result.downloadBitsPerSecond, 100000000);
+      expect(result.uploadBitsPerSecond, 50000000);
+      expect(result.jitterMilliseconds, isNull);
+      expect(result.packetLossPercent, isNull);
+      expect(result.server, isNull);
+      expect(result.isp, isNull);
+      expect(result.completedAt, DateTime(2024, 1, 2, 3, 4, 5));
+    });
+
+    test('rejects a result without required identity', () {
+      expect(
+        () =>
+            SpeedtestResult.fromJson(<String, dynamic>{'status': 'completed'}),
+        throwsA(isA<SpeedtestProtocolException>()),
+      );
+    });
+
+    test('unknown statuses remain explicit and terminal', () {
+      final SpeedtestResult result = SpeedtestResult.fromJson(
+        <String, dynamic>{'id': 1, 'status': 'future-status'},
+      );
+      expect(result.status, SpeedtestResultStatus.unknown);
+      expect(result.status.isInProgress, isFalse);
+    });
+
+    test('omits negative and non-finite off-contract measurements', () {
+      final SpeedtestResult result = SpeedtestResult.fromJson(
+        <String, dynamic>{
+          'id': 2,
+          'status': 'completed',
+          'download_bits': double.nan,
+          'upload_bits': double.infinity,
+          'ping': -1,
+          'data': <String, dynamic>{'packetLoss': -5},
+        },
+      );
+
+      expect(result.downloadBitsPerSecond, isNull);
+      expect(result.uploadBitsPerSecond, isNull);
+      expect(result.pingMilliseconds, isNull);
+      expect(result.packetLossPercent, isNull);
+    });
+  });
+
+  group('SpeedtestResultsPage', () {
+    test('parses pagination without trusting the absolute next URL', () {
+      final SpeedtestResultsPage page = SpeedtestResultsPage.fromJson(
+        resultPage(<Map<String, dynamic>>[currentResult], lastPage: 2),
+        requestedPage: 1,
+        pageSize: 25,
+      );
+      expect(page.results, hasLength(1));
+      expect(page.hasMore, isTrue);
+      expect(page.page, 1);
+    });
+
+    test('accepts an empty history', () {
+      final SpeedtestResultsPage page = SpeedtestResultsPage.fromJson(
+        resultPage(const <Map<String, dynamic>>[]),
+        requestedPage: 1,
+        pageSize: 25,
+      );
+      expect(page.results, isEmpty);
+      expect(page.hasMore, isFalse);
+    });
+  });
+
+  test('formats speed, latency, and packet loss units', () {
+    expect(formatSpeed(999000000), '999 Mbps');
+    expect(formatSpeed(1250000000), '1.25 Gbps');
+    expect(formatMilliseconds(12.45), '12.4 ms');
+    expect(formatPacketLoss(0.25), '0.3%');
+  });
+}

--- a/services/service_speedtest_tracker/test/speedtest_tracker_providers_test.dart
+++ b/services/service_speedtest_tracker/test/speedtest_tracker_providers_test.dart
@@ -1,0 +1,470 @@
+import 'dart:async';
+
+import 'package:core_models/core_models.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+
+void main() {
+  const Instance instance = Instance(
+    id: 'speedtest-test',
+    name: 'Test tracker',
+    kind: ServiceKind.speedtestTracker,
+    localUrl: 'https://tracker.example.test',
+    externalUrl: '',
+    urlMode: UrlMode.forceLocal,
+    auth: InstanceAuth.apiKey(apiKey: 'placeholder-token'),
+  );
+  final DateTime submittedAt = DateTime.utc(2026, 7, 21, 12);
+
+  test('adopts an already-running result without a second submission',
+      () async {
+    final _FakeApi api = _FakeApi(
+      listPages: <SpeedtestResultsPage>[
+        _page(<SpeedtestResult>[_result(1, SpeedtestResultStatus.running)]),
+      ],
+      polled: <SpeedtestResult>[
+        _result(1, SpeedtestResultStatus.completed),
+      ],
+    );
+    final ProviderContainer container = _container(instance, api);
+    final ProviderSubscription<SpeedtestRunState> subscription =
+        _listen(container, instance);
+    addTearDown(subscription.close);
+    addTearDown(container.dispose);
+
+    await container
+        .read(speedtestRunControllerProvider(instance).notifier)
+        .run();
+
+    expect(api.runCalls, 0);
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.completed,
+    );
+  });
+
+  test('queues once, polls, and completes', () async {
+    final _FakeApi api = _FakeApi(
+      listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+      queued: _result(2, SpeedtestResultStatus.waiting),
+      polled: <SpeedtestResult>[
+        _result(2, SpeedtestResultStatus.running),
+        _result(2, SpeedtestResultStatus.completed),
+      ],
+    );
+    final ProviderContainer container = _container(instance, api);
+    final ProviderSubscription<SpeedtestRunState> subscription =
+        _listen(container, instance);
+    addTearDown(subscription.close);
+    addTearDown(container.dispose);
+
+    await container
+        .read(speedtestRunControllerProvider(instance).notifier)
+        .run();
+
+    expect(api.runCalls, 1);
+    expect(api.pollCalls, 2);
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.completed,
+    );
+  });
+
+  test('403 persists unchanged but clears after credential or URL edits',
+      () async {
+    final Instance edited = instance.copyWith(
+      auth: const InstanceAuth.apiKey(apiKey: 'edited-placeholder-token'),
+    );
+    final Instance urlEdited = instance.copyWith(
+      localUrl: 'https://edited-tracker.example.test',
+    );
+    final _FakeApi editedApi = _FakeApi(
+      listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+    );
+    final _FakeApi urlEditedApi = _FakeApi(
+      listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+    );
+    final _FakeApi deniedApi = _FakeApi(
+      listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+      runErrors: <SpeedtestTrackerException>[
+        const SpeedtestTrackerException(
+          SpeedtestErrorKind.permission,
+          'The API token lacks the speedtests:run ability.',
+        ),
+      ],
+    );
+    final ProviderContainer container = _container(
+      instance,
+      deniedApi,
+      additionalApis: <Instance, _FakeApi>{
+        edited: editedApi,
+        urlEdited: urlEditedApi,
+      },
+      clock: () => submittedAt,
+    );
+    ProviderSubscription<SpeedtestRunState> subscription =
+        _listen(container, instance);
+
+    await container
+        .read(speedtestRunControllerProvider(instance).notifier)
+        .run();
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.permissionDenied,
+    );
+
+    subscription.close();
+    await container.pump();
+    subscription = _listen(container, instance);
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.permissionDenied,
+    );
+
+    final ProviderSubscription<SpeedtestRunState> editedSubscription =
+        _listen(container, edited);
+    expect(
+      container.read(speedtestRunControllerProvider(edited)).phase,
+      SpeedtestRunPhase.idle,
+    );
+    final ProviderSubscription<SpeedtestRunState> urlEditedSubscription =
+        _listen(container, urlEdited);
+    expect(
+      container.read(speedtestRunControllerProvider(urlEdited)).phase,
+      SpeedtestRunPhase.idle,
+    );
+
+    subscription.close();
+    editedSubscription.close();
+    urlEditedSubscription.close();
+    container.dispose();
+  });
+
+  test('ambiguous accepted submissions adopt the newly visible result',
+      () async {
+    for (final SpeedtestTrackerException error in <SpeedtestTrackerException>[
+      const SpeedtestTrackerException(
+        SpeedtestErrorKind.timeout,
+        'Timed out.',
+      ),
+      const SpeedtestTrackerException(
+        SpeedtestErrorKind.offline,
+        'Connection reset.',
+      ),
+      const SpeedtestTrackerException(
+        SpeedtestErrorKind.server,
+        'Late server response.',
+        statusCode: 503,
+      ),
+      const SpeedtestTrackerException(
+        SpeedtestErrorKind.other,
+        'Unknown network response.',
+      ),
+    ]) {
+      final SpeedtestResult adopted = _result(
+        8,
+        SpeedtestResultStatus.waiting,
+        createdAt: submittedAt.add(const Duration(seconds: 1)),
+      );
+      final _FakeApi api = _FakeApi(
+        listPages: <SpeedtestResultsPage>[
+          _page(const <SpeedtestResult>[]),
+          _page(<SpeedtestResult>[adopted]),
+        ],
+        runErrors: <SpeedtestTrackerException>[error],
+        polled: <SpeedtestResult>[
+          _result(8, SpeedtestResultStatus.completed),
+        ],
+      );
+      final ProviderContainer container = _container(
+        instance,
+        api,
+        clock: () => submittedAt,
+      );
+      final ProviderSubscription<SpeedtestRunState> subscription =
+          _listen(container, instance);
+
+      await container
+          .read(speedtestRunControllerProvider(instance).notifier)
+          .run();
+
+      expect(api.runCalls, 1, reason: error.kind.name);
+      expect(api.pollCalls, 1, reason: error.kind.name);
+      expect(
+        container.read(speedtestRunControllerProvider(instance)).phase,
+        SpeedtestRunPhase.completed,
+        reason: error.kind.name,
+      );
+      subscription.close();
+      container.dispose();
+    }
+  });
+
+  test('does not submit twice while reconciliation is in progress', () async {
+    final Completer<SpeedtestResultsPage> reconciliation =
+        Completer<SpeedtestResultsPage>();
+    final SpeedtestResult adopted = _result(
+      9,
+      SpeedtestResultStatus.completed,
+      createdAt: submittedAt.add(const Duration(seconds: 1)),
+    );
+    final _FakeApi api = _FakeApi(
+      listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+      runErrors: <SpeedtestTrackerException>[
+        const SpeedtestTrackerException(
+          SpeedtestErrorKind.timeout,
+          'Timed out.',
+        ),
+      ],
+      pendingList: reconciliation,
+    );
+    final ProviderContainer container = _container(
+      instance,
+      api,
+      clock: () => submittedAt,
+    );
+    final ProviderSubscription<SpeedtestRunState> subscription =
+        _listen(container, instance);
+    addTearDown(subscription.close);
+    addTearDown(container.dispose);
+
+    final SpeedtestRunController controller =
+        container.read(speedtestRunControllerProvider(instance).notifier);
+    final Future<void> firstRun = controller.run();
+    await _waitForPhase(container, instance, SpeedtestRunPhase.reconciling);
+
+    await controller.run();
+    expect(api.runCalls, 1);
+
+    reconciliation.complete(_page(<SpeedtestResult>[adopted]));
+    await firstRun;
+    expect(api.runCalls, 1);
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.completed,
+    );
+  });
+
+  test('indeterminate outcome requires explicit confirmation before retry',
+      () async {
+    final _FakeApi api = _FakeApi(
+      listPages: <SpeedtestResultsPage>[
+        _page(const <SpeedtestResult>[]),
+        _page(const <SpeedtestResult>[]),
+        _page(const <SpeedtestResult>[]),
+      ],
+      runErrors: <SpeedtestTrackerException>[
+        const SpeedtestTrackerException(
+          SpeedtestErrorKind.timeout,
+          'Timed out.',
+        ),
+      ],
+      queued: _result(12, SpeedtestResultStatus.completed),
+    );
+    final ProviderContainer container = _container(
+      instance,
+      api,
+      reconcileMaxPolls: 1,
+      clock: () => submittedAt,
+    );
+    final ProviderSubscription<SpeedtestRunState> subscription =
+        _listen(container, instance);
+    addTearDown(subscription.close);
+    addTearDown(container.dispose);
+    final SpeedtestRunController controller =
+        container.read(speedtestRunControllerProvider(instance).notifier);
+
+    await controller.run();
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.indeterminate,
+    );
+    expect(api.runCalls, 1);
+
+    await controller.run();
+    expect(api.runCalls, 1);
+
+    await controller.run(confirmIndeterminateRetry: true);
+    expect(api.runCalls, 2);
+    expect(
+      container.read(speedtestRunControllerProvider(instance)).phase,
+      SpeedtestRunPhase.completed,
+    );
+  });
+
+  test('failed and skipped result reasons are retained', () async {
+    for (final SpeedtestResultStatus terminal in <SpeedtestResultStatus>[
+      SpeedtestResultStatus.failed,
+      SpeedtestResultStatus.skipped,
+    ]) {
+      final _FakeApi api = _FakeApi(
+        listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+        queued: _result(4, SpeedtestResultStatus.waiting),
+        polled: <SpeedtestResult>[
+          _result(4, terminal, message: 'Upstream failure reason'),
+        ],
+      );
+      final ProviderContainer container = _container(instance, api);
+      final ProviderSubscription<SpeedtestRunState> subscription =
+          _listen(container, instance);
+
+      await container
+          .read(speedtestRunControllerProvider(instance).notifier)
+          .run();
+
+      final SpeedtestRunState state =
+          container.read(speedtestRunControllerProvider(instance));
+      expect(state.phase, SpeedtestRunPhase.failed);
+      expect(state.message, 'Upstream failure reason');
+      subscription.close();
+      container.dispose();
+    }
+  });
+
+  test('disposing the controller stops a pending polling delay', () async {
+    final _FakeApi api = _FakeApi(
+      listPages: <SpeedtestResultsPage>[_page(const <SpeedtestResult>[])],
+      queued: _result(20, SpeedtestResultStatus.waiting),
+      polled: <SpeedtestResult>[
+        _result(20, SpeedtestResultStatus.completed),
+      ],
+    );
+    final ProviderContainer container = _container(
+      instance,
+      api,
+      pollInterval: const Duration(hours: 1),
+    );
+    final ProviderSubscription<SpeedtestRunState> subscription =
+        _listen(container, instance);
+    final Future<void> run =
+        container.read(speedtestRunControllerProvider(instance).notifier).run();
+    await _waitForPhase(container, instance, SpeedtestRunPhase.queued);
+
+    subscription.close();
+    await container.pump();
+    await run.timeout(const Duration(seconds: 1));
+
+    expect(api.pollCalls, 0);
+    container.dispose();
+  });
+}
+
+ProviderContainer _container(
+  Instance instance,
+  _FakeApi api, {
+  int maxPolls = 5,
+  int reconcileMaxPolls = 2,
+  Duration pollInterval = Duration.zero,
+  DateTime Function()? clock,
+  Map<Instance, _FakeApi> additionalApis = const <Instance, _FakeApi>{},
+}) =>
+    ProviderContainer(
+      overrides: <Override>[
+        speedtestTrackerApiProvider(instance).overrideWith(
+          (Ref ref) async => api,
+        ),
+        for (final MapEntry<Instance, _FakeApi> entry in additionalApis.entries)
+          speedtestTrackerApiProvider(entry.key).overrideWith(
+            (Ref ref) async => entry.value,
+          ),
+        speedtestRunPollIntervalProvider.overrideWithValue(pollInterval),
+        speedtestRunMaxPollsProvider.overrideWithValue(maxPolls),
+        speedtestRunReconcileMaxPollsProvider.overrideWithValue(
+          reconcileMaxPolls,
+        ),
+        speedtestRunClockProvider.overrideWithValue(
+          clock ?? DateTime.now,
+        ),
+      ],
+    );
+
+ProviderSubscription<SpeedtestRunState> _listen(
+  ProviderContainer container,
+  Instance instance,
+) =>
+    container.listen<SpeedtestRunState>(
+      speedtestRunControllerProvider(instance),
+      (_, __) {},
+      fireImmediately: true,
+    );
+
+Future<void> _waitForPhase(
+  ProviderContainer container,
+  Instance instance,
+  SpeedtestRunPhase phase,
+) async {
+  for (int attempt = 0; attempt < 100; attempt++) {
+    if (container.read(speedtestRunControllerProvider(instance)).phase ==
+        phase) {
+      return;
+    }
+    await Future<void>.delayed(Duration.zero);
+  }
+  fail('Run controller did not reach ${phase.name}.');
+}
+
+SpeedtestResult _result(
+  int id,
+  SpeedtestResultStatus status, {
+  DateTime? createdAt,
+  String? message,
+}) =>
+    SpeedtestResult(
+      id: id,
+      status: status,
+      createdAt: createdAt,
+      message: message,
+    );
+
+SpeedtestResultsPage _page(List<SpeedtestResult> results) =>
+    SpeedtestResultsPage(results: results, page: 1, hasMore: false);
+
+class _FakeApi extends SpeedtestTrackerApi {
+  _FakeApi({
+    required this.listPages,
+    this.queued,
+    this.polled = const <SpeedtestResult>[],
+    this.runErrors = const <SpeedtestTrackerException>[],
+    this.pendingList,
+  }) : super(Dio());
+
+  final List<SpeedtestResultsPage> listPages;
+  final SpeedtestResult? queued;
+  final List<SpeedtestResult> polled;
+  final List<SpeedtestTrackerException> runErrors;
+  final Completer<SpeedtestResultsPage>? pendingList;
+  int listCalls = 0;
+  int runCalls = 0;
+  int pollCalls = 0;
+
+  @override
+  Future<SpeedtestResultsPage> listResults({
+    int page = 1,
+    int pageSize = 25,
+    SpeedtestResultStatus? status,
+  }) async {
+    final int index = listCalls++;
+    if (index >= listPages.length && pendingList != null) {
+      return pendingList!.future;
+    }
+    return listPages[index.clamp(0, listPages.length - 1)];
+  }
+
+  @override
+  Future<SpeedtestResult> runSpeedtest() async {
+    final int index = runCalls++;
+    if (index < runErrors.length) {
+      throw runErrors[index];
+    }
+    return queued!;
+  }
+
+  @override
+  Future<SpeedtestResult> getResult(int id) async {
+    final int index = pollCalls++;
+    return polled[index.clamp(0, polled.length - 1)];
+  }
+}

--- a/services/service_speedtest_tracker/test/speedtest_ui_hardening_test.dart
+++ b/services/service_speedtest_tracker/test/speedtest_ui_hardening_test.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_speedtest_tracker/service_speedtest_tracker.dart';
+import 'package:service_speedtest_tracker/src/widgets/speedtest_history_chart.dart';
+import 'package:service_speedtest_tracker/src/widgets/speedtest_result_views.dart';
+
+void main() {
+  testWidgets('stacked charts fit a narrow large-text layout',
+      (WidgetTester tester) async {
+    final SemanticsHandle semantics = tester.ensureSemantics();
+    tester.view.physicalSize = const Size(240, 600);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: MediaQuery(
+          data: const MediaQueryData(
+            size: Size(240, 600),
+            textScaler: TextScaler.linear(2),
+          ),
+          child: Scaffold(
+            body: SpeedtestHistoryChart(
+              results: <SpeedtestResult>[
+                _result(1, 900000000, 100000000),
+                _result(2, 1500000000, 200000000),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('Download history'), findsOneWidget);
+    expect(find.text('Upload history'), findsOneWidget);
+    expect(find.text('Gbps'), findsOneWidget);
+    expect(find.text('Mbps'), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets('download and upload use independent rounded Mbps scales',
+      (WidgetTester tester) async {
+    final SemanticsHandle semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SpeedtestHistoryChart(
+            results: <SpeedtestResult>[
+              _result(1, 650000000, 175000000),
+              _result(2, 687000000, 188000000),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.bySemanticsLabel(
+        RegExp(r'Download history chart.*midpoint 350, maximum 700 Mbps'),
+      ),
+      findsOneWidget,
+    );
+    expect(
+      find.bySemanticsLabel(
+        RegExp(r'Upload history chart.*midpoint 100, maximum 200 Mbps'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('700'), findsOneWidget);
+    expect(find.text('350'), findsOneWidget);
+    expect(find.text('200'), findsOneWidget);
+    expect(find.text('100'), findsOneWidget);
+    expect(find.text('0'), findsNWidgets(2));
+    semantics.dispose();
+  });
+
+  testWidgets('large download values use a rounded Gbps scale',
+      (WidgetTester tester) async {
+    final SemanticsHandle semantics = tester.ensureSemantics();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SpeedtestHistoryChart(
+            results: <SpeedtestResult>[
+              _result(1, 1250000000, 90000000),
+              _result(2, 1420000000, 100000000),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.bySemanticsLabel(
+        RegExp(r'Download history chart.*midpoint 0.75, maximum 1.5 Gbps'),
+      ),
+      findsOneWidget,
+    );
+    expect(find.text('1.5'), findsOneWidget);
+    expect(find.text('0.75'), findsOneWidget);
+    expect(find.text('Gbps'), findsOneWidget);
+    expect(find.text('Mbps'), findsOneWidget);
+    semantics.dispose();
+  });
+
+  testWidgets('empty and single-result chart behavior remains explicit',
+      (WidgetTester tester) async {
+    for (final List<SpeedtestResult> results in <List<SpeedtestResult>>[
+      const <SpeedtestResult>[],
+      <SpeedtestResult>[_result(1, 100000000, 50000000)],
+    ]) {
+      await tester.pumpWidget(
+        MaterialApp(home: SpeedtestHistoryChart(results: results)),
+      );
+      expect(
+        find.text('Run at least two tests to draw a history.'),
+        findsOneWidget,
+      );
+    }
+  });
+
+  testWidgets('chart omits manually constructed invalid speed values',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: SpeedtestHistoryChart(
+          results: <SpeedtestResult>[
+            _result(1, double.nan, -1),
+            _result(2, double.infinity, -2),
+          ],
+        ),
+      ),
+    );
+
+    expect(
+      find.text('Run at least two tests to draw a history.'),
+      findsOneWidget,
+    );
+    expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('latest card does not render an empty metadata text row',
+      (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SpeedtestLatestCard(
+            result: _result(1, 100000000, 50000000),
+          ),
+        ),
+      ),
+    );
+
+    expect(
+      find.byWidgetPredicate(
+        (Widget widget) => widget is Text && widget.data == '',
+      ),
+      findsNothing,
+    );
+  });
+}
+
+SpeedtestResult _result(int id, double download, double upload) =>
+    SpeedtestResult(
+      id: id,
+      status: SpeedtestResultStatus.completed,
+      downloadBitsPerSecond: download,
+      uploadBitsPerSecond: upload,
+      measuredAt: DateTime.utc(2026, 7, 20 + id),
+    );

--- a/services/service_speedtest_tracker/test/support/fake_http_client_adapter.dart
+++ b/services/service_speedtest_tracker/test/support/fake_http_client_adapter.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+
+typedef ResponseFactory = ({int status, Object? data}) Function(
+  RequestOptions options,
+);
+
+class FakeHttpClientAdapter implements HttpClientAdapter {
+  FakeHttpClientAdapter(this.responseFactory, {this.headersFactory});
+
+  final ResponseFactory responseFactory;
+  final Map<String, List<String>> Function(RequestOptions options)?
+      headersFactory;
+  final List<RequestOptions> requests = <RequestOptions>[];
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    requests.add(options);
+    final ({Object? data, int status}) response = responseFactory(options);
+    return ResponseBody.fromString(
+      jsonEncode(response.data),
+      response.status,
+      headers: <String, List<String>>{
+        Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+        ...?headersFactory?.call(options),
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}


### PR DESCRIPTION
## AI assistance disclosure

OpenAI Codex was used to assist with repository analysis, implementation, testing, and code review. I reviewed the resulting changes, performed live-device testing against my Speedtest Tracker instance, and take responsibility for the submitted code.


## Summary

Adds native Speedtest Tracker support to Atrium.

### Features

- Adds Speedtest Tracker to the Add Service menu
- Places configured instances under Analytics
- Supports local and external connection profiles
- Stores bearer tokens using Atrium's existing secure credential storage
- Adds authenticated health and connection checks
- Supports multiple Speedtest Tracker instances
- Displays:
  - latest download and upload results
  - ping and jitter
  - optional packet loss
  - server, location, and ISP information
  - recent result history
- Adds separately scaled download and upload history charts
- Adds a confirmed asynchronous Run Speedtest workflow
- Adds the configurable `Speedtest results` dashboard widget
- Adds a separate `app.atrium.debug` identity for local debug testing

## Compatibility

- Speedtest Tracker 1.1+ for authenticated result history
- Speedtest Tracker 1.6+ for remotely running tests

No deprecated public API fallback or Ookla server picker is included.

## Security and reliability

- Bearer credentials are redacted from diagnostic output
- Authenticated requests do not follow redirects
- Absolute pagination URLs are not followed
- Ambiguous run submissions are reconciled before another POST is allowed
- External plain HTTP URLs show a security warning
- Self-signed certificates remain opt-in
- API error messages are sanitized

## Testing

- `flutter pub get`
- `dart run tool/build_all.dart`
- `flutter analyze`
- 131 workspace tests passed in total
- Includes 33 Speedtest Tracker tests after the final chart changes
- `flutter build apk --debug`
- `git diff --check`

## Live validation

Tested against a live Speedtest Tracker instance:

- Service registered under Analytics and reported Online
- Dashboard widget loaded and navigated correctly
- Latest result, history, and charts loaded correctly
- Remote test transitioned through running and completed states
- Results, history, charts, and dashboard refreshed after completion
- Debug build installed alongside the official Atrium application
## Screenshots

### Dashboard widget
<img width="1536" height="705" alt="352823" src="https://github.com/user-attachments/assets/8757832e-f246-4d3d-807c-7f25f0f527c1" />

### Latest result and independently scaled history charts
<img width="695" height="1536" alt="352820" src="https://github.com/user-attachments/assets/d220b8f3-dd3b-4492-8b92-05be7d7476ed" />
<img width="695" height="1536" alt="352821" src="https://github.com/user-attachments/assets/da8b57a9-c8a2-4af9-8b45-766cdf4c4b1e" />

### Analytics navigation
<img width="695" height="1536" alt="352822" src="https://github.com/user-attachments/assets/514cbc26-bc75-413d-8b22-61800d523b44" />
