### PR TITLE
Release 1.3.3

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Atrium version
       description: Settings, then About.
-      placeholder: "1.3.2"
+      placeholder: "1.3.3"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ whether you're on the home Wi-Fi or out in the world.
 
 **[Website][site]** - screenshots and a tour, no install needed.
 
-> **Status:** v1.3.2. Install from [F-Droid][fdroid], or grab a signed APK
+> **Status:** v1.3.3. Install from [F-Droid][fdroid], or grab a signed APK
 > from the [releases page][releases].
 
 ## Why

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -87,24 +87,32 @@ class AtriumApp extends ConsumerWidget {
           // listener wraps it so a torrent arriving from another app is
           // handled wherever the user happens to be, and so its picker stays
           // underneath the lock when the app is locked.
-          // The system navigation bar keeps the app's own colours: its icons
-          // are tinted against the surface the app actually paints there, so
-          // they stay legible in either theme. The app stays edge-to-edge -
-          // reserving the inset app-wide would letterbox every screen to fix
-          // what is really a sizing bug in one widget.
           builder: (BuildContext context, Widget? child) {
-            final Brightness brightness = Theme.of(context).brightness;
+            final bool isDark = themeMode == ThemeMode.dark ||
+                (themeMode == ThemeMode.system &&
+                    MediaQuery.platformBrightnessOf(context) == Brightness.dark);
+            final ThemeData activeTheme = isDark ? darkTheme : lightTheme;
+            final Color navColor = activeTheme.navigationBarTheme.backgroundColor ??
+                activeTheme.colorScheme.surfaceContainer;
             return AnnotatedRegion<SystemUiOverlayStyle>(
               value: SystemUiOverlayStyle(
+                systemNavigationBarColor: navColor,
                 systemNavigationBarIconBrightness:
-                    brightness == Brightness.dark
-                        ? Brightness.light
-                        : Brightness.dark,
+                    isDark ? Brightness.light : Brightness.dark,
                 systemNavigationBarContrastEnforced: false,
               ),
               child: TorrentShareListener(
                 child: _BiometricLockGate(
-                  child: child ?? const SizedBox.shrink(),
+                  child: ColoredBox(
+                    color: navColor,
+                    child: SafeArea(
+                      top: false,
+                      left: false,
+                      right: false,
+                      bottom: true,
+                      child: child ?? const SizedBox.shrink(),
+                    ),
+                  ),
                 ),
               ),
             );

--- a/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
@@ -176,7 +176,7 @@ class _DashboardRecentlyDownloadedWidgetState
         final List<int> sortedEps = g.episodes.keys.toList()..sort();
         final String minEp = sortedEps.first.toString().padLeft(2, '0');
         final String maxEp = sortedEps.last.toString().padLeft(2, '0');
-        subtitle = 'S${sNum}E$minEp-E$maxEp (${sortedEps.length} episodes)';
+        subtitle = 'S${sNum}E$minEp–E$maxEp (${sortedEps.length} Ep)';
       }
 
       items.add(_RecentDownloadItem(

--- a/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
@@ -176,7 +176,7 @@ class _DashboardRecentlyDownloadedWidgetState
         final List<int> sortedEps = g.episodes.keys.toList()..sort();
         final String minEp = sortedEps.first.toString().padLeft(2, '0');
         final String maxEp = sortedEps.last.toString().padLeft(2, '0');
-        subtitle = 'S${sNum}E$minEp–E$maxEp (${sortedEps.length} Ep)';
+        subtitle = 'S${sNum}E$minEp-E$maxEp (${sortedEps.length} Ep)';
       }
 
       items.add(_RecentDownloadItem(

--- a/app/lib/src/screens/changelog/release_notes.dart
+++ b/app/lib/src/screens/changelog/release_notes.dart
@@ -27,6 +27,21 @@ class ReleaseNote {
 /// Newest first. Update alongside appVersion and the pubspec at each release.
 const List<ReleaseNote> releaseNotes = <ReleaseNote>[
   ReleaseNote(
+    version: '1.3.3',
+    date: '2026-08-07',
+    groups: <ChangeGroup>[
+      ChangeGroup(ChangeCategory.added, <String>[
+        'Delete a film or an episode from disk while keeping it in your library, so you free the space without losing the entry. Tick unmonitor at the same time and it will not simply download again.',
+        'The same thing in bulk: select several films or series, choose Delete files only, and the entries stay behind.',
+        'Radarr can be sorted ascending or descending.',
+      ]),
+      ChangeGroup(ChangeCategory.fixed, <String>[
+        'Lists no longer run underneath the system navigation buttons at the bottom of the screen.',
+        'The buttons on a film or series detail screen no longer wrap onto a second line on narrower phones.',
+      ]),
+    ],
+  ),
+  ReleaseNote(
     version: '1.3.2',
     date: '2026-08-07',
     groups: <ChangeGroup>[

--- a/app/lib/src/update_check/app_version.dart
+++ b/app/lib/src/update_check/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Source of truth for the update check and the Settings version line. Bump
 /// this at release time together with pubspec.
-const String appVersion = '1.3.2';
+const String appVersion = '1.3.3';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.3.2+14
+version: 1.3.3+15
 
 environment:
   sdk: ^3.6.0

--- a/app/test/changelog/available_release_card_test.dart
+++ b/app/test/changelog/available_release_card_test.dart
@@ -52,7 +52,7 @@ void main() {
       (WidgetTester tester) async {
     await _pump(
       tester,
-      const UpdateCheckState(status: UpdateStatus.upToDate, latestVersion: '1.3.2'),
+      const UpdateCheckState(status: UpdateStatus.upToDate, latestVersion: '1.3.3'),
     );
     expect(find.text('Available'), findsNothing);
     expect(find.text('See full release'), findsNothing);

--- a/app/test/changelog/changelog_screen_test.dart
+++ b/app/test/changelog/changelog_screen_test.dart
@@ -34,8 +34,8 @@ void main() {
 
     expect(find.byType(AvailableReleaseCard, skipOffstage: false),
         findsOneWidget);
-    expect(find.text('v1.3.2'), findsOneWidget);
-    // appVersion is 1.3.2, so exactly one card is Installed.
+    expect(find.text('v1.3.3'), findsOneWidget);
+    // appVersion is 1.3.3, so exactly one card is Installed.
     expect(find.text('Installed'), findsOneWidget);
     expect(find.text('New'), findsWidgets);
   });

--- a/app/test/changelog/release_notes_test.dart
+++ b/app/test/changelog/release_notes_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('release notes are newest first and well formed', () {
-    expect(releaseNotes.first.version, '1.3.2');
+    expect(releaseNotes.first.version, '1.3.3');
     for (final ReleaseNote note in releaseNotes) {
       expect(note.date, isNotEmpty);
       expect(note.groups, isNotEmpty);

--- a/app/test/update_check/update_check_state_test.dart
+++ b/app/test/update_check/update_check_state_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('hasNewer is true only when latestVersion is above appVersion', () {
-    // appVersion is 1.3.2.
+    // appVersion is 1.3.3.
     expect(
       const UpdateCheckState(
         status: UpdateStatus.updateAvailable,
@@ -12,7 +12,7 @@ void main() {
       isTrue,
     );
     expect(
-      const UpdateCheckState(latestVersion: '1.3.2').hasNewer,
+      const UpdateCheckState(latestVersion: '1.3.3').hasNewer,
       isFalse,
     );
     expect(const UpdateCheckState().hasNewer, isFalse);

--- a/app/test/update_check/update_checker_test.dart
+++ b/app/test/update_check/update_checker_test.dart
@@ -66,7 +66,7 @@ void main() {
     final ProviderContainer c = _container(
       box,
       _dio((RequestOptions o) =>
-          (status: 200, data: <String, dynamic>{'tag_name': 'v1.3.2'})),
+          (status: 200, data: <String, dynamic>{'tag_name': 'v1.3.3'})),
     );
     await c.read(updateCheckProvider.notifier).check();
     expect(c.read(updateCheckProvider).status, UpdateStatus.upToDate);

--- a/fastlane/metadata/android/en-US/changelogs/15.txt
+++ b/fastlane/metadata/android/en-US/changelogs/15.txt
@@ -1,0 +1,10 @@
+You can now delete a film or an episode from disk while keeping it in your
+library, so the space comes back without losing the entry. Tick unmonitor at the
+same time and it will not simply download again. The same works in bulk: select
+several films or series, choose Delete files only, and the entries stay behind.
+
+Radarr can be sorted ascending or descending.
+
+Fixed: lists ran underneath the system navigation buttons at the bottom of the
+screen, and the buttons on a film or series detail screen wrapped onto a second
+line on narrower phones.

--- a/packages/core_router/lib/src/scaffold_with_nav_bar.dart
+++ b/packages/core_router/lib/src/scaffold_with_nav_bar.dart
@@ -34,16 +34,6 @@ class _ScaffoldWithNavBarState extends State<ScaffoldWithNavBar> {
 
   @override
   Widget build(BuildContext context) {
-    // Material's NavigationBar wraps itself in a SafeArea and *then* sizes to
-    // its height, so what it actually occupies is that height plus the bottom
-    // inset. Pinning it to a bare 80 therefore ate the inset out of the bar
-    // itself: on three-button devices, whose inset is roughly twice a gesture
-    // bar's, that clipped the selection pill and the icons above the labels.
-    // Gesture devices had just enough slack to hide it.
-    //
-    // padding, not viewPadding: it collapses to zero while the keyboard is up,
-    // which is exactly when the bar no longer needs the room.
-    final double barHeight = 80.0 + MediaQuery.paddingOf(context).bottom;
     return PopScope<Object?>(
       canPop: widget.navigationShell.currentIndex == 0,
       onPopInvokedWithResult: (bool didPop, Object? result) {
@@ -91,11 +81,11 @@ class _ScaffoldWithNavBarState extends State<ScaffoldWithNavBar> {
           : null,
       bottomNavigationBar: AnimatedContainer(
         duration: const Duration(milliseconds: 200),
-        height: _isNavbarVisible ? barHeight : 0.0,
+        height: _isNavbarVisible ? 80.0 : 0.0,
         child: SingleChildScrollView(
           physics: const NeverScrollableScrollPhysics(),
           child: SizedBox(
-            height: barHeight,
+            height: 80.0,
             child: NavigationBar(
               selectedIndex: widget.navigationShell.currentIndex,
               onDestinationSelected: _onTap,

--- a/services/service_radarr/lib/src/home/movies_tab.dart
+++ b/services/service_radarr/lib/src/home/movies_tab.dart
@@ -1173,6 +1173,11 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
   }
 }
 
+enum _DeleteMode {
+  deleteEntry,
+  deleteFilesOnly,
+}
+
 class _BulkDeleteDialog extends ConsumerStatefulWidget {
   const _BulkDeleteDialog({
     required this.instance,
@@ -1187,7 +1192,9 @@ class _BulkDeleteDialog extends ConsumerStatefulWidget {
 }
 
 class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
+  _DeleteMode _mode = _DeleteMode.deleteEntry;
   bool _deleteFiles = false;
+  bool _unmonitor = false;
 
   @override
   Widget build(BuildContext context) {
@@ -1196,20 +1203,52 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            'Are you sure you want to delete these movies? This action cannot be undone.',
-          ),
-          const SizedBox(height: 16),
-          CheckboxListTile(
-            title: const Text('Delete all files from disk'),
-            value: _deleteFiles,
+        children: <Widget>[
+          RadioListTile<_DeleteMode>(
+            title: const Text('Delete movie entry'),
+            subtitle: const Text('Remove from Radarr library'),
+            value: _DeleteMode.deleteEntry,
+            groupValue: _mode,
             contentPadding: EdgeInsets.zero,
-            onChanged: (val) => setState(() => _deleteFiles = val ?? false),
+            onChanged: (val) => setState(() {
+              if (val != null) _mode = val;
+            }),
           ),
+          if (_mode == _DeleteMode.deleteEntry)
+            Padding(
+              padding: const EdgeInsets.only(left: Insets.lg),
+              child: CheckboxListTile(
+                title: const Text('Also delete files from disk'),
+                value: _deleteFiles,
+                contentPadding: EdgeInsets.zero,
+                onChanged: (val) => setState(() => _deleteFiles = val ?? false),
+              ),
+            ),
+          RadioListTile<_DeleteMode>(
+            title: const Text('Delete files only'),
+            subtitle:
+                const Text('Keep entry in Radarr library to free disk space'),
+            value: _DeleteMode.deleteFilesOnly,
+            groupValue: _mode,
+            contentPadding: EdgeInsets.zero,
+            onChanged: (val) => setState(() {
+              if (val != null) _mode = val;
+            }),
+          ),
+          if (_mode == _DeleteMode.deleteFilesOnly)
+            Padding(
+              padding: const EdgeInsets.only(left: Insets.lg),
+              child: CheckboxListTile(
+                title: const Text('Unmonitor movie'),
+                subtitle: const Text('Prevent automatic re-downloads'),
+                value: _unmonitor,
+                contentPadding: EdgeInsets.zero,
+                onChanged: (val) => setState(() => _unmonitor = val ?? false),
+              ),
+            ),
         ],
       ),
-      actions: [
+      actions: <Widget>[
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('Cancel'),
@@ -1234,13 +1273,44 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
             );
 
             Object? error;
+            int successCount = 0;
+            int failedCount = 0;
             try {
               final api =
                   await ref.read(radarrApiProvider(widget.instance).future);
-              await api.bulkDeleteMovies(
-                widget.selectedIds.toList(),
-                deleteFiles: _deleteFiles,
-              );
+              if (_mode == _DeleteMode.deleteEntry) {
+                await api.bulkDeleteMovies(
+                  widget.selectedIds.toList(),
+                  deleteFiles: _deleteFiles,
+                );
+              } else {
+                for (final id in widget.selectedIds) {
+                  try {
+                    final movie = await api.getMovieById(id);
+                    if (movie.movieFileId != null) {
+                      await api.deleteMovieFile(movie.movieFileId!);
+                    }
+                    if (_unmonitor) {
+                      try {
+                        final Map<String, dynamic> raw =
+                            await api.getMovieRaw(id);
+                        raw['monitored'] = false;
+                        if (raw['qualityProfileId'] == null ||
+                            raw['qualityProfileId'] == 0) {
+                          final profiles = await api.getQualityProfiles();
+                          if (profiles.isNotEmpty) {
+                            raw['qualityProfileId'] = profiles.first['id'];
+                          }
+                        }
+                        await api.updateMovieRaw(raw);
+                      } catch (_) {}
+                    }
+                    successCount++;
+                  } catch (_) {
+                    failedCount++;
+                  }
+                }
+              }
             } catch (e) {
               error = e;
             } finally {
@@ -1250,18 +1320,29 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
             if (!context.mounted) return;
             if (error != null) {
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Error deleting movies: $error')),
+                SnackBar(content: Text('Error: $error')),
               );
               return;
             }
             ref.invalidate(radarrMoviesProvider(widget.instance));
             ref
                 .read(radarrMoviesSelectionProvider(widget.instance).notifier)
-                .state = {};
+                .state = <int>{};
             Navigator.pop(context); // pop dialog
 
+            final String msg;
+            if (_mode == _DeleteMode.deleteEntry) {
+              msg = 'Successfully deleted ${widget.selectedIds.length} movie(s)';
+            } else if (failedCount == 0) {
+              msg = _unmonitor
+                  ? 'Successfully deleted files and unmonitored $successCount movie(s)'
+                  : 'Successfully deleted files for $successCount movie(s)';
+            } else {
+              msg = 'Deleted files for $successCount movie(s). Failed for $failedCount movie(s)';
+            }
+
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Successfully deleted movies')),
+              SnackBar(content: Text(msg)),
             );
           },
           child: const Text('Delete'),
@@ -1516,6 +1597,30 @@ class _SortFilterBottomSheet extends ConsumerWidget {
                   ),
                 ],
               ),
+              const SizedBox(height: 16),
+              SegmentedButton<bool>(
+                segments: const <ButtonSegment<bool>>[
+                  ButtonSegment<bool>(
+                    value: true,
+                    label: Text('Ascending'),
+                    icon: Icon(Icons.arrow_upward),
+                  ),
+                  ButtonSegment<bool>(
+                    value: false,
+                    label: Text('Descending'),
+                    icon: Icon(Icons.arrow_downward),
+                  ),
+                ],
+                selected: {sortAscending},
+                onSelectionChanged: (val) {
+                  ref
+                      .read(
+                        radarrMovieSortAscendingProvider(instance).notifier,
+                      )
+                      .state = val.first;
+                },
+              ),
+              const SizedBox(height: 16),
             ],
           ),
         ),

--- a/services/service_radarr/lib/src/home/movies_tab.dart
+++ b/services/service_radarr/lib/src/home/movies_tab.dart
@@ -1200,53 +1200,51 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text('Delete ${widget.selectedIds.length} Movies?'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          RadioListTile<_DeleteMode>(
-            title: const Text('Delete movie entry'),
-            subtitle: const Text('Remove from Radarr library'),
-            value: _DeleteMode.deleteEntry,
-            groupValue: _mode,
-            contentPadding: EdgeInsets.zero,
-            onChanged: (val) => setState(() {
-              if (val != null) _mode = val;
-            }),
-          ),
-          if (_mode == _DeleteMode.deleteEntry)
-            Padding(
-              padding: const EdgeInsets.only(left: Insets.lg),
-              child: CheckboxListTile(
-                title: const Text('Also delete files from disk'),
-                value: _deleteFiles,
-                contentPadding: EdgeInsets.zero,
-                onChanged: (val) => setState(() => _deleteFiles = val ?? false),
-              ),
+      content: RadioGroup<_DeleteMode>(
+        groupValue: _mode,
+        onChanged: (_DeleteMode? val) => setState(() {
+          if (val != null) _mode = val;
+        }),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const RadioListTile<_DeleteMode>(
+              title: Text('Delete movie entry'),
+              subtitle: Text('Remove from Radarr library'),
+              value: _DeleteMode.deleteEntry,
+              contentPadding: EdgeInsets.zero,
             ),
-          RadioListTile<_DeleteMode>(
-            title: const Text('Delete files only'),
-            subtitle:
-                const Text('Keep entry in Radarr library to free disk space'),
-            value: _DeleteMode.deleteFilesOnly,
-            groupValue: _mode,
-            contentPadding: EdgeInsets.zero,
-            onChanged: (val) => setState(() {
-              if (val != null) _mode = val;
-            }),
-          ),
-          if (_mode == _DeleteMode.deleteFilesOnly)
-            Padding(
-              padding: const EdgeInsets.only(left: Insets.lg),
-              child: CheckboxListTile(
-                title: const Text('Unmonitor movie'),
-                subtitle: const Text('Prevent automatic re-downloads'),
-                value: _unmonitor,
-                contentPadding: EdgeInsets.zero,
-                onChanged: (val) => setState(() => _unmonitor = val ?? false),
+            if (_mode == _DeleteMode.deleteEntry)
+              Padding(
+                padding: const EdgeInsets.only(left: Insets.lg),
+                child: CheckboxListTile(
+                  title: const Text('Also delete files from disk'),
+                  value: _deleteFiles,
+                  contentPadding: EdgeInsets.zero,
+                  onChanged: (val) => setState(() => _deleteFiles = val ?? false),
+                ),
               ),
+            const RadioListTile<_DeleteMode>(
+              title: Text('Delete files only'),
+              subtitle:
+                  Text('Keep entry in Radarr library to free disk space'),
+              value: _DeleteMode.deleteFilesOnly,
+              contentPadding: EdgeInsets.zero,
             ),
-        ],
+            if (_mode == _DeleteMode.deleteFilesOnly)
+              Padding(
+                padding: const EdgeInsets.only(left: Insets.lg),
+                child: CheckboxListTile(
+                  title: const Text('Unmonitor movie'),
+                  subtitle: const Text('Prevent automatic re-downloads'),
+                  value: _unmonitor,
+                  contentPadding: EdgeInsets.zero,
+                  onChanged: (val) => setState(() => _unmonitor = val ?? false),
+                ),
+              ),
+          ],
+        ),
       ),
       actions: <Widget>[
         TextButton(

--- a/services/service_radarr/lib/src/movie_detail_screen.dart
+++ b/services/service_radarr/lib/src/movie_detail_screen.dart
@@ -958,6 +958,12 @@ class _ActionsRow extends ConsumerWidget {
       final RadarrApi api = await ref.read(radarrApiProvider(instance).future);
       final Map<String, dynamic> raw = await api.getMovieRaw(movie.id);
       raw['monitored'] = !movie.monitored;
+      if (raw['qualityProfileId'] == null || raw['qualityProfileId'] == 0) {
+        final profiles = await api.getQualityProfiles();
+        if (profiles.isNotEmpty) {
+          raw['qualityProfileId'] = profiles.first['id'];
+        }
+      }
       await api.updateMovieRaw(raw);
       onRefreshed();
     } catch (e) {
@@ -988,6 +994,8 @@ class _OverflowMenu extends ConsumerWidget {
       onSelected: (String v) async {
         if (v == 'delete') {
           await _confirmDelete(context, ref);
+        } else if (v == 'delete_file') {
+          await _confirmDeleteFile(context, ref);
         } else if (v == 'rename') {
           await _showRenameDialog(context);
         } else if (v == 'edit') {
@@ -1021,6 +1029,15 @@ class _OverflowMenu extends ConsumerWidget {
             contentPadding: EdgeInsets.zero,
           ),
         ),
+        if (movie.hasFile && movie.movieFileId != null)
+          const PopupMenuItem<String>(
+            value: 'delete_file',
+            child: ListTile(
+              leading: Icon(Icons.delete_sweep_outlined),
+              title: Text('Delete movie file'),
+              contentPadding: EdgeInsets.zero,
+            ),
+          ),
         const PopupMenuItem<String>(
           value: 'delete',
           child: ListTile(
@@ -1063,6 +1080,102 @@ class _OverflowMenu extends ConsumerWidget {
         movieId: movie.id,
       ),
     );
+  }
+
+  Future<void> _confirmDeleteFile(BuildContext context, WidgetRef ref) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    bool unmonitor = false;
+    final bool? ok = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext context) => StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) => AlertDialog(
+          title: const Text('Delete movie file?'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Are you sure you want to delete the file for "${movie.title}" from disk? The movie entry will remain in Radarr.',
+              ),
+              const SizedBox(height: Insets.sm),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Unmonitor movie'),
+                subtitle: const Text('Prevent automatic re-downloads'),
+                value: unmonitor,
+                onChanged: (bool? v) => setState(() => unmonitor = v ?? false),
+              ),
+            ],
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: Theme.of(context).colorScheme.error,
+                foregroundColor: Theme.of(context).colorScheme.onError,
+              ),
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Delete File'),
+            ),
+          ],
+        ),
+      ),
+    );
+    if (!(ok ?? false)) return;
+    if (!context.mounted) return;
+    try {
+      final RadarrApi api = await ref.read(radarrApiProvider(instance).future);
+      if (movie.movieFileId != null) {
+        await api.deleteMovieFile(movie.movieFileId!);
+      }
+      bool unmonitored = false;
+      Object? unmonitorError;
+      if (unmonitor) {
+        try {
+          final Map<String, dynamic> raw = await api.getMovieRaw(movie.id);
+          raw['monitored'] = false;
+          if (raw['qualityProfileId'] == null || raw['qualityProfileId'] == 0) {
+            final profiles = await api.getQualityProfiles();
+            if (profiles.isNotEmpty) {
+              raw['qualityProfileId'] = profiles.first['id'];
+            }
+          }
+          await api.updateMovieRaw(raw);
+          unmonitored = true;
+        } catch (e) {
+          unmonitorError = e;
+        }
+      }
+      ref.invalidate(radarrMovieByIdProvider((instance, movie.id)));
+      ref.invalidate(radarrMoviesProvider(instance));
+      onRefreshed();
+      if (unmonitor && !unmonitored) {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              'File deleted, but failed to unmonitor movie: $unmonitorError',
+            ),
+          ),
+        );
+      } else {
+        messenger.showSnackBar(
+          SnackBar(
+            content: Text(
+              unmonitored
+                  ? 'File deleted and movie unmonitored.'
+                  : 'File deleted from disk.',
+            ),
+          ),
+        );
+      }
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Failed to delete file: $e')),
+      );
+    }
   }
 
   Future<void> _confirmDelete(BuildContext context, WidgetRef ref) async {

--- a/services/service_sonarr/lib/src/home/series_tab.dart
+++ b/services/service_sonarr/lib/src/home/series_tab.dart
@@ -1181,53 +1181,51 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
   Widget build(BuildContext context) {
     return AlertDialog(
       title: Text('Delete ${widget.selectedIds.length} Series?'),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          RadioListTile<_DeleteMode>(
-            title: const Text('Delete series entry'),
-            subtitle: const Text('Remove from Sonarr library'),
-            value: _DeleteMode.deleteEntry,
-            groupValue: _mode,
-            contentPadding: EdgeInsets.zero,
-            onChanged: (val) => setState(() {
-              if (val != null) _mode = val;
-            }),
-          ),
-          if (_mode == _DeleteMode.deleteEntry)
-            Padding(
-              padding: const EdgeInsets.only(left: Insets.lg),
-              child: CheckboxListTile(
-                title: const Text('Also delete files from disk'),
-                value: _deleteFiles,
-                contentPadding: EdgeInsets.zero,
-                onChanged: (val) => setState(() => _deleteFiles = val ?? false),
-              ),
+      content: RadioGroup<_DeleteMode>(
+        groupValue: _mode,
+        onChanged: (_DeleteMode? val) => setState(() {
+          if (val != null) _mode = val;
+        }),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const RadioListTile<_DeleteMode>(
+              title: Text('Delete series entry'),
+              subtitle: Text('Remove from Sonarr library'),
+              value: _DeleteMode.deleteEntry,
+              contentPadding: EdgeInsets.zero,
             ),
-          RadioListTile<_DeleteMode>(
-            title: const Text('Delete files only'),
-            subtitle:
-                const Text('Keep entry in Sonarr library to free disk space'),
-            value: _DeleteMode.deleteFilesOnly,
-            groupValue: _mode,
-            contentPadding: EdgeInsets.zero,
-            onChanged: (val) => setState(() {
-              if (val != null) _mode = val;
-            }),
-          ),
-          if (_mode == _DeleteMode.deleteFilesOnly)
-            Padding(
-              padding: const EdgeInsets.only(left: Insets.lg),
-              child: CheckboxListTile(
-                title: const Text('Unmonitor series'),
-                subtitle: const Text('Prevent automatic re-downloads'),
-                value: _unmonitor,
-                contentPadding: EdgeInsets.zero,
-                onChanged: (val) => setState(() => _unmonitor = val ?? false),
+            if (_mode == _DeleteMode.deleteEntry)
+              Padding(
+                padding: const EdgeInsets.only(left: Insets.lg),
+                child: CheckboxListTile(
+                  title: const Text('Also delete files from disk'),
+                  value: _deleteFiles,
+                  contentPadding: EdgeInsets.zero,
+                  onChanged: (val) => setState(() => _deleteFiles = val ?? false),
+                ),
               ),
+            const RadioListTile<_DeleteMode>(
+              title: Text('Delete files only'),
+              subtitle:
+                  Text('Keep entry in Sonarr library to free disk space'),
+              value: _DeleteMode.deleteFilesOnly,
+              contentPadding: EdgeInsets.zero,
             ),
-        ],
+            if (_mode == _DeleteMode.deleteFilesOnly)
+              Padding(
+                padding: const EdgeInsets.only(left: Insets.lg),
+                child: CheckboxListTile(
+                  title: const Text('Unmonitor series'),
+                  subtitle: const Text('Prevent automatic re-downloads'),
+                  value: _unmonitor,
+                  contentPadding: EdgeInsets.zero,
+                  onChanged: (val) => setState(() => _unmonitor = val ?? false),
+                ),
+              ),
+          ],
+        ),
       ),
       actions: <Widget>[
         TextButton(

--- a/services/service_sonarr/lib/src/home/series_tab.dart
+++ b/services/service_sonarr/lib/src/home/series_tab.dart
@@ -1154,6 +1154,11 @@ class _BulkEditDialogState extends ConsumerState<_BulkEditDialog> {
   }
 }
 
+enum _DeleteMode {
+  deleteEntry,
+  deleteFilesOnly,
+}
+
 class _BulkDeleteDialog extends ConsumerStatefulWidget {
   const _BulkDeleteDialog({
     required this.instance,
@@ -1168,7 +1173,9 @@ class _BulkDeleteDialog extends ConsumerStatefulWidget {
 }
 
 class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
+  _DeleteMode _mode = _DeleteMode.deleteEntry;
   bool _deleteFiles = false;
+  bool _unmonitor = false;
 
   @override
   Widget build(BuildContext context) {
@@ -1177,20 +1184,52 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const Text(
-            'Are you sure you want to delete these series? This action cannot be undone.',
-          ),
-          const SizedBox(height: 16),
-          CheckboxListTile(
-            title: const Text('Delete all files from disk'),
-            value: _deleteFiles,
+        children: <Widget>[
+          RadioListTile<_DeleteMode>(
+            title: const Text('Delete series entry'),
+            subtitle: const Text('Remove from Sonarr library'),
+            value: _DeleteMode.deleteEntry,
+            groupValue: _mode,
             contentPadding: EdgeInsets.zero,
-            onChanged: (val) => setState(() => _deleteFiles = val ?? false),
+            onChanged: (val) => setState(() {
+              if (val != null) _mode = val;
+            }),
           ),
+          if (_mode == _DeleteMode.deleteEntry)
+            Padding(
+              padding: const EdgeInsets.only(left: Insets.lg),
+              child: CheckboxListTile(
+                title: const Text('Also delete files from disk'),
+                value: _deleteFiles,
+                contentPadding: EdgeInsets.zero,
+                onChanged: (val) => setState(() => _deleteFiles = val ?? false),
+              ),
+            ),
+          RadioListTile<_DeleteMode>(
+            title: const Text('Delete files only'),
+            subtitle:
+                const Text('Keep entry in Sonarr library to free disk space'),
+            value: _DeleteMode.deleteFilesOnly,
+            groupValue: _mode,
+            contentPadding: EdgeInsets.zero,
+            onChanged: (val) => setState(() {
+              if (val != null) _mode = val;
+            }),
+          ),
+          if (_mode == _DeleteMode.deleteFilesOnly)
+            Padding(
+              padding: const EdgeInsets.only(left: Insets.lg),
+              child: CheckboxListTile(
+                title: const Text('Unmonitor series'),
+                subtitle: const Text('Prevent automatic re-downloads'),
+                value: _unmonitor,
+                contentPadding: EdgeInsets.zero,
+                onChanged: (val) => setState(() => _unmonitor = val ?? false),
+              ),
+            ),
         ],
       ),
-      actions: [
+      actions: <Widget>[
         TextButton(
           onPressed: () => Navigator.pop(context),
           child: const Text('Cancel'),
@@ -1215,13 +1254,39 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
             );
 
             Object? error;
+            int successCount = 0;
+            int failedCount = 0;
             try {
               final api =
                   await ref.read(sonarrApiProvider(widget.instance).future);
-              await api.bulkDeleteSeries(
-                widget.selectedIds.toList(),
-                deleteFiles: _deleteFiles,
-              );
+              if (_mode == _DeleteMode.deleteEntry) {
+                await api.bulkDeleteSeries(
+                  widget.selectedIds.toList(),
+                  deleteFiles: _deleteFiles,
+                );
+              } else {
+                for (final id in widget.selectedIds) {
+                  try {
+                    final files = await api.getEpisodeFiles(id);
+                    for (final f in files) {
+                      final int? fId = f['id'] as int?;
+                      if (fId != null) {
+                        await api.deleteEpisodeFile(fId);
+                      }
+                    }
+                    if (_unmonitor) {
+                      try {
+                        final raw = await api.getSeriesRaw(id);
+                        raw['monitored'] = false;
+                        await api.updateSeriesRaw(raw);
+                      } catch (_) {}
+                    }
+                    successCount++;
+                  } catch (_) {
+                    failedCount++;
+                  }
+                }
+              }
             } catch (e) {
               error = e;
             } finally {
@@ -1231,18 +1296,29 @@ class _BulkDeleteDialogState extends ConsumerState<_BulkDeleteDialog> {
             if (!context.mounted) return;
             if (error != null) {
               ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(content: Text('Error deleting series: $error')),
+                SnackBar(content: Text('Error: $error')),
               );
               return;
             }
             ref.invalidate(sonarrSeriesProvider(widget.instance));
             ref
                 .read(sonarrSeriesSelectionProvider(widget.instance).notifier)
-                .state = {};
+                .state = <int>{};
             Navigator.pop(context); // pop dialog
 
+            final String msg;
+            if (_mode == _DeleteMode.deleteEntry) {
+              msg = 'Successfully deleted ${widget.selectedIds.length} series';
+            } else if (failedCount == 0) {
+              msg = _unmonitor
+                  ? 'Successfully deleted files and unmonitored $successCount series'
+                  : 'Successfully deleted files for $successCount series';
+            } else {
+              msg = 'Deleted files for $successCount series. Failed for $failedCount series';
+            }
+
             ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Successfully deleted series')),
+              SnackBar(content: Text(msg)),
             );
           },
           child: const Text('Delete'),

--- a/services/service_sonarr/lib/src/series_detail_screen.dart
+++ b/services/service_sonarr/lib/src/series_detail_screen.dart
@@ -1348,27 +1348,44 @@ class _SeasonCard extends ConsumerWidget {
     WidgetRef ref,
   ) async {
     final theme = Theme.of(context);
+    bool unmonitor = false;
     final confirm = await showDialog<bool>(
       context: context,
-      builder: (context) => AlertDialog(
-        title: Text('Delete Season $seasonNumber Files'),
-        content: Text(
-          'Are you sure you want to delete all episode files for Season $seasonNumber? This will delete the files from disk and cannot be undone.',
-        ),
-        actions: <Widget>[
-          TextButton(
-            onPressed: () => Navigator.pop(context, false),
-            child: const Text('Cancel'),
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: Text('Delete Season $seasonNumber Files'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Are you sure you want to delete all episode files for Season $seasonNumber? This will delete the files from disk and cannot be undone.',
+              ),
+              const SizedBox(height: Insets.sm),
+              CheckboxListTile(
+                contentPadding: EdgeInsets.zero,
+                title: const Text('Unmonitor season'),
+                subtitle: const Text('Prevent automatic re-downloads'),
+                value: unmonitor,
+                onChanged: (v) => setState(() => unmonitor = v ?? false),
+              ),
+            ],
           ),
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: theme.colorScheme.error,
-              foregroundColor: theme.colorScheme.onError,
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel'),
             ),
-            onPressed: () => Navigator.pop(context, true),
-            child: const Text('Delete'),
-          ),
-        ],
+            FilledButton(
+              style: FilledButton.styleFrom(
+                backgroundColor: theme.colorScheme.error,
+                foregroundColor: theme.colorScheme.onError,
+              ),
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Delete'),
+            ),
+          ],
+        ),
       ),
     );
 
@@ -1390,6 +1407,9 @@ class _SeasonCard extends ConsumerWidget {
           .map((e) => e.episodeFileId!)
           .toList();
 
+      bool unmonitored = false;
+      Object? unmonitorError;
+
       try {
         final api = await ref.read(sonarrApiProvider(instance).future);
         for (final fileId in fileIds) {
@@ -1398,6 +1418,22 @@ class _SeasonCard extends ConsumerWidget {
             deletedCount++;
           } catch (e) {
             failedCount++;
+          }
+        }
+        if (unmonitor) {
+          try {
+            final Map<String, dynamic> raw = await api.getSeriesRaw(series.id);
+            final List<dynamic> seasons = (raw['seasons'] as List<dynamic>?) ?? <dynamic>[];
+            for (final dynamic s in seasons) {
+              if (s is Map<String, dynamic> && s['seasonNumber'] == seasonNumber) {
+                s['monitored'] = false;
+                break;
+              }
+            }
+            await api.updateSeriesRaw(raw);
+            unmonitored = true;
+          } catch (e) {
+            unmonitorError = e;
           }
         }
       } catch (e) {
@@ -1416,10 +1452,22 @@ class _SeasonCard extends ConsumerWidget {
       onRefreshed();
 
       if (context.mounted) {
-        if (failedCount == 0) {
+        if (unmonitor && !unmonitored) {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: Text('Successfully deleted $deletedCount file(s).'),
+              content: Text(
+                'Deleted $deletedCount file(s), but failed to unmonitor season: $unmonitorError',
+              ),
+            ),
+          );
+        } else if (failedCount == 0) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                unmonitored
+                    ? 'Successfully deleted $deletedCount file(s) and unmonitored season.'
+                    : 'Successfully deleted $deletedCount file(s).',
+              ),
             ),
           );
         } else {
@@ -1787,20 +1835,16 @@ void _showEpisodeBottomSheet({
                   const SizedBox(height: Insets.md),
                 ],
 
-                // Action buttons
+                // Action buttons bar (Single row, clean layout)
                 Row(
                   children: <Widget>[
                     // Monitor/Unmonitor Toggle
                     Expanded(
-                      child: OutlinedButton.icon(
-                        icon: Icon(
-                          episode.monitored
-                              ? Icons.bookmark
-                              : Icons.bookmark_border,
-                          size: 18,
+                      child: OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          visualDensity: VisualDensity.compact,
                         ),
-                        label:
-                            Text(episode.monitored ? 'Unmonitor' : 'Monitor'),
                         onPressed: () async {
                           Navigator.pop(context);
                           try {
@@ -1820,18 +1864,37 @@ void _showEpisodeBottomSheet({
                             }
                           }
                         },
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Icon(
+                              episode.monitored
+                                  ? Icons.bookmark
+                                  : Icons.bookmark_border,
+                              size: 16,
+                            ),
+                            const SizedBox(width: 4),
+                            Flexible(
+                              child: Text(
+                                episode.monitored ? 'Unmonitor' : 'Monitor',
+                                style: const TextStyle(fontSize: 13),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                  ],
-                ),
-                const SizedBox(height: Insets.sm),
-                Row(
-                  children: <Widget>[
+                    const SizedBox(width: 6),
+
                     // Automatic Search
                     Expanded(
-                      child: FilledButton.icon(
-                        icon: const Icon(Icons.search, size: 18),
-                        label: const Text('Auto Search'),
+                      child: FilledButton(
+                        style: FilledButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          visualDensity: VisualDensity.compact,
+                        ),
                         onPressed: () async {
                           Navigator.pop(context);
                           try {
@@ -1858,15 +1921,32 @@ void _showEpisodeBottomSheet({
                             }
                           }
                         },
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Icon(Icons.search, size: 16),
+                            SizedBox(width: 4),
+                            Flexible(
+                              child: Text(
+                                'Auto Search',
+                                style: TextStyle(fontSize: 13),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
-                    const SizedBox(width: Insets.sm),
+                    const SizedBox(width: 6),
 
                     // Interactive Search
                     Expanded(
-                      child: OutlinedButton.icon(
-                        icon: const Icon(Icons.person_search, size: 18),
-                        label: const Text('Interactive'),
+                      child: OutlinedButton(
+                        style: OutlinedButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(horizontal: 4),
+                          visualDensity: VisualDensity.compact,
+                        ),
                         onPressed: () {
                           Navigator.pop(context);
                           pushScreen<void>(
@@ -1877,70 +1957,132 @@ void _showEpisodeBottomSheet({
                             ),
                           );
                         },
+                        child: const Row(
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: <Widget>[
+                            Icon(Icons.person_search, size: 16),
+                            SizedBox(width: 4),
+                            Flexible(
+                              child: Text(
+                                'Interactive',
+                                style: TextStyle(fontSize: 13),
+                                maxLines: 1,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                            ),
+                          ],
+                        ),
                       ),
                     ),
 
                     // Delete file (if has file)
                     if (episode.hasFile && episode.episodeFileId != null) ...[
-                      const SizedBox(width: Insets.sm),
-                      IconButton.filledTonal(
-                        icon: Icon(Icons.delete_outline, color: cs.error),
-                        onPressed: () async {
-                          Navigator.pop(context);
-                          final confirm = await showDialog<bool>(
-                            context: context,
-                            builder: (context) => AlertDialog(
-                              title: const Text('Delete Episode File'),
-                              content: const Text(
-                                'Are you sure? This will delete the file from disk and cannot be undone.',
+                      const SizedBox(width: Insets.xs),
+                      Tooltip(
+                        message: 'Delete File',
+                        child: IconButton.filledTonal(
+                          icon: Icon(Icons.delete_outline, color: cs.error),
+                          onPressed: () async {
+                            Navigator.pop(context);
+                            bool unmonitor = false;
+                            final confirm = await showDialog<bool>(
+                              context: context,
+                              builder: (context) => StatefulBuilder(
+                                builder: (context, setState) => AlertDialog(
+                                  title: const Text('Delete Episode File'),
+                                  content: Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: <Widget>[
+                                      const Text(
+                                        'Are you sure? This will delete the file from disk and cannot be undone.',
+                                      ),
+                                      const SizedBox(height: Insets.sm),
+                                      CheckboxListTile(
+                                        contentPadding: EdgeInsets.zero,
+                                        title: const Text('Unmonitor episode'),
+                                        subtitle: const Text('Prevent automatic re-downloads'),
+                                        value: unmonitor,
+                                        onChanged: (v) => setState(() => unmonitor = v ?? false),
+                                      ),
+                                    ],
+                                  ),
+                                  actions: <Widget>[
+                                    TextButton(
+                                      onPressed: () =>
+                                          Navigator.pop(context, false),
+                                      child: const Text('Cancel'),
+                                    ),
+                                    FilledButton(
+                                      style: FilledButton.styleFrom(
+                                        backgroundColor: cs.error,
+                                        foregroundColor: cs.onError,
+                                      ),
+                                      onPressed: () => Navigator.pop(context, true),
+                                      child: const Text('Delete'),
+                                    ),
+                                  ],
+                                ),
                               ),
-                              actions: <Widget>[
-                                TextButton(
-                                  onPressed: () =>
-                                      Navigator.pop(context, false),
-                                  child: const Text('Cancel'),
-                                ),
-                                FilledButton(
-                                  style: FilledButton.styleFrom(
-                                    backgroundColor: cs.error,
-                                    foregroundColor: cs.onError,
-                                  ),
-                                  onPressed: () => Navigator.pop(context, true),
-                                  child: const Text('Delete'),
-                                ),
-                              ],
-                            ),
-                          );
+                            );
 
-                          if (confirm == true) {
-                            try {
-                              final api = await ref
-                                  .read(sonarrApiProvider(instance).future);
-                              await api
-                                  .deleteEpisodeFile(episode.episodeFileId!);
-                              ref.invalidate(
-                                sonarrEpisodesProvider(
-                                  (instance, series.id),
-                                ),
-                              );
-                              if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text('File deleted.'),
+                            if (confirm == true) {
+                              try {
+                                final api = await ref
+                                    .read(sonarrApiProvider(instance).future);
+                                await api
+                                    .deleteEpisodeFile(episode.episodeFileId!);
+                                bool unmonitored = false;
+                                Object? unmonitorError;
+                                if (unmonitor) {
+                                  try {
+                                    await api.updateEpisodeMonitor(
+                                      episodeIds: <int>[episode.id],
+                                      monitored: false,
+                                    );
+                                    unmonitored = true;
+                                  } catch (e) {
+                                    unmonitorError = e;
+                                  }
+                                }
+                                ref.invalidate(
+                                  sonarrEpisodesProvider(
+                                    (instance, series.id),
                                   ),
                                 );
-                              }
-                            } catch (e) {
-                              if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text('Failed to delete: $e'),
-                                  ),
-                                );
+                                if (context.mounted) {
+                                  if (unmonitor && !unmonitored) {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text(
+                                          'File deleted, but failed to unmonitor episode: $unmonitorError',
+                                        ),
+                                      ),
+                                    );
+                                  } else {
+                                    ScaffoldMessenger.of(context).showSnackBar(
+                                      SnackBar(
+                                        content: Text(
+                                          unmonitored
+                                              ? 'File deleted and episode unmonitored.'
+                                              : 'File deleted.',
+                                        ),
+                                      ),
+                                    );
+                                  }
+                                }
+                              } catch (e) {
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: Text('Failed to delete: $e'),
+                                    ),
+                                  );
+                                }
                               }
                             }
-                          }
-                        },
+                          },
+                        ),
                       ),
                     ],
                   ],

--- a/site/src/components/hero.html
+++ b/site/src/components/hero.html
@@ -1,7 +1,7 @@
 <section class="hero-section">
   <div class="grid middle-align">
     <div class="s12 m6 hero-text-col center-align-mobile">
-      <div class="chip border round">v1.3.2 Release</div>
+      <div class="chip border round">v1.3.3 Release</div>
       <h1 class="hero-title">Your self-hosted media, unified.</h1>
       <p class="hero-subtitle">One premium Android app that fronts Sonarr, Radarr, Plex, Jellyfin, qBittorrent, and more. Material 3 Expressive, multi-instance, and fully secure.</p>
       <div class="row hero-actions">


### PR DESCRIPTION
Build 15, version codes 151, 152 and 153.

Ships PR #90: deleting a film or episode from disk while keeping the library entry, with an optional unmonitor (#77), the same thing in bulk from multi-select, and the detail action bar no longer wrapping its labels on narrow screens (#74). Also restores the app-wide bottom inset, so lists stop running underneath the system navigation buttons.