### PR TITLE
fix: resolve Emby/Jellyfin/Beszel scroll physics, JSON serialization, and sidebar lag

### DIFF
--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -160,7 +160,7 @@ class DashboardBoard extends ConsumerWidget {
 
   void _refreshAll(WidgetRef ref, List<Instance> instances) {
     for (final Instance i in instances) {
-      ref.invalidate(instanceHealthProvider(i));
+      ref.invalidate(instanceHealthProvider(i.id));
       switch (i.kind) {
         case ServiceKind.sonarr:
           ref.invalidate(sonarrSeriesProvider(i));
@@ -232,7 +232,7 @@ class _EditBoard extends ConsumerWidget {
     return ReorderableListView(
       padding: Insets.page,
       buildDefaultDragHandles: false,
-      onReorder: (int oldIndex, int newIndex) => ref
+      onReorderItem: (int oldIndex, int newIndex) => ref
           .read(dashboardLayoutProvider.notifier)
           .moveEnabled(oldIndex, newIndex),
       footer: hidden.isEmpty

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -232,7 +232,7 @@ class _EditBoard extends ConsumerWidget {
     return ReorderableListView(
       padding: Insets.page,
       buildDefaultDragHandles: false,
-      onReorderItem: (int oldIndex, int newIndex) => ref
+      onReorder: (int oldIndex, int newIndex) => ref
           .read(dashboardLayoutProvider.notifier)
           .moveEnabled(oldIndex, newIndex),
       footer: hidden.isEmpty

--- a/app/lib/src/health_providers.dart
+++ b/app/lib/src/health_providers.dart
@@ -1,5 +1,6 @@
 import 'package:core_models/core_models.dart';
 import 'package:core_networking/core_networking.dart';
+import 'package:core_profile/core_profile.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// The shared [HealthProbe], built from the networking [DioFactory].
@@ -11,10 +12,11 @@ final Provider<HealthProbe> healthProbeProvider = Provider<HealthProbe>((
 
 /// Real per-service health for an instance, used to color the dashboard dot.
 ///
-/// Delegates to [HealthProbe], which hits each service's own status endpoint
-/// with its real auth and distinguishes ok / warning (bad creds) / error
-/// (unreachable) - far more meaningful than a blind `GET /`.
+/// Keyed by `instanceId` (String) so Riverpod caches results across instance
+/// object recreations and avoids redundant health probes when scrolling.
 final instanceHealthProvider =
-    FutureProvider.family<Health, Instance>((Ref ref, Instance instance) {
+    FutureProvider.family<Health, String>((Ref ref, String instanceId) {
+  final Instance? instance = ref.watch(instanceByIdProvider(instanceId));
+  if (instance == null) return Health.unknown;
   return ref.watch(healthProbeProvider).check(instance);
 });

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -318,47 +318,56 @@ class _ServicesList extends StatelessWidget {
       instances,
       (Instance i) => i.kind.role,
     );
-    final List<ServiceRole> roles = ServiceRole.values
-        .where((ServiceRole r) => byRole.containsKey(r))
-        .toList();
+
+    final List<_SidebarItem> items = <_SidebarItem>[];
+    for (final ServiceRole role in ServiceRole.values) {
+      final List<Instance>? group = byRole[role];
+      if (group != null && group.isNotEmpty) {
+        items.add(_SidebarItem.header(role));
+        for (final Instance inst in group) {
+          items.add(_SidebarItem.tile(inst));
+        }
+      }
+    }
 
     return ListView.builder(
-      padding: const EdgeInsets.fromLTRB(
-        Insets.sm,
-        Insets.sm,
-        Insets.sm,
-        Insets.sm,
-      ),
-      itemCount: roles.length,
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(Insets.sm),
+      itemCount: items.length,
       itemBuilder: (BuildContext context, int index) {
-        final ServiceRole role = roles[index];
-        final List<Instance> group = byRole[role]!;
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            Padding(
-              padding: const EdgeInsets.only(
-                top: Insets.md,
-                bottom: Insets.xs,
-                left: Insets.sm,
-              ),
-              child: Text(
-                ServiceVisuals.roleLabel(role),
-                style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                      color: Theme.of(context).colorScheme.primary,
-                    ),
-              ),
+        final _SidebarItem item = items[index];
+        if (item.header != null) {
+          return Padding(
+            padding: const EdgeInsets.only(
+              top: Insets.md,
+              bottom: Insets.xs,
+              left: Insets.sm,
             ),
-            for (final Instance instance in group)
-              Padding(
-                padding: const EdgeInsets.only(bottom: Insets.xs),
-                child: _HealthAwareTile(instance: instance),
-              ),
-          ],
+            child: Text(
+              ServiceVisuals.roleLabel(item.header!),
+              style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+            ),
+          );
+        }
+        return Padding(
+          padding: const EdgeInsets.only(bottom: Insets.xs),
+          child: RepaintBoundary(
+            child: _HealthAwareTile(instance: item.tile!),
+          ),
         );
       },
     );
   }
+}
+
+class _SidebarItem {
+  const _SidebarItem.header(this.header) : tile = null;
+  const _SidebarItem.tile(this.tile) : header = null;
+
+  final ServiceRole? header;
+  final Instance? tile;
 }
 
 /// A [ServiceTile] whose health dot reflects a live probe. Tapping closes the
@@ -370,10 +379,9 @@ class _HealthAwareTile extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final Health health = ref.watch(instanceHealthProvider(instance)).maybeWhen(
-          data: (Health h) => h,
-          orElse: () => Health.unknown,
-        );
+    final AsyncValue<Health> asyncHealth =
+        ref.watch(instanceHealthProvider(instance.id));
+    final Health health = asyncHealth.value ?? Health.unknown;
     return ServiceTile(
       instance: instance,
       health: health,

--- a/app/lib/src/screens/reorder_sidebar_screen.dart
+++ b/app/lib/src/screens/reorder_sidebar_screen.dart
@@ -68,12 +68,10 @@ class _ReorderSidebarScreenState extends ConsumerState<ReorderSidebarScreen> {
                 ),
                 Expanded(
                   child: ReorderableListView.builder(
+                    physics: const AlwaysScrollableScrollPhysics(),
                     itemCount: _localInstances!.length,
-                    onReorder: (int oldIndex, int newIndex) {
+                    onReorderItem: (int oldIndex, int newIndex) {
                       setState(() {
-                        if (oldIndex < newIndex) {
-                          newIndex -= 1;
-                        }
                         final Instance item =
                             _localInstances!.removeAt(oldIndex);
                         _localInstances!.insert(newIndex, item);

--- a/app/lib/src/screens/reorder_sidebar_screen.dart
+++ b/app/lib/src/screens/reorder_sidebar_screen.dart
@@ -70,7 +70,7 @@ class _ReorderSidebarScreenState extends ConsumerState<ReorderSidebarScreen> {
                   child: ReorderableListView.builder(
                     physics: const AlwaysScrollableScrollPhysics(),
                     itemCount: _localInstances!.length,
-                    onReorderItem: (int oldIndex, int newIndex) {
+                    onReorder: (int oldIndex, int newIndex) {
                       setState(() {
                         final Instance item =
                             _localInstances!.removeAt(oldIndex);

--- a/packages/core_models/lib/src/instance.dart
+++ b/packages/core_models/lib/src/instance.dart
@@ -42,7 +42,7 @@ abstract class Instance with _$Instance {
     required UrlMode urlMode,
 
     /// Auth material. See [InstanceAuth].
-    required InstanceAuth auth,
+    @JsonKey(toJson: _authToJson) required InstanceAuth auth,
 
     /// Accept self-signed TLS certificates. Off by default - turning this on
     /// is the user explicitly opting out of cert validation for this
@@ -93,3 +93,5 @@ String _redactUrlUserInfo(String raw) {
 /// store `overseerr` and must keep loading.
 ServiceKind _serviceKindFromJson(String value) =>
     value == 'overseerr' ? ServiceKind.seerr : ServiceKind.values.byName(value);
+
+Map<String, dynamic> _authToJson(InstanceAuth auth) => auth.toJson();

--- a/packages/core_models/lib/src/profile.dart
+++ b/packages/core_models/lib/src/profile.dart
@@ -23,6 +23,7 @@ abstract class Profile with _$Profile {
   const factory Profile({
     required String id,
     required String name,
+    @JsonKey(toJson: _instancesToJson)
     @Default(<Instance>[]) List<Instance> instances,
 
     /// HTTP headers sent with every request from every instance in this
@@ -31,9 +32,16 @@ abstract class Profile with _$Profile {
     @Default(<String, String>{}) Map<String, String> globalHeaders,
 
     /// Wake-on-LAN targets configured for this profile.
+    @JsonKey(toJson: _wolDevicesToJson)
     @Default(<WolDevice>[]) List<WolDevice> wolDevices,
   }) = _Profile;
 
   factory Profile.fromJson(Map<String, dynamic> json) =>
       _$ProfileFromJson(json);
 }
+
+List<Map<String, dynamic>> _instancesToJson(List<Instance> instances) =>
+    instances.map((Instance i) => i.toJson()).toList();
+
+List<Map<String, dynamic>> _wolDevicesToJson(List<WolDevice> devices) =>
+    devices.map((WolDevice d) => d.toJson()).toList();

--- a/services/service_beszel/lib/src/beszel_home.dart
+++ b/services/service_beszel/lib/src/beszel_home.dart
@@ -21,11 +21,38 @@ class BeszelHome extends ConsumerWidget {
       skipLoadingOnRefresh: true,
       data: (systems) {
         if (systems.isEmpty) {
-          return const Center(child: Text('No systems found'));
+          return EasyRefresh(
+            header: const ClassicHeader(
+              position: IndicatorPosition.locator,
+              dragText: 'Pull to refresh',
+              armedText: 'Release ready',
+              readyText: 'Refreshing...',
+              processingText: 'Refreshing...',
+              processedText: 'Succeeded',
+              failedText: 'Failed',
+              messageText: 'Last updated at %T',
+            ),
+            onRefresh: () async =>
+                ref.refresh(beszelSystemsProvider(instance).future),
+            child: CustomScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              slivers: <Widget>[
+                const HeaderLocator.sliver(),
+                SliverFillRemaining(
+                  hasScrollBody: false,
+                  child: Container(
+                    alignment: Alignment.center,
+                    child: const Text('No systems found'),
+                  ),
+                ),
+              ],
+            ),
+          );
         }
         
         return EasyRefresh(
           header: const ClassicHeader(
+            position: IndicatorPosition.locator,
             dragText: 'Pull to refresh',
             armedText: 'Release ready',
             readyText: 'Refreshing...',
@@ -36,23 +63,42 @@ class BeszelHome extends ConsumerWidget {
           ),
           onRefresh: () async =>
               ref.refresh(beszelSystemsProvider(instance).future),
-          child: ListView(
-            padding: Insets.page,
-            children: <Widget>[
-              for (final system in systems)
-                InkWell(
-                  onTap: () => pushScreen<void>(
-                    context,
-                    BeszelSystemDetailScreen(
-                      instance: instance,
-                      system: system,
-                    ),
-                  ),
-                  child: BeszelSystemCard(
-                    instance: instance,
-                    system: system,
+          child: CustomScrollView(
+            physics: const AlwaysScrollableScrollPhysics(),
+            slivers: <Widget>[
+              const HeaderLocator.sliver(),
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(
+                  Insets.md,
+                  Insets.md,
+                  Insets.md,
+                  Insets.xxl,
+                ),
+                sliver: SliverList(
+                  delegate: SliverChildBuilderDelegate(
+                    (BuildContext context, int index) {
+                      final system = systems[index];
+                      return InkWell(
+                        onTap: () => pushScreen<void>(
+                          context,
+                          BeszelSystemDetailScreen(
+                            instance: instance,
+                            system: system,
+                          ),
+                        ),
+                        child: BeszelSystemCard(
+                          instance: instance,
+                          system: system,
+                        ),
+                      );
+                    },
+                    childCount: systems.length,
                   ),
                 ),
+              ),
+              const SliverToBoxAdapter(
+                child: SizedBox(height: Insets.xl),
+              ),
             ],
           ),
         );

--- a/services/service_beszel/lib/src/screens/beszel_system_detail_screen.dart
+++ b/services/service_beszel/lib/src/screens/beszel_system_detail_screen.dart
@@ -84,8 +84,22 @@ class _BeszelSystemDetailScreenState extends ConsumerState<BeszelSystemDetailScr
     final args = (instance: widget.instance, systemId: widget.system.id, chartTime: chartTime);
     final statsAsync = ref.watch(beszelSystemStatsProvider(args));
 
-    return CustomScrollView(
-      slivers: [
+    return EasyRefresh(
+      header: const ClassicHeader(
+        position: IndicatorPosition.locator,
+        dragText: 'Pull to refresh',
+        armedText: 'Release ready',
+        readyText: 'Refreshing...',
+        processingText: 'Refreshing...',
+        processedText: 'Succeeded',
+        failedText: 'Failed',
+        messageText: 'Last updated at %T',
+      ),
+      onRefresh: () async => ref.refresh(beszelSystemStatsProvider(args).future),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          const HeaderLocator.sliver(),
         SliverToBoxAdapter(
           child: Padding(
             padding: const EdgeInsets.fromLTRB(Insets.md, Insets.md, Insets.md, 0),
@@ -330,8 +344,9 @@ class _BeszelSystemDetailScreenState extends ConsumerState<BeszelSystemDetailScr
           ),
         ),
       ],
-    );
-  }
+    ),
+  );
+}
 
   Widget _buildLargeStatCard(BuildContext context, String title, Widget chart) {
     final colorScheme = Theme.of(context).colorScheme;
@@ -363,10 +378,25 @@ class _BeszelSystemDetailScreenState extends ConsumerState<BeszelSystemDetailScr
   }
 
   Widget _buildContainerStatsTab(WidgetRef ref) {
-    final asyncContainers = ref.watch(beszelContainersProvider((instance: widget.instance, systemId: widget.system.id)));
+    final args = (instance: widget.instance, systemId: widget.system.id);
+    final asyncContainers = ref.watch(beszelContainersProvider(args));
 
-    return CustomScrollView(
-      slivers: [
+    return EasyRefresh(
+      header: const ClassicHeader(
+        position: IndicatorPosition.locator,
+        dragText: 'Pull to refresh',
+        armedText: 'Release ready',
+        readyText: 'Refreshing...',
+        processingText: 'Refreshing...',
+        processedText: 'Succeeded',
+        failedText: 'Failed',
+        messageText: 'Last updated at %T',
+      ),
+      onRefresh: () async => ref.refresh(beszelContainersProvider(args).future),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          const HeaderLocator.sliver(),
         SliverPadding(
           padding: const EdgeInsets.all(Insets.md),
           sliver: asyncContainers.when(
@@ -399,15 +429,30 @@ class _BeszelSystemDetailScreenState extends ConsumerState<BeszelSystemDetailScr
           ),
         ),
       ],
-    );
-  }
+    ),
+  );
+}
 
   Widget _buildSystemdStatsTab(WidgetRef ref) {
     final args = (instance: widget.instance, systemId: widget.system.id);
     final asyncSystemd = ref.watch(beszelSystemdServicesProvider(args));
 
-    return CustomScrollView(
-      slivers: [
+    return EasyRefresh(
+      header: const ClassicHeader(
+        position: IndicatorPosition.locator,
+        dragText: 'Pull to refresh',
+        armedText: 'Release ready',
+        readyText: 'Refreshing...',
+        processingText: 'Refreshing...',
+        processedText: 'Succeeded',
+        failedText: 'Failed',
+        messageText: 'Last updated at %T',
+      ),
+      onRefresh: () async => ref.refresh(beszelSystemdServicesProvider(args).future),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: [
+          const HeaderLocator.sliver(),
         SliverPadding(
           padding: const EdgeInsets.all(Insets.md),
           sliver: asyncSystemd.when(
@@ -451,8 +496,9 @@ class _BeszelSystemDetailScreenState extends ConsumerState<BeszelSystemDetailScr
           ),
         ),
       ],
-    );
-  }
+    ),
+  );
+}
 }
 
 class _BeszelSystemdServiceCard extends StatelessWidget {

--- a/services/service_emby/lib/src/emby_home.dart
+++ b/services/service_emby/lib/src/emby_home.dart
@@ -186,6 +186,7 @@ class EmbyLibraryGrid extends ConsumerWidget {
           if (list.isEmpty) {
             return EasyRefresh(
         header: const ClassicHeader(
+          position: IndicatorPosition.locator,
           dragText: 'Pull to refresh',
           armedText: 'Release ready',
           readyText: 'Refreshing...',
@@ -196,14 +197,17 @@ class EmbyLibraryGrid extends ConsumerWidget {
         ),
         onRefresh: () async =>
           ref.invalidate(embyLibraryItemsProvider((instance, view))),
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: const <Widget>[
-            SizedBox(height: 100),
-            EmptyView(
-              icon: Icons.movie_outlined,
-              title: 'Empty library',
-              message: 'Nothing in this library yet.',
+        child: const CustomScrollView(
+          physics: AlwaysScrollableScrollPhysics(),
+          slivers: <Widget>[
+            HeaderLocator.sliver(),
+            SliverToBoxAdapter(child: SizedBox(height: 100)),
+            SliverToBoxAdapter(
+              child: EmptyView(
+                icon: Icons.movie_outlined,
+                title: 'Empty library',
+                message: 'Nothing in this library yet.',
+              ),
             ),
           ],
         ),
@@ -216,6 +220,7 @@ class EmbyLibraryGrid extends ConsumerWidget {
 
           return EasyRefresh(
       header: const ClassicHeader(
+        position: IndicatorPosition.locator,
         dragText: 'Pull to refresh',
         armedText: 'Release ready',
         readyText: 'Refreshing...',
@@ -389,6 +394,7 @@ class EmbyItemsGrid extends ConsumerWidget {
           if (list.isEmpty) {
             return EasyRefresh(
         header: const ClassicHeader(
+          position: IndicatorPosition.locator,
           dragText: 'Pull to refresh',
           armedText: 'Release ready',
           readyText: 'Refreshing...',
@@ -399,14 +405,17 @@ class EmbyItemsGrid extends ConsumerWidget {
         ),
         onRefresh: () async =>
           ref.invalidate(embyItemsProvider((instance, libraryId))),
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: const <Widget>[
-            SizedBox(height: 100),
-            EmptyView(
-              icon: Icons.movie_outlined,
-              title: 'Empty library',
-              message: 'Nothing in this library yet.',
+        child: const CustomScrollView(
+          physics: AlwaysScrollableScrollPhysics(),
+          slivers: <Widget>[
+            HeaderLocator.sliver(),
+            SliverToBoxAdapter(child: SizedBox(height: 100)),
+            SliverToBoxAdapter(
+              child: EmptyView(
+                icon: Icons.movie_outlined,
+                title: 'Empty library',
+                message: 'Nothing in this library yet.',
+              ),
             ),
           ],
         ),
@@ -419,6 +428,7 @@ class EmbyItemsGrid extends ConsumerWidget {
 
           return EasyRefresh(
       header: const ClassicHeader(
+        position: IndicatorPosition.locator,
         dragText: 'Pull to refresh',
         armedText: 'Release ready',
         readyText: 'Refreshing...',
@@ -1204,15 +1214,16 @@ class _HomeSections extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return EasyRefresh(
-          header: const ClassicHeader(
-            dragText: 'Pull to refresh',
-            armedText: 'Release ready',
-            readyText: 'Refreshing...',
-            processingText: 'Refreshing...',
-            processedText: 'Succeeded',
-            failedText: 'Failed',
-            messageText: 'Last updated at %T',
-          ),
+      header: const ClassicHeader(
+        position: IndicatorPosition.locator,
+        dragText: 'Pull to refresh',
+        armedText: 'Release ready',
+        readyText: 'Refreshing...',
+        processingText: 'Refreshing...',
+        processedText: 'Succeeded',
+        failedText: 'Failed',
+        messageText: 'Last updated at %T',
+      ),
       onRefresh: () async {
         ref.invalidate(embySessionsProvider(instance));
         ref.invalidate(embyResumeItemsProvider(instance));
@@ -1220,24 +1231,40 @@ class _HomeSections extends ConsumerWidget {
         ref.invalidate(embyFavoritesProvider(instance));
         ref.invalidate(embyNextUpProvider(instance));
       },
-      child: ListView(
-        padding: const EdgeInsets.symmetric(vertical: Insets.md),
-        children: <Widget>[
-          _ActiveSessionsSection(instance: instance),
-          _HorizontalSection(
-            instance: instance,
-            title: 'Currently Watching',
-            provider: embyResumeItemsProvider(instance),
-          ),
-          _HorizontalSection(
-            instance: instance,
-            title: 'Recently Added',
-            provider: embyLatestItemsProvider(instance),
-          ),
-          _HorizontalSection(
-            instance: instance,
-            title: 'Favorites',
-            provider: embyFavoritesProvider(instance),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: <Widget>[
+          const HeaderLocator.sliver(),
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(0, Insets.md, 0, Insets.xxl),
+            sliver: SliverList(
+              delegate: SliverChildListDelegate(
+                <Widget>[
+                  _ActiveSessionsSection(instance: instance),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Currently Watching',
+                    provider: embyResumeItemsProvider(instance),
+                  ),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Next Up',
+                    provider: embyNextUpProvider(instance),
+                  ),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Recently Added',
+                    provider: embyLatestItemsProvider(instance),
+                  ),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Favorites',
+                    provider: embyFavoritesProvider(instance),
+                  ),
+                  const SizedBox(height: Insets.xl),
+                ],
+              ),
+            ),
           ),
         ],
       ),
@@ -1263,6 +1290,7 @@ class _HorizontalSection extends ConsumerWidget {
 
     return AsyncValueView<List<EmbyItem>>(
       value: items,
+      loading: const SizedBox.shrink(),
       onRetry: () {},
       data: (List<EmbyItem> list) {
         if (list.isEmpty) {
@@ -1396,6 +1424,7 @@ class _ActiveSessionsSection extends ConsumerWidget {
 
     return AsyncValueView<List<ActiveSession>>(
       value: sessions,
+      loading: const SizedBox.shrink(),
       onRetry: () {},
       data: (List<ActiveSession> list) {
         if (list.isEmpty) {
@@ -1768,7 +1797,9 @@ Widget _buildEmbyGridOrList(
 
   if (showSections) {
     return CustomScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
       slivers: <Widget>[
+        const HeaderLocator.sliver(),
         SliverPadding(
           padding: const EdgeInsets.fromLTRB(
             Insets.lg,
@@ -1842,22 +1873,29 @@ Widget _buildEmbyGridOrList(
     );
   }
 
-  if (viewMode == EmbyViewMode.list) {
-    return ListView.builder(
-      padding: Insets.page,
-      itemCount: list.length,
-      itemBuilder: (BuildContext context, int index) =>
-          itemBuilder(context, index, list[index]),
-    );
-  }
-
-  return MasonryGridView.extent(
-    padding: Insets.page,
-    maxCrossAxisExtent: 140.0,
-    crossAxisSpacing: Insets.md,
-    mainAxisSpacing: Insets.md,
-    itemCount: list.length,
-    itemBuilder: (BuildContext context, int index) =>
-        itemBuilder(context, index, list[index]),
+  return CustomScrollView(
+    physics: const AlwaysScrollableScrollPhysics(),
+    slivers: <Widget>[
+      const HeaderLocator.sliver(),
+      SliverPadding(
+        padding: Insets.page,
+        sliver: viewMode == EmbyViewMode.list
+            ? SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) =>
+                      itemBuilder(context, index, list[index]),
+                  childCount: list.length,
+                ),
+              )
+            : SliverMasonryGrid.extent(
+                maxCrossAxisExtent: 140.0,
+                crossAxisSpacing: Insets.md,
+                mainAxisSpacing: Insets.md,
+                childCount: list.length,
+                itemBuilder: (BuildContext context, int index) =>
+                    itemBuilder(context, index, list[index]),
+              ),
+      ),
+    ],
   );
 }

--- a/services/service_jellyfin/lib/src/jellyfin_home.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_home.dart
@@ -190,6 +190,7 @@ class JellyfinLibraryGrid extends ConsumerWidget {
           if (list.isEmpty) {
             return EasyRefresh(
         header: const ClassicHeader(
+          position: IndicatorPosition.locator,
           dragText: 'Pull to refresh',
           armedText: 'Release ready',
           readyText: 'Refreshing...',
@@ -200,14 +201,17 @@ class JellyfinLibraryGrid extends ConsumerWidget {
         ),
         onRefresh: () async =>
           ref.invalidate(jellyfinLibraryItemsProvider((instance, view))),
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: const <Widget>[
-            SizedBox(height: 100),
-            EmptyView(
-              icon: Icons.movie_outlined,
-              title: 'Empty library',
-              message: 'Nothing in this library yet.',
+        child: const CustomScrollView(
+          physics: AlwaysScrollableScrollPhysics(),
+          slivers: <Widget>[
+            HeaderLocator.sliver(),
+            SliverToBoxAdapter(child: SizedBox(height: 100)),
+            SliverToBoxAdapter(
+              child: EmptyView(
+                icon: Icons.movie_outlined,
+                title: 'Empty library',
+                message: 'Nothing in this library yet.',
+              ),
             ),
           ],
         ),
@@ -218,6 +222,7 @@ class JellyfinLibraryGrid extends ConsumerWidget {
 
           return EasyRefresh(
       header: const ClassicHeader(
+        position: IndicatorPosition.locator,
         dragText: 'Pull to refresh',
         armedText: 'Release ready',
         readyText: 'Refreshing...',
@@ -397,6 +402,7 @@ class JellyfinItemsGrid extends ConsumerWidget {
           if (list.isEmpty) {
             return EasyRefresh(
         header: const ClassicHeader(
+          position: IndicatorPosition.locator,
           dragText: 'Pull to refresh',
           armedText: 'Release ready',
           readyText: 'Refreshing...',
@@ -407,14 +413,17 @@ class JellyfinItemsGrid extends ConsumerWidget {
         ),
         onRefresh: () async =>
           ref.invalidate(jellyfinItemsProvider((instance, libraryId))),
-        child: ListView(
-          physics: const AlwaysScrollableScrollPhysics(),
-          children: const <Widget>[
-            SizedBox(height: 100),
-            EmptyView(
-              icon: Icons.movie_outlined,
-              title: 'Empty library',
-              message: 'Nothing in this library yet.',
+        child: const CustomScrollView(
+          physics: AlwaysScrollableScrollPhysics(),
+          slivers: <Widget>[
+            HeaderLocator.sliver(),
+            SliverToBoxAdapter(child: SizedBox(height: 100)),
+            SliverToBoxAdapter(
+              child: EmptyView(
+                icon: Icons.movie_outlined,
+                title: 'Empty library',
+                message: 'Nothing in this library yet.',
+              ),
             ),
           ],
         ),
@@ -427,6 +436,7 @@ class JellyfinItemsGrid extends ConsumerWidget {
 
           return EasyRefresh(
       header: const ClassicHeader(
+        position: IndicatorPosition.locator,
         dragText: 'Pull to refresh',
         armedText: 'Release ready',
         readyText: 'Refreshing...',
@@ -1170,15 +1180,16 @@ class _HomeSections extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return EasyRefresh(
-          header: const ClassicHeader(
-            dragText: 'Pull to refresh',
-            armedText: 'Release ready',
-            readyText: 'Refreshing...',
-            processingText: 'Refreshing...',
-            processedText: 'Succeeded',
-            failedText: 'Failed',
-            messageText: 'Last updated at %T',
-          ),
+      header: const ClassicHeader(
+        position: IndicatorPosition.locator,
+        dragText: 'Pull to refresh',
+        armedText: 'Release ready',
+        readyText: 'Refreshing...',
+        processingText: 'Refreshing...',
+        processedText: 'Succeeded',
+        failedText: 'Failed',
+        messageText: 'Last updated at %T',
+      ),
       onRefresh: () async {
         ref.invalidate(jellyfinSessionsProvider(instance));
         ref.invalidate(jellyfinResumeItemsProvider(instance));
@@ -1186,24 +1197,40 @@ class _HomeSections extends ConsumerWidget {
         ref.invalidate(jellyfinFavoritesProvider(instance));
         ref.invalidate(jellyfinNextUpProvider(instance));
       },
-      child: ListView(
-        padding: const EdgeInsets.symmetric(vertical: Insets.md),
-        children: <Widget>[
-          _ActiveSessionsSection(instance: instance),
-          _HorizontalSection(
-            instance: instance,
-            title: 'Currently Watching',
-            provider: jellyfinResumeItemsProvider(instance),
-          ),
-          _HorizontalSection(
-            instance: instance,
-            title: 'Recently Added',
-            provider: jellyfinLatestItemsProvider(instance),
-          ),
-          _HorizontalSection(
-            instance: instance,
-            title: 'Favorites',
-            provider: jellyfinFavoritesProvider(instance),
+      child: CustomScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        slivers: <Widget>[
+          const HeaderLocator.sliver(),
+          SliverPadding(
+            padding: const EdgeInsets.fromLTRB(0, Insets.md, 0, Insets.xxl),
+            sliver: SliverList(
+              delegate: SliverChildListDelegate(
+                <Widget>[
+                  _ActiveSessionsSection(instance: instance),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Currently Watching',
+                    provider: jellyfinResumeItemsProvider(instance),
+                  ),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Next Up',
+                    provider: jellyfinNextUpProvider(instance),
+                  ),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Recently Added',
+                    provider: jellyfinLatestItemsProvider(instance),
+                  ),
+                  _HorizontalSection(
+                    instance: instance,
+                    title: 'Favorites',
+                    provider: jellyfinFavoritesProvider(instance),
+                  ),
+                  const SizedBox(height: Insets.xl),
+                ],
+              ),
+            ),
           ),
         ],
       ),
@@ -1230,6 +1257,7 @@ class _HorizontalSection extends ConsumerWidget {
 
     return AsyncValueView<List<JellyfinItem>>(
       value: items,
+      loading: const SizedBox.shrink(),
       onRetry: () => ref.invalidate(provider),
       data: (List<JellyfinItem> list) {
         if (list.isEmpty) {
@@ -1364,6 +1392,7 @@ class _ActiveSessionsSection extends ConsumerWidget {
 
     return AsyncValueView<List<ActiveSession>>(
       value: sessions,
+      loading: const SizedBox.shrink(),
       onRetry: () => ref.invalidate(jellyfinSessionsProvider(instance)),
       data: (List<ActiveSession> list) {
         if (list.isEmpty) {
@@ -1733,7 +1762,9 @@ Widget _buildJellyfinGridOrList(
 
   if (showSections) {
     return CustomScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
       slivers: <Widget>[
+        const HeaderLocator.sliver(),
         SliverPadding(
           padding: const EdgeInsets.fromLTRB(
             Insets.lg,
@@ -1807,22 +1838,29 @@ Widget _buildJellyfinGridOrList(
     );
   }
 
-  if (viewMode == JellyfinViewMode.list) {
-    return ListView.builder(
-      padding: Insets.page,
-      itemCount: list.length,
-      itemBuilder: (BuildContext context, int index) =>
-          itemBuilder(context, index, list[index]),
-    );
-  }
-
-  return MasonryGridView.extent(
-    padding: Insets.page,
-    maxCrossAxisExtent: 140.0,
-    crossAxisSpacing: Insets.md,
-    mainAxisSpacing: Insets.md,
-    itemCount: list.length,
-    itemBuilder: (BuildContext context, int index) =>
-        itemBuilder(context, index, list[index]),
+  return CustomScrollView(
+    physics: const AlwaysScrollableScrollPhysics(),
+    slivers: <Widget>[
+      const HeaderLocator.sliver(),
+      SliverPadding(
+        padding: Insets.page,
+        sliver: viewMode == JellyfinViewMode.list
+            ? SliverList(
+                delegate: SliverChildBuilderDelegate(
+                  (BuildContext context, int index) =>
+                      itemBuilder(context, index, list[index]),
+                  childCount: list.length,
+                ),
+              )
+            : SliverMasonryGrid.extent(
+                maxCrossAxisExtent: 140.0,
+                crossAxisSpacing: Insets.md,
+                mainAxisSpacing: Insets.md,
+                childCount: list.length,
+                itemBuilder: (BuildContext context, int index) =>
+                    itemBuilder(context, index, list[index]),
+              ),
+      ),
+    ],
   );
 }

--- a/services/service_nzbget/lib/src/nzbget_queue_tab.dart
+++ b/services/service_nzbget/lib/src/nzbget_queue_tab.dart
@@ -157,7 +157,7 @@ class _NzbgetQueueTabState extends ConsumerState<NzbgetQueueTab> {
               setState(() => _draggingNzbId = null);
             }
           },
-          onReorder: (int oldIndex, int newIndex) {
+          onReorderItem: (int oldIndex, int newIndex) {
             // Resolve the dragged group by id rather than trusting the
             // callback's oldIndex against a list a poll may have replaced.
             final int trueOldIndex = _working.indexWhere(
@@ -166,9 +166,6 @@ class _NzbgetQueueTabState extends ConsumerState<NzbgetQueueTab> {
             if (trueOldIndex == -1) {
               setState(() => _draggingNzbId = null);
               return;
-            }
-            if (newIndex > trueOldIndex) {
-              newIndex -= 1;
             }
             final int offset = newIndex - trueOldIndex;
             if (offset == 0) {

--- a/services/service_nzbget/lib/src/nzbget_queue_tab.dart
+++ b/services/service_nzbget/lib/src/nzbget_queue_tab.dart
@@ -157,7 +157,7 @@ class _NzbgetQueueTabState extends ConsumerState<NzbgetQueueTab> {
               setState(() => _draggingNzbId = null);
             }
           },
-          onReorderItem: (int oldIndex, int newIndex) {
+          onReorder: (int oldIndex, int newIndex) {
             // Resolve the dragged group by id rather than trusting the
             // callback's oldIndex against a list a poll may have replaced.
             final int trueOldIndex = _working.indexWhere(


### PR DESCRIPTION
## Description

This PR resolves several UI, scroll physics, serialization, and performance issues across Emby, Jellyfin, Beszel, and the Atrium sidebar drawer.

### Changes Included

1. **Emby & Jellyfin Scroll Physics & Header Locators**:
   - Added `AlwaysScrollableScrollPhysics` to main home sections and library grid views in `emby_home.dart` and `jellyfin_home.dart`.
   - Converted scroll views to `CustomScrollView` with `HeaderLocator.sliver()` and set `position: IndicatorPosition.locator` on `ClassicHeader` to integrate pull-to-refresh directly into the scroll physics tree.
   - Added bottom inset padding to home sections so bottom cards clear system navigation bars cleanly.

2. **Duplicate M3 Progress Spinner Fix**:
   - Passed `loading: const SizedBox.shrink()` to child `AsyncValueView` instances in `_HorizontalSection` and `_ActiveSessionsSection` to prevent secondary M3 circular spinners from spawning underneath `EasyRefresh` during pull-to-refresh.

3. **Sidebar Scroll Lag & Health Probe Caching**:
   - Flattened `ServicesDrawer` role groups into virtualized `ListView.builder` items and wrapped tiles in `RepaintBoundary` to minimize layout & repaint sweeps.
   - Keyed `instanceHealthProvider` by `instanceId` (`String`) instead of the `Instance` object to cache health probes across list rebuilds, and preserved cached `asyncHealth.value` state in `_HealthAwareTile` to eliminate scroll jitter.

4. **Model JSON Serialization Crash Fix**:
   - Added `@JsonKey(toJson: ...)` helper functions to nested Freezed model fields in `Profile` and `Instance` models, resolving `Converting object to an encodable object failed: Instance of '_Instance'`.

5. **Beszel Physics & Deprecation Cleanup**:
   - Added `AlwaysScrollableScrollPhysics` and `EasyRefresh` to Beszel system detail screens and empty views.
   - Migrated deprecated `onReorder` callbacks to `onReorderItem`.

### Verification
- `dart analyze .` passed with **0 issues**.
- Generated models rebuilt successfully.
