### PR TITLE
refactor: 2-tier OpenAPI generator and typed clients for Sonarr, Lidarr, Ombi, and Tracearr

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,3 +44,5 @@ workspace:
   - services/service_speedtest_tracker
   - services/service_tracearr
   - services/service_beszel
+  - services/service_lidarr
+  - services/service_ombi

--- a/services/service_lidarr/.gitignore
+++ b/services/service_lidarr/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated OpenAPI client & freezed model code
+lib/src/generated/

--- a/services/service_lidarr/lib/service_lidarr.dart
+++ b/services/service_lidarr/lib/service_lidarr.dart
@@ -1,0 +1,4 @@
+export 'src/generated/generated.dart';
+export 'src/services/lidarr_album_service.dart';
+export 'src/services/lidarr_artist_service.dart';
+export 'src/services/lidarr_client.dart';

--- a/services/service_lidarr/lib/src/services/lidarr_album_service.dart
+++ b/services/service_lidarr/lib/src/services/lidarr_album_service.dart
@@ -1,0 +1,26 @@
+import '../generated/api/raw_album_api.dart';
+import '../generated/models/album_resource.dart';
+import '../generated/responses/lidarr_exception.dart';
+
+/// High-level service wrapper for Lidarr Album operations.
+class LidarrAlbumService {
+  final RawAlbumApi _rawAlbumApi;
+
+  LidarrAlbumService(this._rawAlbumApi);
+
+  /// Retrieves albums in Lidarr, optionally filtered by artistId.
+  Future<List<AlbumResource>> getAlbums({String? artistId}) async {
+    final response = await _rawAlbumApi.getAlbum(artistId: artistId);
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw LidarrException(
+        response.error!.message ?? 'Failed to fetch albums',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw LidarrException('Failed to fetch albums', statusCode: response.statusCode);
+  }
+}

--- a/services/service_lidarr/lib/src/services/lidarr_artist_service.dart
+++ b/services/service_lidarr/lib/src/services/lidarr_artist_service.dart
@@ -1,0 +1,60 @@
+import '../generated/api/raw_artist_api.dart';
+import '../generated/api/raw_artist_lookup_api.dart';
+import '../generated/models/artist_resource.dart';
+import '../generated/responses/lidarr_exception.dart';
+
+/// High-level service wrapper for Lidarr Artist operations.
+class LidarrArtistService {
+  final RawArtistApi _rawArtistApi;
+  final RawArtistLookupApi _rawArtistLookupApi;
+
+  LidarrArtistService(this._rawArtistApi, this._rawArtistLookupApi);
+
+  /// Retrieves all artists monitored in Lidarr.
+  Future<List<ArtistResource>> getArtists({String? mbId}) async {
+    final response = await _rawArtistApi.getArtist(mbId: mbId);
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw LidarrException(
+        response.error!.message ?? 'Failed to fetch artists',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw LidarrException('Failed to fetch artists', statusCode: response.statusCode);
+  }
+
+  /// Retrieves a specific artist by ID.
+  Future<ArtistResource?> getArtistById(String id) async {
+    final response = await _rawArtistApi.getArtistById(id: id);
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw LidarrException(
+        response.error!.message ?? 'Failed to fetch artist',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw LidarrException('Failed to fetch artist', statusCode: response.statusCode);
+  }
+
+  /// Searches for artists by term.
+  Future<List<ArtistResource>> searchArtist(String term) async {
+    final response = await _rawArtistLookupApi.getArtistLookup(term: term);
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw LidarrException(
+        response.error!.message ?? 'Artist lookup failed',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw LidarrException('Artist lookup failed', statusCode: response.statusCode);
+  }
+}

--- a/services/service_lidarr/lib/src/services/lidarr_client.dart
+++ b/services/service_lidarr/lib/src/services/lidarr_client.dart
@@ -1,0 +1,49 @@
+import 'package:dio/dio.dart';
+
+import '../generated/api/raw_album_api.dart';
+import '../generated/api/raw_artist_api.dart';
+import '../generated/api/raw_artist_lookup_api.dart';
+import '../generated/api/raw_command_api.dart';
+import '../generated/api/raw_history_api.dart';
+import '../generated/api/raw_queue_api.dart';
+
+import 'lidarr_album_service.dart';
+import 'lidarr_artist_service.dart';
+
+/// Central client for Lidarr API services.
+class LidarrClient {
+  final Dio dio;
+  final String baseUrl;
+  final String? apiKey;
+
+  late final RawArtistApi rawArtistApi;
+  late final RawArtistLookupApi rawArtistLookupApi;
+  late final RawAlbumApi rawAlbumApi;
+  late final RawQueueApi rawQueueApi;
+  late final RawHistoryApi rawHistoryApi;
+  late final RawCommandApi rawCommandApi;
+
+  late final LidarrArtistService artistService;
+  late final LidarrAlbumService albumService;
+
+  LidarrClient({
+    Dio? dio,
+    required this.baseUrl,
+    this.apiKey,
+  }) : dio = dio ?? Dio() {
+    this.dio.options.baseUrl = baseUrl.endsWith('/') ? baseUrl : '$baseUrl/';
+    if (apiKey != null && apiKey!.isNotEmpty) {
+      this.dio.options.headers['X-Api-Key'] = apiKey;
+    }
+
+    rawArtistApi = RawArtistApi(this.dio);
+    rawArtistLookupApi = RawArtistLookupApi(this.dio);
+    rawAlbumApi = RawAlbumApi(this.dio);
+    rawQueueApi = RawQueueApi(this.dio);
+    rawHistoryApi = RawHistoryApi(this.dio);
+    rawCommandApi = RawCommandApi(this.dio);
+
+    artistService = LidarrArtistService(rawArtistApi, rawArtistLookupApi);
+    albumService = LidarrAlbumService(rawAlbumApi);
+  }
+}

--- a/services/service_lidarr/pubspec.yaml
+++ b/services/service_lidarr/pubspec.yaml
@@ -1,5 +1,5 @@
-name: service_sonarr
-description: Sonarr v3 API client and UI screens for Atrium.
+name: service_lidarr
+description: Lidarr API client, generated models, and service adapters for Atrium.
 publish_to: none
 resolution: workspace
 
@@ -8,29 +8,17 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
-  cached_network_image: ^3.4.1
   collection: ^1.18.0
-  core_models:
-  core_networking:
-  core_profile:
-  core_router:
-  core_storage:
-  core_ui:
   dio: ^5.7.0
   flutter:
     sdk: flutter
-  flutter_riverpod: ^3.3.2
   freezed_annotation: ^3.1.0
-  go_router: ^17.3.0
-  hive_ce: ^2.10.1
-  intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
-  progress_indicator_m3e:
-  url_launcher: ^6.3.2
 
 dev_dependencies:
   build_runner: ^2.4.13
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
   freezed: ^3.2.5

--- a/services/service_lidarr/test/lidarr_parser_test.dart
+++ b/services/service_lidarr/test/lidarr_parser_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+void main() {
+  group('Lidarr Generated Specs & Models Test', () {
+    test('ArtistResource serialization and deserialization', () {
+      final json = {
+        'id': 42,
+        'artistName': 'Daft Punk',
+        'foreignArtistId': 'a70445a7-2d5d-4775-b198-88ed3e3692ea',
+        'monitored': true,
+      };
+
+      final model = ArtistResource.fromJson(json);
+      expect(model.id, equals(42));
+      expect(model.artistName, equals('Daft Punk'));
+      expect(model.monitored, equals(true));
+
+      final toJsonResult = model.toJson();
+      expect(toJsonResult['id'], equals(42));
+      expect(toJsonResult['artistName'], equals('Daft Punk'));
+    });
+
+    test('LidarrError and Exception parsing', () {
+      final errorJson = {
+        'message': 'Artist not found',
+        'description': 'The requested artist ID does not exist',
+        'status': 404,
+      };
+
+      final lidarrError = LidarrError.fromJson(errorJson);
+      expect(lidarrError.message, equals('Artist not found'));
+
+      final exception = LidarrException(
+        lidarrError.message!,
+        statusCode: 404,
+        error: lidarrError,
+      );
+      expect(exception.statusCode, equals(404));
+      expect(exception.toString(), contains('Artist not found'));
+    });
+
+    test('LidarrClient initialization', () {
+      final client = LidarrClient(
+        baseUrl: 'http://localhost:8686',
+        apiKey: 'test-lidarr-api-key',
+      );
+
+      expect(client.baseUrl, equals('http://localhost:8686'));
+      expect(client.dio.options.baseUrl, equals('http://localhost:8686/'));
+      expect(client.apiKey, equals('test-lidarr-api-key'));
+    });
+  });
+}

--- a/services/service_lidarr/tool/openapi.json
+++ b/services/service_lidarr/tool/openapi.json
@@ -1,0 +1,13102 @@
+{
+  "openapi": "3.0.4",
+  "info": {
+    "title": "Lidarr",
+    "description": "Lidarr API docs",
+    "license": {
+      "name": "GPL-3.0",
+      "url": "https://github.com/Lidarr/Lidarr/blob/develop/LICENSE.md"
+    },
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "{protocol}://{hostpath}",
+      "variables": {
+        "protocol": {
+          "default": "http",
+          "enum": [
+            "http",
+            "https"
+          ]
+        },
+        "hostpath": {
+          "default": "localhost:8686"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api/v1/album": {
+      "get": {
+        "tags": [
+          "Album"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "foreignAlbumId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeAllArtistAlbums",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Album"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/album/{id}": {
+      "put": {
+        "tags": [
+          "Album"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Album"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "deleteFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "addImportListExclusion",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Album"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/album/monitor": {
+      "put": {
+        "tags": [
+          "Album"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumsMonitoredResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumsMonitoredResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumsMonitoredResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/album/lookup": {
+      "get": {
+        "tags": [
+          "AlbumLookup"
+        ],
+        "parameters": [
+          {
+            "name": "term",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/albumstudio": {
+      "post": {
+        "tags": [
+          "AlbumStudio"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AlbumStudioResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api": {
+      "get": {
+        "tags": [
+          "ApiInfo"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/artist/{id}": {
+      "get": {
+        "tags": [
+          "Artist"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtistResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtistResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtistResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Artist"
+        ],
+        "parameters": [
+          {
+            "name": "moveFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtistResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Artist"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "deleteFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "addImportListExclusion",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/artist": {
+      "get": {
+        "tags": [
+          "Artist"
+        ],
+        "parameters": [
+          {
+            "name": "mbId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtistResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Artist"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtistResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/artist/editor": {
+      "put": {
+        "tags": [
+          "ArtistEditor"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistEditorResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistEditorResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistEditorResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ArtistEditor"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistEditorResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistEditorResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ArtistEditorResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/artist/lookup": {
+      "get": {
+        "tags": [
+          "ArtistLookup"
+        ],
+        "parameters": [
+          {
+            "name": "term",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ArtistResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "returnUrl",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "rememberMe": {
+                    "type": "string"
+                  }
+                }
+              },
+              "encoding": {
+                "username": {
+                  "style": "form"
+                },
+                "password": {
+                  "style": "form"
+                },
+                "rememberMe": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/logout": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/autotagging/{id}": {
+      "get": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoTaggingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/autotagging": {
+      "post": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoTaggingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AutoTaggingResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/autotagging/schema": {
+      "get": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/backup": {
+      "get": {
+        "tags": [
+          "Backup"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BackupResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BackupResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BackupResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/system/backup/{id}": {
+      "delete": {
+        "tags": [
+          "Backup"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/backup/restore/{id}": {
+      "post": {
+        "tags": [
+          "Backup"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/backup/restore/upload": {
+      "post": {
+        "tags": [
+          "Backup"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/blocklist": {
+      "get": {
+        "tags": [
+          "Blocklist"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlocklistResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/blocklist/{id}": {
+      "delete": {
+        "tags": [
+          "Blocklist"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/blocklist/bulk": {
+      "delete": {
+        "tags": [
+          "Blocklist"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistBulkResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistBulkResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/calendar": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "unmonitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AlbumResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/calendar/{id}": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feed/v1/calendar/lidarr.ics": {
+      "get": {
+        "tags": [
+          "CalendarFeed"
+        ],
+        "parameters": [
+          {
+            "name": "pastDays",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 7
+            }
+          },
+          {
+            "name": "futureDays",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 28
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          {
+            "name": "unmonitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/command/{id}": {
+      "get": {
+        "tags": [
+          "Command"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Command"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/command": {
+      "post": {
+        "tags": [
+          "Command"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommandResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Command"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommandResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/customfilter/{id}": {
+      "get": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFilterResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/customfilter": {
+      "get": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFilterResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFilterResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/customformat/{id}": {
+      "get": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/customformat": {
+      "get": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFormatResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/customformat/bulk": {
+      "put": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/customformat/schema": {
+      "get": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/wanted/cutoff": {
+      "get": {
+        "tags": [
+          "Cutoff"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "monitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/wanted/cutoff/{id}": {
+      "get": {
+        "tags": [
+          "Cutoff"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/delayprofile": {
+      "post": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/delayprofile/{id}": {
+      "delete": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/delayprofile/reorder/{id}": {
+      "put": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "afterId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/diskspace": {
+      "get": {
+        "tags": [
+          "DiskSpace"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DiskSpaceResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient/{id}": {
+      "get": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient": {
+      "get": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DownloadClientResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient/bulk": {
+      "put": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient/schema": {
+      "get": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DownloadClientResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient/test": {
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient/testall": {
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/downloadclient/action/{name}": {
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/config/downloadclient/{id}": {
+      "get": {
+        "tags": [
+          "DownloadClientConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DownloadClientConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/downloadclient": {
+      "get": {
+        "tags": [
+          "DownloadClientConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/filesystem": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "allowFoldersWithoutTrailingSlashes",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/filesystem/type": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/filesystem/mediafiles": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HealthResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/history": {
+      "get": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeAlbum",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeTrack",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "downloadId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "artistIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "quality",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoryResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/history/since": {
+      "get": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/EntityHistoryEventType"
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeAlbum",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeTrack",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HistoryResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/history/artist": {
+      "get": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/EntityHistoryEventType"
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeAlbum",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeTrack",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HistoryResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/history/failed/{id}": {
+      "post": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/config/host/{id}": {
+      "get": {
+        "tags": [
+          "HostConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "HostConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostConfigResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostConfigResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/host": {
+      "get": {
+        "tags": [
+          "HostConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/importlist/{id}": {
+      "get": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/importlist": {
+      "get": {
+        "tags": [
+          "ImportList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/importlist/bulk": {
+      "put": {
+        "tags": [
+          "ImportList"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ImportList"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/importlist/schema": {
+      "get": {
+        "tags": [
+          "ImportList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/importlist/test": {
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/importlist/testall": {
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/importlist/action/{name}": {
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/importlistexclusion/{id}": {
+      "get": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/importlistexclusion": {
+      "get": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListExclusionResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListExclusionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListExclusionResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/indexer/{id}": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/indexer": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/indexer/bulk": {
+      "put": {
+        "tags": [
+          "Indexer"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Indexer"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/indexer/schema": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/indexer/test": {
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/indexer/testall": {
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/indexer/action/{name}": {
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/config/indexer/{id}": {
+      "get": {
+        "tags": [
+          "IndexerConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "IndexerConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/indexer": {
+      "get": {
+        "tags": [
+          "IndexerConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/indexerflag": {
+      "get": {
+        "tags": [
+          "IndexerFlag"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerFlagResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerFlagResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerFlagResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/language/{id}": {
+      "get": {
+        "tags": [
+          "Language"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/language": {
+      "get": {
+        "tags": [
+          "Language"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/localization": {
+      "get": {
+        "tags": [
+          "Localization"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalizationResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/log": {
+      "get": {
+        "tags": [
+          "Log"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/log/file": {
+      "get": {
+        "tags": [
+          "LogFile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogFileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/log/file/{filename}": {
+      "get": {
+        "tags": [
+          "LogFile"
+        ],
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "[-.a-zA-Z0-9]+?\\.txt",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/manualimport": {
+      "post": {
+        "tags": [
+          "ManualImport"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ManualImportUpdateResource"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ManualImportUpdateResource"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ManualImportUpdateResource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ManualImport"
+        ],
+        "parameters": [
+          {
+            "name": "folder",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "downloadId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "filterExistingFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "replaceExistingFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManualImportResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManualImportResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManualImportResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mediacover/artist/{artistId}/{filename}": {
+      "get": {
+        "tags": [
+          "MediaCover"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "(.+)\\.(jpg|png|gif)",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/mediacover/album/{albumId}/{filename}": {
+      "get": {
+        "tags": [
+          "MediaCover"
+        ],
+        "parameters": [
+          {
+            "name": "albumId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "(.+)\\.(jpg|png|gif)",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/config/mediamanagement/{id}": {
+      "get": {
+        "tags": [
+          "MediaManagementConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "MediaManagementConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MediaManagementConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/mediamanagement": {
+      "get": {
+        "tags": [
+          "MediaManagementConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/metadata/{id}": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/metadata": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/metadata/schema": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/metadata/test": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/metadata/testall": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/metadata/action/{name}": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/metadataprofile": {
+      "post": {
+        "tags": [
+          "MetadataProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "MetadataProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataProfileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataProfileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/metadataprofile/{id}": {
+      "delete": {
+        "tags": [
+          "MetadataProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "MetadataProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "MetadataProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/metadataprofile/schema": {
+      "get": {
+        "tags": [
+          "MetadataProfileSchema"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/metadataprovider/{id}": {
+      "get": {
+        "tags": [
+          "MetadataProviderConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "MetadataProviderConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataProviderConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/metadataprovider": {
+      "get": {
+        "tags": [
+          "MetadataProviderConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataProviderConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/wanted/missing": {
+      "get": {
+        "tags": [
+          "Missing"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "monitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/wanted/missing/{id}": {
+      "get": {
+        "tags": [
+          "Missing"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/naming/{id}": {
+      "get": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NamingConfigResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NamingConfigResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/NamingConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/naming": {
+      "get": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/naming/examples": {
+      "get": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "parameters": [
+          {
+            "name": "renameTracks",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "replaceIllegalCharacters",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "colonReplacementFormat",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "standardTrackFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "multiDiscTrackFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "artistFolderFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeArtistName",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeAlbumTitle",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeQuality",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "replaceSpaces",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "separator",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "numberStyle",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/notification/{id}": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/notification": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notification/schema": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/notification/test": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/notification/testall": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/notification/action/{name}": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/parse": {
+      "get": {
+        "tags": [
+          "Parse"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParseResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ping": {
+      "get": {
+        "tags": [
+          "Ping"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "Ping"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/qualitydefinition/{id}": {
+      "put": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityDefinitionResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityDefinitionResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityDefinitionResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/qualitydefinition": {
+      "get": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/qualitydefinition/update": {
+      "put": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/qualityprofile": {
+      "post": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityProfileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityProfileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/qualityprofile/{id}": {
+      "delete": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/qualityprofile/schema": {
+      "get": {
+        "tags": [
+          "QualityProfileSchema"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/queue/{id}": {
+      "delete": {
+        "tags": [
+          "Queue"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "removeFromClient",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "blocklist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "skipRedownload",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "changeCategory",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/queue/bulk": {
+      "delete": {
+        "tags": [
+          "Queue"
+        ],
+        "parameters": [
+          {
+            "name": "removeFromClient",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "blocklist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "skipRedownload",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "changeCategory",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/queue": {
+      "get": {
+        "tags": [
+          "Queue"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeUnknownArtistItems",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeAlbum",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "artistIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DownloadProtocol"
+            }
+          },
+          {
+            "name": "quality",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/queue/grab/{id}": {
+      "post": {
+        "tags": [
+          "QueueAction"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/queue/grab/bulk": {
+      "post": {
+        "tags": [
+          "QueueAction"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/queue/details": {
+      "get": {
+        "tags": [
+          "QueueDetails"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "includeArtist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeAlbum",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QueueResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/queue/status": {
+      "get": {
+        "tags": [
+          "QueueStatus"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueStatusResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/release": {
+      "post": {
+        "tags": [
+          "Release"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Release"
+        ],
+        "parameters": [
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/releaseprofile/{id}": {
+      "get": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/releaseprofile": {
+      "get": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseProfileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseProfileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/release/push": {
+      "post": {
+        "tags": [
+          "ReleasePush"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/remotepathmapping/{id}": {
+      "get": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/remotepathmapping": {
+      "post": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RemotePathMappingResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/rename": {
+      "get": {
+        "tags": [
+          "RenameTrack"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RenameTrackResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RenameTrackResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RenameTrackResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/retag": {
+      "get": {
+        "tags": [
+          "RetagTrack"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RetagTrackResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RetagTrackResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RetagTrackResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/rootfolder/{id}": {
+      "get": {
+        "tags": [
+          "RootFolder"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RootFolder"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RootFolderResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RootFolderResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RootFolderResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "RootFolder"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/rootfolder": {
+      "post": {
+        "tags": [
+          "RootFolder"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RootFolderResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "RootFolder"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RootFolderResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/search": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "term",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SearchResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/content/{path}": {
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^(?!api/).*",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/{path}": {
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^(?!(api|feed)/).*",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/status": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/system/routes": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/routes/duplicate": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/shutdown": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/system/restart": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/tag/{id}": {
+      "get": {
+        "tags": [
+          "Tag"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Tag"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tag"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/tag": {
+      "get": {
+        "tags": [
+          "Tag"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tag"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tag/detail/{id}": {
+      "get": {
+        "tags": [
+          "TagDetails"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDetailsResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDetailsResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDetailsResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/tag/detail": {
+      "get": {
+        "tags": [
+          "TagDetails"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagDetailsResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/system/task": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/system/task/{id}": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/track": {
+      "get": {
+        "tags": [
+          "Track"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "albumReleaseId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "trackIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrackResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrackResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrackResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/track/{id}": {
+      "get": {
+        "tags": [
+          "Track"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/trackfile/{id}": {
+      "get": {
+        "tags": [
+          "TrackFile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackFileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackFileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackFileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "TrackFile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackFileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackFileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrackFileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "TrackFile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/trackfile": {
+      "get": {
+        "tags": [
+          "TrackFile"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "trackFileIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "albumId",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "unmapped",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrackFileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrackFileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TrackFileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/trackfile/editor": {
+      "put": {
+        "tags": [
+          "TrackFile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileListResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileListResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/trackfile/bulk": {
+      "delete": {
+        "tags": [
+          "TrackFile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileListResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileListResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/TrackFileListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v1/config/ui/{id}": {
+      "put": {
+        "tags": [
+          "UiConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UiConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "UiConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/config/ui": {
+      "get": {
+        "tags": [
+          "UiConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/update": {
+      "get": {
+        "tags": [
+          "Update"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UpdateResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/log/file/update": {
+      "get": {
+        "tags": [
+          "UpdateLogFile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogFileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/log/file/update/{filename}": {
+      "get": {
+        "tags": [
+          "UpdateLogFile"
+        ],
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "[-.a-zA-Z0-9]+?\\.txt",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddAlbumOptions": {
+        "type": "object",
+        "properties": {
+          "addType": {
+            "$ref": "#/components/schemas/AlbumAddType"
+          },
+          "searchForNewAlbum": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AddArtistOptions": {
+        "type": "object",
+        "properties": {
+          "monitor": {
+            "$ref": "#/components/schemas/MonitorTypes"
+          },
+          "albumsToMonitor": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "searchForMissingAlbums": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumAddType": {
+        "enum": [
+          "automatic",
+          "manual"
+        ],
+        "type": "string"
+      },
+      "AlbumReleaseResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "foreignReleaseId": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "media": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediumResource"
+            },
+            "nullable": true
+          },
+          "mediumCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "disambiguation": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "label": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "format": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "disambiguation": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "foreignAlbumId": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "anyReleaseOk": {
+            "type": "boolean"
+          },
+          "profileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumType": {
+            "type": "string",
+            "nullable": true
+          },
+          "secondaryTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "mediumCount": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "ratings": {
+            "$ref": "#/components/schemas/Ratings"
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "releases": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlbumReleaseResource"
+            },
+            "nullable": true
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "media": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediumResource"
+            },
+            "nullable": true
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Links"
+            },
+            "nullable": true
+          },
+          "lastSearchTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/AlbumStatisticsResource"
+          },
+          "addOptions": {
+            "$ref": "#/components/schemas/AddAlbumOptions"
+          },
+          "remoteCover": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlbumResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumStatisticsResource": {
+        "type": "object",
+        "properties": {
+          "trackFileCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalTrackCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sizeOnDisk": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "percentOfTracks": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumStudioArtistResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "monitored": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "albums": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlbumResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumStudioResource": {
+        "type": "object",
+        "properties": {
+          "artist": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlbumStudioArtistResource"
+            },
+            "nullable": true
+          },
+          "monitoringOptions": {
+            "$ref": "#/components/schemas/MonitoringOptions"
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlbumsMonitoredResource": {
+        "type": "object",
+        "properties": {
+          "albumIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AllowFingerprinting": {
+        "enum": [
+          "never",
+          "newFiles",
+          "allFiles"
+        ],
+        "type": "string"
+      },
+      "ApplyTags": {
+        "enum": [
+          "add",
+          "remove",
+          "replace"
+        ],
+        "type": "string"
+      },
+      "ArtistEditorResource": {
+        "type": "object",
+        "properties": {
+          "artistIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "metadataProfileId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "moveFiles": {
+            "type": "boolean"
+          },
+          "deleteFiles": {
+            "type": "boolean"
+          },
+          "addImportListExclusion": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ArtistResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ArtistStatusType"
+          },
+          "ended": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          },
+          "foreignArtistId": {
+            "type": "string",
+            "nullable": true
+          },
+          "mbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "tadbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "discogsId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "allMusicId": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistType": {
+            "type": "string",
+            "nullable": true
+          },
+          "disambiguation": {
+            "type": "string",
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Links"
+            },
+            "nullable": true
+          },
+          "nextAlbum": {
+            "$ref": "#/components/schemas/AlbumResource"
+          },
+          "lastAlbum": {
+            "$ref": "#/components/schemas/AlbumResource"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Member"
+            },
+            "nullable": true
+          },
+          "remotePoster": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadataProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "folder": {
+            "type": "string",
+            "nullable": true
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "cleanName": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortName": {
+            "type": "string",
+            "nullable": true
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "addOptions": {
+            "$ref": "#/components/schemas/AddArtistOptions"
+          },
+          "ratings": {
+            "$ref": "#/components/schemas/Ratings"
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/ArtistStatisticsResource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ArtistStatisticsResource": {
+        "type": "object",
+        "properties": {
+          "albumCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackFileCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalTrackCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sizeOnDisk": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "percentOfTracks": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ArtistStatusType": {
+        "enum": [
+          "continuing",
+          "ended",
+          "deleted"
+        ],
+        "type": "string"
+      },
+      "ArtistTitleInfo": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "titleWithoutYear": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AuthenticationRequiredType": {
+        "enum": [
+          "enabled",
+          "disabledForLocalAddresses"
+        ],
+        "type": "string"
+      },
+      "AuthenticationType": {
+        "enum": [
+          "none",
+          "basic",
+          "forms",
+          "external"
+        ],
+        "type": "string"
+      },
+      "AutoTaggingResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "removeTagsAutomatically": {
+            "type": "boolean"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "specifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AutoTaggingSpecificationSchema"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AutoTaggingSpecificationSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "negate": {
+            "type": "boolean"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/BackupType"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupType": {
+        "enum": [
+          "scheduled",
+          "manual",
+          "update"
+        ],
+        "type": "string"
+      },
+      "BlocklistBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlocklistResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "sourceTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "indexer": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlocklistResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlocklistResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CertificateValidationType": {
+        "enum": [
+          "enabled",
+          "disabledForLocalAddresses",
+          "disabled"
+        ],
+        "type": "string"
+      },
+      "Command": {
+        "type": "object",
+        "properties": {
+          "sendUpdatesToClient": {
+            "type": "boolean"
+          },
+          "updateScheduledTask": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "completionMessage": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "requiresDiskAccess": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isExclusive": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isTypeExclusive": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isLongRunning": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "lastExecutionTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastStartTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/CommandTrigger"
+          },
+          "suppressMessages": {
+            "type": "boolean"
+          },
+          "clientUserAgent": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CommandPriority": {
+        "enum": [
+          "normal",
+          "high",
+          "low"
+        ],
+        "type": "string"
+      },
+      "CommandResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "commandName": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "body": {
+            "$ref": "#/components/schemas/Command"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/CommandPriority"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CommandStatus"
+          },
+          "result": {
+            "$ref": "#/components/schemas/CommandResult"
+          },
+          "queued": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "started": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ended": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "duration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true
+          },
+          "exception": {
+            "type": "string",
+            "nullable": true
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/CommandTrigger"
+          },
+          "clientUserAgent": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateChangeTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "sendUpdatesToClient": {
+            "type": "boolean"
+          },
+          "updateScheduledTask": {
+            "type": "boolean"
+          },
+          "lastExecutionTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CommandResult": {
+        "enum": [
+          "unknown",
+          "successful",
+          "unsuccessful"
+        ],
+        "type": "string"
+      },
+      "CommandStatus": {
+        "enum": [
+          "queued",
+          "started",
+          "completed",
+          "failed",
+          "aborted",
+          "cancelled",
+          "orphaned"
+        ],
+        "type": "string"
+      },
+      "CommandTrigger": {
+        "enum": [
+          "unspecified",
+          "manual",
+          "scheduled"
+        ],
+        "type": "string"
+      },
+      "CustomFilterResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": { }
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFormatBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "includeCustomFormatWhenRenaming": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFormatResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "includeCustomFormatWhenRenaming": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "specifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatSpecificationSchema"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFormatSpecificationSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "negate": {
+            "type": "boolean"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatSpecificationSchema"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DatabaseType": {
+        "enum": [
+          "sqLite",
+          "postgreSQL"
+        ],
+        "type": "string"
+      },
+      "DelayProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "enableUsenet": {
+            "type": "boolean"
+          },
+          "enableTorrent": {
+            "type": "boolean"
+          },
+          "preferredProtocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "usenetDelay": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "torrentDelay": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bypassIfHighestQuality": {
+            "type": "boolean"
+          },
+          "bypassIfAboveCustomFormatScore": {
+            "type": "boolean"
+          },
+          "minimumCustomFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DiskSpaceResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "freeSpace": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalSpace": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadClientBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "enable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "removeCompletedDownloads": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "removeFailedDownloads": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadClientConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadClientWorkingFolders": {
+            "type": "string",
+            "nullable": true
+          },
+          "enableCompletedDownloadHandling": {
+            "type": "boolean"
+          },
+          "autoRedownloadFailed": {
+            "type": "boolean"
+          },
+          "autoRedownloadFailedFromInteractiveSearch": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadClientResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DownloadClientResource"
+            },
+            "nullable": true
+          },
+          "enable": {
+            "type": "boolean"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "removeCompletedDownloads": {
+            "type": "boolean"
+          },
+          "removeFailedDownloads": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadProtocol": {
+        "enum": [
+          "unknown",
+          "usenet",
+          "torrent"
+        ],
+        "type": "string"
+      },
+      "EntityHistoryEventType": {
+        "enum": [
+          "unknown",
+          "grabbed",
+          "artistFolderImported",
+          "trackFileImported",
+          "downloadFailed",
+          "trackFileDeleted",
+          "trackFileRenamed",
+          "albumImportIncomplete",
+          "downloadImported",
+          "trackFileRetagged",
+          "downloadIgnored"
+        ],
+        "type": "string"
+      },
+      "Field": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "unit": {
+            "type": "string",
+            "nullable": true
+          },
+          "helpText": {
+            "type": "string",
+            "nullable": true
+          },
+          "helpTextWarning": {
+            "type": "string",
+            "nullable": true
+          },
+          "helpLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "advanced": {
+            "type": "boolean"
+          },
+          "selectOptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SelectOption"
+            },
+            "nullable": true
+          },
+          "selectOptionsProviderAction": {
+            "type": "string",
+            "nullable": true
+          },
+          "section": {
+            "type": "string",
+            "nullable": true
+          },
+          "hidden": {
+            "type": "string",
+            "nullable": true
+          },
+          "privacy": {
+            "$ref": "#/components/schemas/PrivacyLevel"
+          },
+          "placeholder": {
+            "type": "string",
+            "nullable": true
+          },
+          "isFloat": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileDateType": {
+        "enum": [
+          "none",
+          "albumReleaseDate"
+        ],
+        "type": "string"
+      },
+      "HealthCheckResult": {
+        "enum": [
+          "ok",
+          "notice",
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      },
+      "HealthResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/HealthCheckResult"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "wikiUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HistoryResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sourceTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "qualityCutoffNotMet": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventType": {
+            "$ref": "#/components/schemas/EntityHistoryEventType"
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "nullable": true
+          },
+          "album": {
+            "$ref": "#/components/schemas/AlbumResource"
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "track": {
+            "$ref": "#/components/schemas/TrackResource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HistoryResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HistoryResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bindAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sslPort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "enableSsl": {
+            "type": "boolean"
+          },
+          "launchBrowser": {
+            "type": "boolean"
+          },
+          "authenticationMethod": {
+            "$ref": "#/components/schemas/AuthenticationType"
+          },
+          "authenticationRequired": {
+            "$ref": "#/components/schemas/AuthenticationRequiredType"
+          },
+          "analyticsEnabled": {
+            "type": "boolean"
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "passwordConfirmation": {
+            "type": "string",
+            "nullable": true
+          },
+          "logLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "logSizeLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "consoleLogLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sslCertPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "sslCertPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "instanceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "updateAutomatically": {
+            "type": "boolean"
+          },
+          "updateMechanism": {
+            "$ref": "#/components/schemas/UpdateMechanism"
+          },
+          "updateScriptPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyEnabled": {
+            "type": "boolean"
+          },
+          "proxyType": {
+            "$ref": "#/components/schemas/ProxyType"
+          },
+          "proxyHostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyPort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "proxyUsername": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyBypassFilter": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyBypassLocalAddresses": {
+            "type": "boolean"
+          },
+          "certificateValidation": {
+            "$ref": "#/components/schemas/CertificateValidationType"
+          },
+          "backupFolder": {
+            "type": "string",
+            "nullable": true
+          },
+          "backupInterval": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "backupRetention": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trustCgnatIpAddresses": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "enableAutomaticAdd": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListExclusionResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "foreignId": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListMonitorType": {
+        "enum": [
+          "none",
+          "specificAlbum",
+          "entireArtist"
+        ],
+        "type": "string"
+      },
+      "ImportListResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImportListResource"
+            },
+            "nullable": true
+          },
+          "enableAutomaticAdd": {
+            "type": "boolean"
+          },
+          "shouldMonitor": {
+            "$ref": "#/components/schemas/ImportListMonitorType"
+          },
+          "shouldMonitorExisting": {
+            "type": "boolean"
+          },
+          "shouldSearch": {
+            "type": "boolean"
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadataProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "listType": {
+            "$ref": "#/components/schemas/ImportListType"
+          },
+          "listOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minRefreshInterval": {
+            "type": "string",
+            "format": "date-span"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListType": {
+        "enum": [
+          "program",
+          "spotify",
+          "lastFm",
+          "other",
+          "advanced"
+        ],
+        "type": "string"
+      },
+      "IndexerBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "enableRss": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "enableAutomaticSearch": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "enableInteractiveSearch": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minimumAge": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maximumSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "retention": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rssSyncInterval": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerFlagResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameLower": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IndexerResource"
+            },
+            "nullable": true
+          },
+          "enableRss": {
+            "type": "boolean"
+          },
+          "enableAutomaticSearch": {
+            "type": "boolean"
+          },
+          "enableInteractiveSearch": {
+            "type": "boolean"
+          },
+          "supportsRss": {
+            "type": "boolean"
+          },
+          "supportsSearch": {
+            "type": "boolean"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadClientId": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IsoCountry": {
+        "type": "object",
+        "properties": {
+          "twoLetterCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LanguageResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameLower": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Links": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LocalizationResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "strings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogFileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "filename": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastWriteTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "contentsUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "exception": {
+            "type": "string",
+            "nullable": true
+          },
+          "exceptionType": {
+            "type": "string",
+            "nullable": true
+          },
+          "level": {
+            "type": "string",
+            "nullable": true
+          },
+          "logger": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LogResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManualImportResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "album": {
+            "$ref": "#/components/schemas/AlbumResource"
+          },
+          "albumReleaseId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tracks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrackResource"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rejections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rejection"
+            },
+            "nullable": true
+          },
+          "audioTags": {
+            "$ref": "#/components/schemas/ParsedTrackInfo"
+          },
+          "additionalFile": {
+            "type": "boolean"
+          },
+          "replaceExistingFiles": {
+            "type": "boolean"
+          },
+          "disableReleaseSwitching": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManualImportUpdateResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "albumReleaseId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "tracks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrackResource"
+            },
+            "nullable": true
+          },
+          "trackIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalFile": {
+            "type": "boolean"
+          },
+          "replaceExistingFiles": {
+            "type": "boolean"
+          },
+          "disableReleaseSwitching": {
+            "type": "boolean"
+          },
+          "rejections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Rejection"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaCover": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "coverType": {
+            "$ref": "#/components/schemas/MediaCoverTypes"
+          },
+          "extension": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "remoteUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaCoverTypes": {
+        "enum": [
+          "unknown",
+          "poster",
+          "banner",
+          "fanart",
+          "screenshot",
+          "headshot",
+          "cover",
+          "disc",
+          "logo",
+          "clearlogo"
+        ],
+        "type": "string"
+      },
+      "MediaInfoModel": {
+        "type": "object",
+        "properties": {
+          "audioFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioBitrate": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audioChannels": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audioBits": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audioSampleRate": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaInfoResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audioChannels": {
+            "type": "number",
+            "format": "double"
+          },
+          "audioBitRate": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioCodec": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioBits": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioSampleRate": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaManagementConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "autoUnmonitorPreviouslyDownloadedTracks": {
+            "type": "boolean"
+          },
+          "recycleBin": {
+            "type": "string",
+            "nullable": true
+          },
+          "recycleBinCleanupDays": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadPropersAndRepacks": {
+            "$ref": "#/components/schemas/ProperDownloadTypes"
+          },
+          "createEmptyArtistFolders": {
+            "type": "boolean"
+          },
+          "deleteEmptyFolders": {
+            "type": "boolean"
+          },
+          "fileDate": {
+            "$ref": "#/components/schemas/FileDateType"
+          },
+          "watchLibraryForChanges": {
+            "type": "boolean"
+          },
+          "rescanAfterRefresh": {
+            "$ref": "#/components/schemas/RescanAfterRefreshType"
+          },
+          "allowFingerprinting": {
+            "$ref": "#/components/schemas/AllowFingerprinting"
+          },
+          "setPermissionsLinux": {
+            "type": "boolean"
+          },
+          "chmodFolder": {
+            "type": "string",
+            "nullable": true
+          },
+          "chownGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "skipFreeSpaceCheckWhenImporting": {
+            "type": "boolean"
+          },
+          "minimumFreeSpaceWhenImporting": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "copyUsingHardlinks": {
+            "type": "boolean"
+          },
+          "enableMediaInfo": {
+            "type": "boolean"
+          },
+          "useScriptImport": {
+            "type": "boolean"
+          },
+          "scriptImportPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "importExtraFiles": {
+            "type": "boolean"
+          },
+          "extraFileExtensions": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediumResource": {
+        "type": "object",
+        "properties": {
+          "mediumNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "mediumName": {
+            "type": "string",
+            "nullable": true
+          },
+          "mediumFormat": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Member": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "instrument": {
+            "type": "string",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MetadataProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "primaryAlbumTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfilePrimaryAlbumTypeItemResource"
+            },
+            "nullable": true
+          },
+          "secondaryAlbumTypes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileSecondaryAlbumTypeItemResource"
+            },
+            "nullable": true
+          },
+          "releaseStatuses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileReleaseStatusItemResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MetadataProviderConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadataSource": {
+            "type": "string",
+            "nullable": true
+          },
+          "writeAudioTags": {
+            "$ref": "#/components/schemas/WriteAudioTagsType"
+          },
+          "scrubAudioTags": {
+            "type": "boolean"
+          },
+          "embedCoverArt": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MetadataResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MetadataResource"
+            },
+            "nullable": true
+          },
+          "enable": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MonitorTypes": {
+        "enum": [
+          "all",
+          "future",
+          "missing",
+          "existing",
+          "latest",
+          "first",
+          "none",
+          "unknown"
+        ],
+        "type": "string"
+      },
+      "MonitoringOptions": {
+        "type": "object",
+        "properties": {
+          "monitor": {
+            "$ref": "#/components/schemas/MonitorTypes"
+          },
+          "albumsToMonitor": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NamingConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "renameTracks": {
+            "type": "boolean"
+          },
+          "replaceIllegalCharacters": {
+            "type": "boolean"
+          },
+          "colonReplacementFormat": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "standardTrackFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "multiDiscTrackFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistFolderFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "includeArtistName": {
+            "type": "boolean"
+          },
+          "includeAlbumTitle": {
+            "type": "boolean"
+          },
+          "includeQuality": {
+            "type": "boolean"
+          },
+          "replaceSpaces": {
+            "type": "boolean"
+          },
+          "separator": {
+            "type": "string",
+            "nullable": true
+          },
+          "numberStyle": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "NewItemMonitorTypes": {
+        "enum": [
+          "all",
+          "none",
+          "new"
+        ],
+        "type": "string"
+      },
+      "NotificationResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationResource"
+            },
+            "nullable": true
+          },
+          "link": {
+            "type": "string",
+            "nullable": true
+          },
+          "onGrab": {
+            "type": "boolean"
+          },
+          "onReleaseImport": {
+            "type": "boolean"
+          },
+          "onUpgrade": {
+            "type": "boolean"
+          },
+          "onRename": {
+            "type": "boolean"
+          },
+          "onArtistAdd": {
+            "type": "boolean"
+          },
+          "onArtistDelete": {
+            "type": "boolean"
+          },
+          "onAlbumDelete": {
+            "type": "boolean"
+          },
+          "onHealthIssue": {
+            "type": "boolean"
+          },
+          "onHealthRestored": {
+            "type": "boolean"
+          },
+          "onDownloadFailure": {
+            "type": "boolean"
+          },
+          "onImportFailure": {
+            "type": "boolean"
+          },
+          "onTrackRetag": {
+            "type": "boolean"
+          },
+          "onApplicationUpdate": {
+            "type": "boolean"
+          },
+          "supportsOnGrab": {
+            "type": "boolean"
+          },
+          "supportsOnReleaseImport": {
+            "type": "boolean"
+          },
+          "supportsOnUpgrade": {
+            "type": "boolean"
+          },
+          "supportsOnRename": {
+            "type": "boolean"
+          },
+          "supportsOnArtistAdd": {
+            "type": "boolean"
+          },
+          "supportsOnArtistDelete": {
+            "type": "boolean"
+          },
+          "supportsOnAlbumDelete": {
+            "type": "boolean"
+          },
+          "supportsOnHealthIssue": {
+            "type": "boolean"
+          },
+          "supportsOnHealthRestored": {
+            "type": "boolean"
+          },
+          "includeHealthWarnings": {
+            "type": "boolean"
+          },
+          "supportsOnDownloadFailure": {
+            "type": "boolean"
+          },
+          "supportsOnImportFailure": {
+            "type": "boolean"
+          },
+          "supportsOnTrackRetag": {
+            "type": "boolean"
+          },
+          "supportsOnApplicationUpdate": {
+            "type": "boolean"
+          },
+          "testCommand": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParseResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "parsedAlbumInfo": {
+            "$ref": "#/components/schemas/ParsedAlbumInfo"
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "albums": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlbumResource"
+            },
+            "nullable": true
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParsedAlbumInfo": {
+        "type": "object",
+        "properties": {
+          "releaseTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "albumTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          },
+          "albumType": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistTitleInfo": {
+            "$ref": "#/components/schemas/ArtistTitleInfo"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "releaseDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "discography": {
+            "type": "boolean"
+          },
+          "discographyStart": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "discographyEnd": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseVersion": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParsedTrackInfo": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "albumTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistTitleInfo": {
+            "$ref": "#/components/schemas/ArtistTitleInfo"
+          },
+          "artistMBId": {
+            "type": "string",
+            "nullable": true
+          },
+          "albumMBId": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseMBId": {
+            "type": "string",
+            "nullable": true
+          },
+          "recordingMBId": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackMBId": {
+            "type": "string",
+            "nullable": true
+          },
+          "discNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "discCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "country": {
+            "$ref": "#/components/schemas/IsoCountry"
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "catalogNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "disambiguation": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "string",
+            "format": "date-span"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "mediaInfo": {
+            "$ref": "#/components/schemas/MediaInfoModel"
+          },
+          "trackNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseHash": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PingResource": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PrimaryAlbumType": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PrivacyLevel": {
+        "enum": [
+          "normal",
+          "password",
+          "apiKey",
+          "userName"
+        ],
+        "type": "string"
+      },
+      "ProfileFormatItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "format": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "score": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProfilePrimaryAlbumTypeItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumType": {
+            "$ref": "#/components/schemas/PrimaryAlbumType"
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProfileReleaseStatusItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "releaseStatus": {
+            "$ref": "#/components/schemas/ReleaseStatus"
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProfileSecondaryAlbumTypeItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumType": {
+            "$ref": "#/components/schemas/SecondaryAlbumType"
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProperDownloadTypes": {
+        "enum": [
+          "preferAndUpgrade",
+          "doNotUpgrade",
+          "doNotPrefer"
+        ],
+        "type": "string"
+      },
+      "ProviderMessage": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/ProviderMessageType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProviderMessageType": {
+        "enum": [
+          "info",
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      },
+      "ProxyType": {
+        "enum": [
+          "http",
+          "socks4",
+          "socks5"
+        ],
+        "type": "string"
+      },
+      "Quality": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityDefinitionResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/Quality"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "weight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "maxSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "preferredSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityModel": {
+        "type": "object",
+        "properties": {
+          "quality": {
+            "$ref": "#/components/schemas/Quality"
+          },
+          "revision": {
+            "$ref": "#/components/schemas/Revision"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityProfileQualityItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/Quality"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QualityProfileQualityItemResource"
+            },
+            "nullable": true
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "upgradeAllowed": {
+            "type": "boolean"
+          },
+          "cutoff": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QualityProfileQualityItemResource"
+            },
+            "nullable": true
+          },
+          "minFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "cutoffFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "formatItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileFormatItemResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "album": {
+            "$ref": "#/components/schemas/AlbumResource"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "number",
+            "format": "double"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "sizeleft": {
+            "type": "number",
+            "format": "double"
+          },
+          "timeleft": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true
+          },
+          "estimatedCompletionTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "added": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackedDownloadStatus": {
+            "$ref": "#/components/schemas/TrackedDownloadStatus"
+          },
+          "trackedDownloadState": {
+            "$ref": "#/components/schemas/TrackedDownloadState"
+          },
+          "statusMessages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrackedDownloadStatusMessage"
+            },
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "downloadClient": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadClientHasPostImportCategory": {
+            "type": "boolean"
+          },
+          "indexer": {
+            "type": "string",
+            "nullable": true
+          },
+          "outputPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackFileCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackHasFileCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadForced": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueueResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueStatusResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unknownCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errors": {
+            "type": "boolean"
+          },
+          "warnings": {
+            "type": "boolean"
+          },
+          "unknownErrors": {
+            "type": "boolean"
+          },
+          "unknownWarnings": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ratings": {
+        "type": "object",
+        "properties": {
+          "votes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Rejection": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/RejectionType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RejectionType": {
+        "enum": [
+          "permanent",
+          "temporary"
+        ],
+        "type": "string"
+      },
+      "ReleaseProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "required": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "ignored": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "indexerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReleaseResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "guid": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "qualityWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ageHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "ageMinutes": {
+            "type": "number",
+            "format": "double"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "indexerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indexer": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "subGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "discography": {
+            "type": "boolean"
+          },
+          "sceneSource": {
+            "type": "boolean"
+          },
+          "airDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          },
+          "albumTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "temporarilyRejected": {
+            "type": "boolean"
+          },
+          "rejected": {
+            "type": "boolean"
+          },
+          "rejections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "commentUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadAllowed": {
+            "type": "boolean"
+          },
+          "releaseWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "magnetUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "seeders": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "leechers": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "downloadClientId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "downloadClient": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReleaseStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RemotePathMappingResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "host": {
+            "type": "string",
+            "nullable": true
+          },
+          "remotePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "localPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RenameTrackResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "trackFileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "existingPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "newPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RescanAfterRefreshType": {
+        "enum": [
+          "always",
+          "afterManual",
+          "never"
+        ],
+        "type": "string"
+      },
+      "RetagTrackResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "trackFileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "changes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagDifference"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Revision": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "real": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isRepack": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RootFolderResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultMetadataProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "defaultQualityProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "defaultMonitorOption": {
+            "$ref": "#/components/schemas/MonitorTypes"
+          },
+          "defaultNewItemMonitorOption": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "defaultTags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "accessible": {
+            "type": "boolean"
+          },
+          "freeSpace": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "totalSpace": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeMode": {
+        "enum": [
+          "console",
+          "service",
+          "tray"
+        ],
+        "type": "string"
+      },
+      "SearchResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "foreignId": {
+            "type": "string",
+            "nullable": true
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "album": {
+            "$ref": "#/components/schemas/AlbumResource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SecondaryAlbumType": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SelectOption": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hint": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SortDirection": {
+        "enum": [
+          "default",
+          "ascending",
+          "descending"
+        ],
+        "type": "string"
+      },
+      "SystemResource": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "nullable": true
+          },
+          "instanceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "buildTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "isDebug": {
+            "type": "boolean"
+          },
+          "isProduction": {
+            "type": "boolean"
+          },
+          "isAdmin": {
+            "type": "boolean"
+          },
+          "isUserInteractive": {
+            "type": "boolean"
+          },
+          "startupPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "appData": {
+            "type": "string",
+            "nullable": true
+          },
+          "osName": {
+            "type": "string",
+            "nullable": true
+          },
+          "osVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "isNetCore": {
+            "type": "boolean"
+          },
+          "isLinux": {
+            "type": "boolean"
+          },
+          "isOsx": {
+            "type": "boolean"
+          },
+          "isWindows": {
+            "type": "boolean"
+          },
+          "isDocker": {
+            "type": "boolean"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/RuntimeMode"
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "databaseType": {
+            "$ref": "#/components/schemas/DatabaseType"
+          },
+          "databaseVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "authentication": {
+            "$ref": "#/components/schemas/AuthenticationType"
+          },
+          "migrationVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtimeVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtimeName": {
+            "type": "string",
+            "nullable": true
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "packageVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "packageAuthor": {
+            "type": "string",
+            "nullable": true
+          },
+          "packageUpdateMechanism": {
+            "$ref": "#/components/schemas/UpdateMechanism"
+          },
+          "packageUpdateMechanismMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TagDetailsResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "delayProfileIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "importListIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "notificationIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "restrictionIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "indexerIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "downloadClientIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "autoTagIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "artistIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TagDifference": {
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string",
+            "nullable": true
+          },
+          "oldValue": {
+            "type": "string",
+            "nullable": true
+          },
+          "newValue": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TagResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TaskResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "taskName": {
+            "type": "string",
+            "nullable": true
+          },
+          "interval": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lastExecution": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastStartTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "nextExecution": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastDuration": {
+            "type": "string",
+            "format": "date-span",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrackFileListResource": {
+        "type": "object",
+        "properties": {
+          "trackFileIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "sceneName": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrackFileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "dateAdded": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "sceneName": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "qualityWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "mediaInfo": {
+            "$ref": "#/components/schemas/MediaInfoResource"
+          },
+          "qualityCutoffNotMet": {
+            "type": "boolean"
+          },
+          "audioTags": {
+            "$ref": "#/components/schemas/ParsedTrackInfo"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrackResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "artistId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "foreignTrackId": {
+            "type": "string",
+            "nullable": true
+          },
+          "foreignRecordingId": {
+            "type": "string",
+            "nullable": true
+          },
+          "trackFileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "albumId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "explicit": {
+            "type": "boolean"
+          },
+          "absoluteTrackNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trackFile": {
+            "$ref": "#/components/schemas/TrackFileResource"
+          },
+          "mediumNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hasFile": {
+            "type": "boolean"
+          },
+          "artist": {
+            "$ref": "#/components/schemas/ArtistResource"
+          },
+          "ratings": {
+            "$ref": "#/components/schemas/Ratings"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrackedDownloadState": {
+        "enum": [
+          "downloading",
+          "downloadFailed",
+          "downloadFailedPending",
+          "importBlocked",
+          "importPending",
+          "importing",
+          "importFailed",
+          "imported",
+          "ignored"
+        ],
+        "type": "string"
+      },
+      "TrackedDownloadStatus": {
+        "enum": [
+          "ok",
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      },
+      "TrackedDownloadStatusMessage": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UiConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "firstDayOfWeek": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "calendarWeekColumnHeader": {
+            "type": "string",
+            "nullable": true
+          },
+          "shortDateFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "longDateFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "showRelativeDates": {
+            "type": "boolean"
+          },
+          "enableColorImpairedMode": {
+            "type": "boolean"
+          },
+          "uiLanguage": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "expandAlbumByDefault": {
+            "type": "boolean"
+          },
+          "expandSingleByDefault": {
+            "type": "boolean"
+          },
+          "expandEPByDefault": {
+            "type": "boolean"
+          },
+          "expandBroadcastByDefault": {
+            "type": "boolean"
+          },
+          "expandOtherByDefault": {
+            "type": "boolean"
+          },
+          "theme": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateChanges": {
+        "type": "object",
+        "properties": {
+          "new": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "fixed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateMechanism": {
+        "enum": [
+          "builtIn",
+          "script",
+          "external",
+          "apt",
+          "docker"
+        ],
+        "type": "string"
+      },
+      "UpdateResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "installed": {
+            "type": "boolean"
+          },
+          "installedOn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "installable": {
+            "type": "boolean"
+          },
+          "latest": {
+            "type": "boolean"
+          },
+          "changes": {
+            "$ref": "#/components/schemas/UpdateChanges"
+          },
+          "hash": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "WriteAudioTagsType": {
+        "enum": [
+          "no",
+          "newFiles",
+          "allFiles",
+          "sync"
+        ],
+        "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "X-Api-Key": {
+        "type": "apiKey",
+        "description": "Apikey passed as header",
+        "name": "X-Api-Key",
+        "in": "header"
+      },
+      "apikey": {
+        "type": "apiKey",
+        "description": "Apikey passed as query parameter",
+        "name": "apikey",
+        "in": "query"
+      }
+    }
+  },
+  "security": [
+    {
+      "X-Api-Key": [ ]
+    },
+    {
+      "apikey": [ ]
+    }
+  ]
+}

--- a/services/service_lidarr/tool/openapi_parser.dart
+++ b/services/service_lidarr/tool/openapi_parser.dart
@@ -1,0 +1,734 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls, avoid_redundant_argument_values, require_trailing_commas, prefer_const_declarations, prefer_single_quotes, prefer_final_locals
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> args) {
+  final inputPath = args.isNotEmpty
+      ? args[0]
+      : '${Directory.current.path}/tool/openapi.json';
+  final outputDir = args.length > 1
+      ? args[1]
+      : '${Directory.current.path}/lib/src/generated';
+
+  final file = File(inputPath);
+  if (!file.existsSync()) {
+    print('Error: Input OpenAPI JSON file not found at $inputPath');
+    exit(1);
+  }
+
+  print('Parsing Lidarr OpenAPI specification from: $inputPath');
+  final jsonString = file.readAsStringSync();
+  final spec = jsonDecode(jsonString) as Map<String, dynamic>;
+
+  final parser = LidarrOpenApiParser(spec, outputDir);
+  parser.generateAll();
+  print('Successfully generated all Lidarr Dart models and API clients in: $outputDir');
+}
+
+class LidarrOpenApiParser {
+  final Map<String, dynamic> spec;
+  final String outputDir;
+
+  final Map<String, String> schemaClassNames = {};
+  final Map<String, dynamic> schemas = {};
+  final Map<String, List<Map<String, dynamic>>> tagEndpoints = {};
+
+  LidarrOpenApiParser(this.spec, this.outputDir) {
+    _initSchemas();
+    _initEndpoints();
+  }
+
+  void _initSchemas() {
+    final rawSchemas =
+        (spec['components']?['schemas'] as Map<String, dynamic>?) ?? {};
+    schemas.addAll(rawSchemas);
+
+    for (final fullKey in schemas.keys) {
+      schemaClassNames[fullKey] = _resolveClassName(fullKey, rawSchemas);
+    }
+  }
+
+  void _initEndpoints() {
+    final paths = (spec['paths'] as Map<String, dynamic>?) ?? {};
+    for (final pathEntry in paths.entries) {
+      final path = pathEntry.key;
+      final methods = pathEntry.value as Map<String, dynamic>;
+
+      for (final methodEntry in methods.entries) {
+        final verb = methodEntry.key.toLowerCase();
+        if (!['get', 'post', 'put', 'delete', 'patch'].contains(verb)) continue;
+
+        final op = methodEntry.value as Map<String, dynamic>;
+        final tags = (op['tags'] as List<dynamic>?)?.cast<String>() ?? ['Default'];
+        final tag = tags.first;
+
+        tagEndpoints.putIfAbsent(tag, () => []).add({
+          'path': path,
+          'verb': verb,
+          'operation': op,
+        });
+      }
+    }
+  }
+
+  String _sanitizeIdentifier(String name) {
+    return name.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '');
+  }
+
+  String _toPascalCase(String text) {
+    final clean = text.replaceAll(RegExp(r'[^a-zA-Z0-9]'), ' ');
+    final words = clean.split(RegExp(r'\s+')).where((w) => w.isNotEmpty);
+    return words.map((w) => w[0].toUpperCase() + w.substring(1)).join('');
+  }
+
+  String _toCamelCase(String text) {
+    final pascal = _toPascalCase(text);
+    if (pascal.isEmpty) return 'item';
+    var camel = pascal[0].toLowerCase() + pascal.substring(1);
+    if (RegExp(r'^[0-9]').hasMatch(camel)) {
+      camel = 'val$camel';
+    }
+    const keywords = {
+      'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
+      'class', 'const', 'continue', 'covariant', 'default', 'deferred', 'do',
+      'dynamic', 'else', 'enum', 'export', 'extends', 'extension', 'external',
+      'factory', 'false', 'finally', 'for', 'function', 'get', 'hide',
+      'if', 'implements', 'import', 'in', 'interface', 'is', 'late', 'library',
+      'mixin', 'new', 'null', 'on', 'operator', 'part', 'required', 'rethrow',
+      'return', 'set', 'show', 'static', 'super', 'switch', 'sync', 'this',
+      'throw', 'true', 'try', 'typedef', 'var', 'void', 'while', 'with', 'yield'
+    };
+    return keywords.contains(camel) ? '${camel}Val' : camel;
+  }
+
+  String _toSnakeCase(String name) {
+    return name
+        .replaceAllMapped(RegExp(r'([A-Z])'), (m) => '_${m.group(1)!.toLowerCase()}')
+        .replaceAll(RegExp(r'^_'), '')
+        .replaceAll(RegExp(r'_+'), '_');
+  }
+
+  String _resolveClassName(String fullKey, Map<String, dynamic> rawSchemas) {
+    final genericMatch = RegExp(r'`\d+\[\[(?:[^\.,]+\.)*([^\.,]+),').firstMatch(fullKey);
+    final genericSuffix = genericMatch != null
+        ? _sanitizeIdentifier(genericMatch.group(1)!)
+        : '';
+
+    final cleanBase = fullKey.replaceAll(RegExp(r'`\d+\[\[.*'), '');
+    final parts = cleanBase.split('.');
+    final short = parts.last;
+
+    final collisions = rawSchemas.keys
+        .where((k) => k.replaceAll(RegExp(r'`\d+\[\[.*'), '').split('.').last == short)
+        .toList();
+
+    String baseName;
+    if (collisions.length == 1) {
+      baseName = _sanitizeIdentifier(short);
+    } else {
+      final meaningful = parts
+          .where((p) => !['Lidarr', 'Api', 'External', 'Models', 'Core', 'V1'].contains(p))
+          .toList();
+      final effective = meaningful.isEmpty ? parts : meaningful;
+      baseName = effective.map(_sanitizeIdentifier).join('');
+    }
+
+    return '$baseName$genericSuffix';
+  }
+
+  void generateAll() {
+    _createDirectories();
+    _generateResponseFiles();
+    _generateModelFiles();
+    _generateApiFiles();
+    _generateExportFile();
+  }
+
+  void _createDirectories() {
+    final dir = Directory(outputDir);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+    Directory('$outputDir/models').createSync(recursive: true);
+    Directory('$outputDir/responses').createSync(recursive: true);
+    Directory('$outputDir/api').createSync(recursive: true);
+  }
+
+  void _generateResponseFiles() {
+    final apiResponseContent = '''
+import 'lidarr_error.dart';
+
+/// Standardized API response container for Lidarr API calls.
+class ApiResponse<T> {
+  final T? data;
+  final LidarrError? error;
+  final int? statusCode;
+  final bool isSuccess;
+
+  const ApiResponse.success(this.data, {this.statusCode})
+      : error = null,
+        isSuccess = true;
+
+  const ApiResponse.error(this.error, {this.statusCode})
+      : data = null,
+        isSuccess = false;
+}
+''';
+    File('$outputDir/responses/api_response.dart')
+        .writeAsStringSync(apiResponseContent);
+
+    final errorContent = '''
+import 'package:dio/dio.dart';
+
+/// Error model returned by Lidarr API endpoints.
+class LidarrError {
+  final String? message;
+  final String? description;
+  final List<String> errors;
+
+  const LidarrError({
+    this.message,
+    this.description,
+    this.errors = const [],
+  });
+
+  factory LidarrError.fromJson(Map<String, dynamic> json) {
+    final errList = (json['errors'] as List<dynamic>?)
+            ?.map((e) => e.toString())
+            .toList() ??
+        [];
+    return LidarrError(
+      message: json['message'] as String? ?? json['error'] as String?,
+      description: json['description'] as String?,
+      errors: errList,
+    );
+  }
+
+  factory LidarrError.fromDio(DioException exception) {
+    if (exception.response?.data is Map<String, dynamic>) {
+      return LidarrError.fromJson(
+          exception.response!.data as Map<String, dynamic>);
+    }
+    return LidarrError(
+      message: exception.message ?? 'HTTP Error \${exception.response?.statusCode}',
+      description: exception.type.toString(),
+    );
+  }
+}
+''';
+    File('$outputDir/responses/lidarr_error.dart')
+        .writeAsStringSync(errorContent);
+
+    final exceptionContent = '''
+import 'lidarr_error.dart';
+
+/// Custom exception thrown on Lidarr API failure.
+class LidarrException implements Exception {
+  final String message;
+  final int? statusCode;
+  final LidarrError? error;
+
+  const LidarrException(
+    this.message, {
+    this.statusCode,
+    this.error,
+  });
+
+  @override
+  String toString() =>
+      'LidarrException(statusCode: \$statusCode, message: \$message, error: \$error)';
+}
+''';
+    File('$outputDir/responses/lidarr_exception.dart')
+        .writeAsStringSync(exceptionContent);
+  }
+
+  void _generateModelFiles() {
+    for (final entry in schemas.entries) {
+      final fullKey = entry.key;
+      final schema = entry.value as Map<String, dynamic>;
+      final className = schemaClassNames[fullKey]!;
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildModelCode(fullKey, className, schema);
+      File('$outputDir/models/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildModelCode(
+      String fullKey, String className, Map<String, dynamic> schema) {
+    final isEnum = schema.containsKey('enum');
+    if (isEnum) {
+      return _buildEnumCode(className, schema);
+    }
+
+    final properties = (schema['properties'] as Map<String, dynamic>?) ?? {};
+    final title = schema['title'] as String?;
+    final description = schema['description'] as String?;
+
+    final imports = <String>{};
+    final fields = <_ModelField>[];
+    final usedFieldNames = <String>{};
+
+    for (final propEntry in properties.entries) {
+      final propKey = propEntry.key;
+      final propSchema = propEntry.value as Map<String, dynamic>;
+      var fieldName = _toCamelCase(propKey);
+      if (usedFieldNames.contains(fieldName)) {
+        fieldName = '${fieldName}Alt';
+      }
+      usedFieldNames.add(fieldName);
+
+      final fieldTypeInfo = _parseType(propSchema, imports);
+      final propDesc = propSchema['description'] as String?;
+      final isDeprecated = propSchema['deprecated'] == true;
+
+      fields.add(_ModelField(
+        jsonKey: propKey,
+        fieldName: fieldName,
+        dartType: fieldTypeInfo.dartType,
+        isNullable: fieldTypeInfo.isNullable,
+        isList: fieldTypeInfo.isList,
+        isCustomClass: fieldTypeInfo.isCustomClass,
+        customClassName: fieldTypeInfo.customClassName,
+        description: propDesc,
+        isDeprecated: isDeprecated,
+      ));
+    }
+
+    final fileName = _toSnakeCase(className);
+    final buffer = StringBuffer();
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    for (final imp in imports) {
+      if (imp != className) {
+        final impFileName = _toSnakeCase(imp);
+        buffer.writeln("import '$impFileName.dart';");
+      }
+    }
+    buffer.writeln();
+    buffer.writeln("part '$fileName.freezed.dart';");
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+
+    final classDoc = description ?? title;
+    if (classDoc != null && classDoc.isNotEmpty) {
+      for (final line in classDoc.split('\n')) {
+        buffer.writeln('/// ${line.trim()}');
+      }
+      buffer.writeln('///');
+    }
+    buffer.writeln('/// Original C# Schema: `$fullKey`');
+    if (schema['deprecated'] == true) {
+      buffer.writeln("@Deprecated('Marked deprecated in OpenAPI spec')");
+    }
+    buffer.writeln('@freezed');
+    buffer.writeln('abstract class $className with _\$$className {');
+    if (fields.isEmpty) {
+      buffer.writeln('  const factory $className() = _$className;');
+    } else {
+      buffer.writeln('  const factory $className({');
+      for (final f in fields) {
+        if (f.description != null && f.description!.isNotEmpty) {
+          for (final line in f.description!.split('\n')) {
+            buffer.writeln('    /// ${line.trim()}');
+          }
+        }
+        if (f.isDeprecated) {
+          buffer.writeln("    @Deprecated('Marked deprecated in OpenAPI spec')");
+        }
+        final typeStr = f.dartType.endsWith('?') ? f.dartType : '${f.dartType}?';
+        buffer.writeln("    @JsonKey(name: '${f.jsonKey}') $typeStr ${f.fieldName},");
+      }
+      buffer.writeln('  }) = _$className;');
+    }
+    buffer.writeln();
+    buffer.writeln('  factory $className.fromJson(Map<String, dynamic> json) =>');
+    buffer.writeln('      _\$${className}FromJson(json);');
+    buffer.writeln('}');
+
+    return buffer.toString();
+  }
+
+  String _buildEnumCode(String className, Map<String, dynamic> schema) {
+    final buffer = StringBuffer();
+    final enumList = schema['enum'] as List<dynamic>;
+    final fileName = _toSnakeCase(className);
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    buffer.writeln();
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+    buffer.writeln('/// Enum `$className`');
+    buffer.writeln('@JsonEnum(alwaysCreate: true)');
+    buffer.writeln('enum $className {');
+
+    for (final item in enumList) {
+      final strVal = item.toString();
+      final identifier = _toCamelCase(strVal);
+      buffer.writeln("  @JsonValue('$strVal')");
+      buffer.writeln('  $identifier,');
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _TypeInfo _parseType(
+      Map<String, dynamic> schema, Set<String> imports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      imports.add(cls);
+      return _TypeInfo(
+          dartType: cls, isNullable: true, isCustomClass: true, customClassName: cls);
+    }
+
+    final type = schema['type'] as String?;
+    if (type == 'array') {
+      final items = (schema['items'] as Map<String, dynamic>?) ?? {};
+      final itemType = _parseType(items, imports);
+      final listDartType = 'List<${itemType.dartType}>';
+      return _TypeInfo(
+        dartType: listDartType,
+        isNullable: true,
+        isList: true,
+        customClassName: itemType.isCustomClass ? itemType.customClassName : null,
+      );
+    }
+
+    if (type == 'integer') {
+      return _TypeInfo(dartType: 'int', isNullable: true);
+    }
+    if (type == 'number') {
+      return _TypeInfo(dartType: 'double', isNullable: true);
+    }
+    if (type == 'boolean') {
+      return _TypeInfo(dartType: 'bool', isNullable: true);
+    }
+    if (type == 'string') {
+      return _TypeInfo(dartType: 'String', isNullable: true);
+    }
+
+    return _TypeInfo(dartType: 'dynamic', isNullable: true);
+  }
+
+  void _generateApiFiles() {
+    for (final entry in tagEndpoints.entries) {
+      final tag = entry.key;
+      final endpoints = entry.value;
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildApiCode(tag, className, endpoints);
+      File('$outputDir/api/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildApiCode(
+      String tag, String className, List<Map<String, dynamic>> endpoints) {
+    final buffer = StringBuffer();
+    final imports = <String>{
+      "import 'dart:convert';",
+      "import 'package:dio/dio.dart';",
+      "import '../responses/api_response.dart';",
+      "import '../responses/lidarr_error.dart';",
+      "import '../responses/lidarr_exception.dart';",
+    };
+
+    final modelImports = <String>{};
+
+    for (final ep in endpoints) {
+      final op = ep['operation'] as Map<String, dynamic>;
+      final respSchema = _getSuccessResponseSchema(op);
+      if (respSchema != null) {
+        _extractModelImports(respSchema, modelImports);
+      }
+      final bodySchema = _getRequestBodySchema(op);
+      if (bodySchema != null) {
+        _extractModelImports(bodySchema, modelImports);
+      }
+    }
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    for (final imp in imports) {
+      buffer.writeln(imp);
+    }
+
+    for (final mImp in modelImports) {
+      final fileName = _toSnakeCase(mImp);
+      buffer.writeln("import '../models/$fileName.dart';");
+    }
+    buffer.writeln();
+
+    buffer.writeln('/// Raw API client for `$tag` endpoints.');
+    buffer.writeln('class $className {');
+    buffer.writeln('  final Dio _dio;');
+    buffer.writeln();
+    buffer.writeln('  $className(this._dio);');
+    buffer.writeln();
+
+    final usedMethodNames = <String>{};
+    for (final ep in endpoints) {
+      final path = ep['path'] as String;
+      final verb = ep['verb'] as String;
+      final op = ep['operation'] as Map<String, dynamic>;
+
+      final summary = op['summary'] as String?;
+      final description = op['description'] as String?;
+      final operationId = op['operationId'] as String?;
+
+      var methodName = _buildMethodName(verb, path, operationId);
+      if (usedMethodNames.contains(methodName)) {
+        var count = 2;
+        while (usedMethodNames.contains('$methodName$count')) {
+          count++;
+        }
+        methodName = '$methodName$count';
+      }
+      usedMethodNames.add(methodName);
+
+      final doc = summary ?? description;
+      if (doc != null && doc.isNotEmpty) {
+        for (final line in doc.split('\n')) {
+          buffer.writeln('  /// ${line.trim()}');
+        }
+      }
+      buffer.writeln('  /// HTTP $verb $path');
+      if (op['deprecated'] == true) {
+        buffer.writeln("  @Deprecated('Marked deprecated in OpenAPI spec')");
+      }
+
+      final respSchema = _getSuccessResponseSchema(op);
+      final returnTypeInfo = _getReturnTypeInfo(respSchema);
+      final returnType = returnTypeInfo.type;
+
+      buffer.writeln('  Future<ApiResponse<$returnType>> $methodName(');
+
+      final params = (op['parameters'] as List<dynamic>?)?.cast<Map<String, dynamic>>() ?? [];
+      final pathParams = params.where((p) => p['in'] == 'path').toList();
+      final queryParams = params.where((p) => p['in'] == 'query').toList();
+      final bodySchema = _getRequestBodySchema(op);
+
+      final methodParams = <String>[];
+      for (final p in pathParams) {
+        final pName = _toCamelCase(p['name'] as String);
+        methodParams.add('required String $pName');
+      }
+      for (final q in queryParams) {
+        final qName = _toCamelCase(q['name'] as String);
+        methodParams.add('String? $qName');
+      }
+      if (bodySchema != null) {
+        methodParams.add('dynamic body');
+      }
+
+      if (methodParams.isNotEmpty) {
+        buffer.writeln('    {${methodParams.join(', ')}}');
+      }
+      buffer.writeln('  ) async {');
+
+      var interpolatedPath = path;
+      for (final p in pathParams) {
+        final rawName = p['name'] as String;
+        final pName = _toCamelCase(rawName);
+        interpolatedPath = interpolatedPath.replaceAll('{$rawName}', '\$$pName');
+      }
+
+      buffer.writeln('    try {');
+      buffer.writeln('      final Response<dynamic> resp = await _dio.$verb<dynamic>(');
+      buffer.writeln("        '$interpolatedPath',");
+      if (queryParams.isNotEmpty) {
+        buffer.writeln('        queryParameters: <String, dynamic>{');
+        for (final q in queryParams) {
+          final qRaw = q['name'] as String;
+          final qName = _toCamelCase(qRaw);
+          buffer.writeln("          if ($qName != null) '$qRaw': $qName,");
+        }
+        buffer.writeln('        },');
+      }
+      if (bodySchema != null) {
+        buffer.writeln('        data: body,');
+      }
+      buffer.writeln('      );');
+
+      buffer.writeln('      ${_buildDeserializationCode(returnTypeInfo)}');
+      buffer.writeln('      return ApiResponse.success(data, statusCode: resp.statusCode);');
+      buffer.writeln('    } on DioException catch (e) {');
+      buffer.writeln('      return ApiResponse.error(LidarrError.fromDio(e), statusCode: e.response?.statusCode);');
+      buffer.writeln('    }');
+      buffer.writeln('  }');
+      buffer.writeln();
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _ReturnTypeInfo _getReturnTypeInfo(Map<String, dynamic>? schema) {
+    if (schema == null) return _ReturnTypeInfo(type: 'void', isList: false, isCustomClass: false);
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      return _ReturnTypeInfo(type: cls, isList: false, isCustomClass: true, className: cls);
+    }
+    if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null && items.containsKey('\$ref')) {
+        final ref = items['\$ref'] as String;
+        final key = ref.replaceFirst('#/components/schemas/', '');
+        final cls = schemaClassNames[key] ?? 'dynamic';
+        return _ReturnTypeInfo(type: 'List<$cls>', isList: true, isCustomClass: true, className: cls);
+      }
+      return _ReturnTypeInfo(type: 'List<dynamic>', isList: true, isCustomClass: false);
+    }
+    return _ReturnTypeInfo(type: 'dynamic', isList: false, isCustomClass: false);
+  }
+
+  String _buildDeserializationCode(_ReturnTypeInfo info) {
+    if (info.type == 'void') {
+      return 'final void data = null;';
+    }
+    if (info.isList && info.isCustomClass) {
+      return 'final List<${info.className}> data = (resp.data as List<dynamic>?)?.map((e) => ${info.className}.fromJson(e as Map<String, dynamic>)).toList() ?? <${info.className}>[];';
+    }
+    if (info.isCustomClass) {
+      return 'final ${info.className}? data = resp.data is Map<String, dynamic> ? ${info.className}.fromJson(resp.data as Map<String, dynamic>) : null;';
+    }
+    return 'final dynamic data = resp.data;';
+  }
+
+  String _buildMethodName(String verb, String path, String? operationId) {
+    if (operationId != null && operationId.isNotEmpty) {
+      var clean = operationId.replaceAll(RegExp(r'ApiV\d+'), '');
+      return _toCamelCase(clean);
+    }
+    final pathParamMatches = RegExp(r'\{([^}]+)\}').allMatches(path);
+    final pathParamNames = pathParamMatches.map((m) => m.group(1)!).toList();
+
+    final cleanPath = path
+        .replaceAll(RegExp(r'^/api/v\d+/'), '/')
+        .replaceAll(RegExp(r'^/api/'), '/')
+        .replaceAll(RegExp(r'\{[^}]+\}'), '');
+    final parts = cleanPath.split('/').where((p) => p.isNotEmpty).toList();
+
+    if (pathParamNames.isNotEmpty) {
+      parts.add('by');
+      parts.addAll(pathParamNames);
+    }
+
+    final nameParts = [verb, ...parts];
+    return _toCamelCase(nameParts.join('_'));
+  }
+
+  Map<String, dynamic>? _getSuccessResponseSchema(Map<String, dynamic> op) {
+    final responses = op['responses'] as Map<String, dynamic>?;
+    if (responses == null) return null;
+    final resp200 = responses['200'] ?? responses['201'];
+    if (resp200 is Map<String, dynamic>) {
+      final content = resp200['content'] as Map<String, dynamic>?;
+      final jsonContent = content?['application/json'] ?? content?['text/json'];
+      return jsonContent?['schema'] as Map<String, dynamic>?;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _getRequestBodySchema(Map<String, dynamic> op) {
+    final reqBody = op['requestBody'] as Map<String, dynamic>?;
+    final content = reqBody?['content'] as Map<String, dynamic>?;
+    final jsonContent = content?['application/json'] ?? content?['text/json'];
+    return jsonContent?['schema'] as Map<String, dynamic>?;
+  }
+
+  void _extractModelImports(
+      Map<String, dynamic> schema, Set<String> modelImports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key];
+      if (cls != null) modelImports.add(cls);
+    } else if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null) _extractModelImports(items, modelImports);
+    }
+  }
+
+  void _generateExportFile() {
+    final buffer = StringBuffer();
+    buffer.writeln("// Autogenerated OpenAPI Exports for Lidarr\n");
+    buffer.writeln("export 'responses/api_response.dart';");
+    buffer.writeln("export 'responses/lidarr_error.dart';");
+    buffer.writeln("export 'responses/lidarr_exception.dart';");
+
+    for (final entry in schemas.entries) {
+      final className = schemaClassNames[entry.key]!;
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'models/$fileName.dart';");
+    }
+
+    for (final tag in tagEndpoints.keys) {
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'api/$fileName.dart';");
+    }
+
+    File('$outputDir/generated.dart').writeAsStringSync(buffer.toString());
+  }
+}
+
+class _ModelField {
+  final String jsonKey;
+  final String fieldName;
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+  final String? description;
+  final bool isDeprecated;
+
+  _ModelField({
+    required this.jsonKey,
+    required this.fieldName,
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+    this.description,
+    this.isDeprecated = false,
+  });
+}
+
+class _TypeInfo {
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+
+  _TypeInfo({
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+  });
+}
+
+class _ReturnTypeInfo {
+  final String type;
+  final bool isList;
+  final bool isCustomClass;
+  final String? className;
+
+  _ReturnTypeInfo({
+    required this.type,
+    required this.isList,
+    required this.isCustomClass,
+    this.className,
+  });
+}

--- a/services/service_ombi/.gitignore
+++ b/services/service_ombi/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated OpenAPI client & freezed model code
+lib/src/generated/

--- a/services/service_ombi/lib/service_ombi.dart
+++ b/services/service_ombi/lib/service_ombi.dart
@@ -1,0 +1,5 @@
+export 'src/generated/generated.dart';
+export 'src/services/ombi_client.dart';
+export 'src/services/ombi_request_service.dart';
+export 'src/services/ombi_search_service.dart';
+export 'src/services/ombi_settings_service.dart';

--- a/services/service_ombi/lib/src/services/ombi_client.dart
+++ b/services/service_ombi/lib/src/services/ombi_client.dart
@@ -1,0 +1,63 @@
+import 'package:dio/dio.dart';
+
+import '../generated/api/raw_calendar_api.dart';
+import '../generated/api/raw_identity_api.dart';
+import '../generated/api/raw_issues_api.dart';
+import '../generated/api/raw_plex_api.dart';
+import '../generated/api/raw_radarr_api.dart';
+import '../generated/api/raw_request_api.dart';
+import '../generated/api/raw_requests_api.dart';
+import '../generated/api/raw_search_api.dart';
+import '../generated/api/raw_settings_api.dart';
+import '../generated/api/raw_sonarr_api.dart';
+import 'ombi_request_service.dart';
+import 'ombi_search_service.dart';
+import 'ombi_settings_service.dart';
+
+/// Central client for Ombi API services.
+class OmbiClient {
+  final Dio dio;
+  final String baseUrl;
+  final String? apiKey;
+
+  late final RawSearchApi rawSearchApi;
+  late final RawRequestApi rawRequestApi;
+  late final RawRequestsApi rawRequestsApi;
+  late final RawSettingsApi rawSettingsApi;
+  late final RawIdentityApi rawIdentityApi;
+  late final RawCalendarApi rawCalendarApi;
+  late final RawIssuesApi rawIssuesApi;
+  late final RawSonarrApi rawSonarrApi;
+  late final RawRadarrApi rawRadarrApi;
+  late final RawPlexApi rawPlexApi;
+
+  late final OmbiSearchService searchService;
+  late final OmbiRequestService requestService;
+  late final OmbiSettingsService settingsService;
+
+  OmbiClient({
+    Dio? dio,
+    required this.baseUrl,
+    this.apiKey,
+  }) : dio = dio ?? Dio() {
+    this.dio.options.baseUrl = baseUrl.endsWith('/') ? baseUrl : '$baseUrl/';
+    if (apiKey != null && apiKey!.isNotEmpty) {
+      this.dio.options.headers['ApiKey'] = apiKey;
+    }
+
+    rawSearchApi = RawSearchApi(this.dio);
+    rawRequestApi = RawRequestApi(this.dio);
+    rawRequestsApi = RawRequestsApi(this.dio);
+    rawSettingsApi = RawSettingsApi(this.dio);
+    rawIdentityApi = RawIdentityApi(this.dio);
+    rawCalendarApi = RawCalendarApi(this.dio);
+    rawIssuesApi = RawIssuesApi(this.dio);
+    rawSonarrApi = RawSonarrApi(this.dio);
+    rawRadarrApi = RawRadarrApi(this.dio);
+    rawPlexApi = RawPlexApi(this.dio);
+
+    searchService = OmbiSearchService(rawSearchApi);
+    requestService = OmbiRequestService(rawRequestApi);
+    settingsService = OmbiSettingsService(rawSettingsApi);
+  }
+}

--- a/services/service_ombi/lib/src/services/ombi_request_service.dart
+++ b/services/service_ombi/lib/src/services/ombi_request_service.dart
@@ -1,0 +1,26 @@
+import '../generated/api/raw_request_api.dart';
+import '../generated/models/movie_requests.dart';
+import '../generated/responses/ombi_exception.dart';
+
+/// High-level service wrapper for Ombi media requests and approvals.
+class OmbiRequestService {
+  final RawRequestApi _rawRequestApi;
+
+  OmbiRequestService(this._rawRequestApi);
+
+  /// Retrieves details for a specific movie request by ID.
+  Future<MovieRequests?> getMovieRequestInfo(String requestId) async {
+    final response = await _rawRequestApi.getRequestMovieInfoByRequestId(requestId: requestId);
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw OmbiException(
+        response.error!.message ?? 'Movie request info failed',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw OmbiException('Movie request info failed', statusCode: response.statusCode);
+  }
+}

--- a/services/service_ombi/lib/src/services/ombi_search_service.dart
+++ b/services/service_ombi/lib/src/services/ombi_search_service.dart
@@ -1,0 +1,43 @@
+import '../generated/api/raw_search_api.dart';
+import '../generated/models/movie_full_info_view_model.dart';
+import '../generated/models/multi_search_result.dart';
+import '../generated/responses/ombi_exception.dart';
+
+/// High-level service wrapper for Ombi search endpoints with exception handling.
+class OmbiSearchService {
+  final RawSearchApi _rawSearchApi;
+
+  OmbiSearchService(this._rawSearchApi);
+
+  /// Performs a multi-search across movies and TV shows.
+  Future<List<MultiSearchResult>> searchMulti(String searchTerm) async {
+    final response = await _rawSearchApi.postSearchMultiBySearchTerm(searchTerm: searchTerm);
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw OmbiException(
+        response.error!.message ?? 'Multi search failed',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw OmbiException('Multi search failed', statusCode: response.statusCode);
+  }
+
+  /// Retrieves movie details by Movie DB ID.
+  Future<MovieFullInfoViewModel?> getMovieInfo(String movieDbId) async {
+    final response = await _rawSearchApi.getSearchMovieByMovieDbId(movieDbId: movieDbId);
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw OmbiException(
+        response.error!.message ?? 'Movie lookup failed',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw OmbiException('Movie lookup failed', statusCode: response.statusCode);
+  }
+}

--- a/services/service_ombi/lib/src/services/ombi_settings_service.dart
+++ b/services/service_ombi/lib/src/services/ombi_settings_service.dart
@@ -1,0 +1,25 @@
+import '../generated/api/raw_settings_api.dart';
+import '../generated/responses/ombi_exception.dart';
+
+/// High-level service wrapper for Ombi settings endpoints.
+class OmbiSettingsService {
+  final RawSettingsApi _rawSettingsApi;
+
+  OmbiSettingsService(this._rawSettingsApi);
+
+  /// Retrieves general Ombi system settings.
+  Future<dynamic> getOmbiSettings() async {
+    final response = await _rawSettingsApi.getSettingsOmbi();
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw OmbiException(
+        response.error!.message ?? 'Failed to fetch Ombi settings',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw OmbiException('Failed to fetch Ombi settings', statusCode: response.statusCode);
+  }
+}

--- a/services/service_ombi/pubspec.yaml
+++ b/services/service_ombi/pubspec.yaml
@@ -1,5 +1,5 @@
-name: service_sonarr
-description: Sonarr v3 API client and UI screens for Atrium.
+name: service_ombi
+description: Ombi API client, generated models, and service adapters for Atrium.
 publish_to: none
 resolution: workspace
 
@@ -8,29 +8,17 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
-  cached_network_image: ^3.4.1
   collection: ^1.18.0
-  core_models:
-  core_networking:
-  core_profile:
-  core_router:
-  core_storage:
-  core_ui:
   dio: ^5.7.0
   flutter:
     sdk: flutter
-  flutter_riverpod: ^3.3.2
   freezed_annotation: ^3.1.0
-  go_router: ^17.3.0
-  hive_ce: ^2.10.1
-  intl: ^0.20.1
   json_annotation: ^4.9.0
   meta: ^1.16.0
-  progress_indicator_m3e:
-  url_launcher: ^6.3.2
 
 dev_dependencies:
   build_runner: ^2.4.13
+  flutter_lints: ^6.0.0
   flutter_test:
     sdk: flutter
   freezed: ^3.2.5

--- a/services/service_ombi/test/ombi_parser_test.dart
+++ b/services/service_ombi/test/ombi_parser_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_ombi/service_ombi.dart';
+
+void main() {
+  group('Ombi Generated Specs & Models Test', () {
+    test('CalendarViewModel serialization and deserialization', () {
+      final json = {
+        'title': 'Inception',
+        'start': '2010-07-16T00:00:00Z',
+        'backgroundColor': '#000000',
+      };
+
+      final model = CalendarViewModel.fromJson(json);
+      expect(model.title, equals('Inception'));
+      expect(model.start, equals('2010-07-16T00:00:00Z'));
+
+      final toJsonResult = model.toJson();
+      expect(toJsonResult['title'], equals('Inception'));
+      expect(toJsonResult['backgroundColor'], equals('#000000'));
+    });
+
+    test('OmbiError and Exception parsing', () {
+      final errorJson = {
+        'message': 'Invalid movie ID specified.',
+        'description': 'Bad Request',
+      };
+
+      final ombiError = OmbiError.fromJson(errorJson);
+      expect(ombiError.message, equals('Invalid movie ID specified.'));
+      expect(ombiError.description, equals('Bad Request'));
+
+      final exception = OmbiException(
+        ombiError.message!,
+        statusCode: 400,
+        error: ombiError,
+      );
+      expect(exception.statusCode, equals(400));
+      expect(exception.toString(), contains('Invalid movie ID specified.'));
+    });
+
+    test('Enum serialization', () {
+      expect(ErrorCode.alreadyRequested.name, equals('alreadyRequested'));
+    });
+
+    test('OmbiClient initialization', () {
+      final client = OmbiClient(
+        baseUrl: 'https://ombi.example.com',
+        apiKey: 'test-api-key-123',
+      );
+
+      expect(client.baseUrl, equals('https://ombi.example.com'));
+      expect(client.dio.options.baseUrl, equals('https://ombi.example.com/'));
+      expect(client.apiKey, equals('test-api-key-123'));
+    });
+  });
+}

--- a/services/service_ombi/tool/openapi.json
+++ b/services/service_ombi/tool/openapi.json
@@ -1,0 +1,23043 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Ombi Api V1",
+    "contact": {
+      "name": "Jamie Rees",
+      "url": "https://www.ombi.io/"
+    },
+    "version": "v1"
+  },
+  "paths": {
+    "/api/v2/Calendar": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.CalendarViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.CalendarViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.CalendarViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/CouchPotato/profile": {
+      "post": {
+        "tags": [
+          "CouchPotato"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.CouchPotato.Models.CouchPotatoProfiles"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/CouchPotato/apikey": {
+      "post": {
+        "tags": [
+          "CouchPotato"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.CouchPotato.Models.CouchPotatoApiKey"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/CustomPage": {
+      "get": {
+        "tags": [
+          "CustomPage"
+        ],
+        "summary": "Gets the Custom Page Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomPageSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomPage"
+        ],
+        "summary": "Saves the Custom Page Settings.",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomPageSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomPageSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomPageSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomPageSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Emby": {
+      "post": {
+        "tags": [
+          "Emby"
+        ],
+        "summary": "Signs into the Emby Api",
+        "requestBody": {
+          "description": "The request.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Emby/info": {
+      "post": {
+        "tags": [
+          "Emby"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Emby.Models.PublicInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Emby/users": {
+      "get": {
+        "tags": [
+          "Emby"
+        ],
+        "summary": "Gets the emby users.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.External.UsersViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Emby/Library": {
+      "post": {
+        "tags": [
+          "Emby"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Emby.Models.EmbyItemContainer`1[[Ombi.Api.External.MediaServers.Emby.Models.Media.MediaFolders, Ombi.Api.External, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Features": {
+      "get": {
+        "tags": [
+          "Features"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Features/enable": {
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Features/disable": {
+      "post": {
+        "tags": [
+          "Features"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.FeatureEnablement"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Hub/Users": {
+      "get": {
+        "tags": [
+          "Hub"
+        ],
+        "summary": "Returns the currently connected users in Ombi",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.ConnectedUsersViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.ConnectedUsersViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.ConnectedUsersViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/Users": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Gets all users.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/dropdown/Users": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Gets all users for dropdown purposes.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModelDropdown"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Gets the current logged in user.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Creates the user.",
+        "requestBody": {
+          "description": "The user.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.IdentityResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Updates the user.",
+        "requestBody": {
+          "description": "The user.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.IdentityResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/language": {
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Sets the current users language",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UserLanguage"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UserLanguage"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UserLanguage"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UserLanguage"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/streamingcountry": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Returns the supported country codes that we have streaming data for",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Sets the current users country streaming preference",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.CountryStreamingPreference"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.CountryStreamingPreference"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.CountryStreamingPreference"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.CountryStreamingPreference"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/User/{id}": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Gets the user by the user id.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/local": {
+      "put": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "This is for the local user to change their details.",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UpdateLocalUserModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UpdateLocalUserModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UpdateLocalUserModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.Identity.UpdateLocalUserModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.IdentityResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/{userId}": {
+      "delete": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Deletes the user.",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "The user.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.IdentityResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/claims": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "summary": "Gets all available claims in the system.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.UI.ClaimCheckboxes"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/welcomeEmail": {
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.UserViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/notificationpreferences": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.UserNotificationPreferences"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/notificationpreferences/{userId}": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/NotificationPreferences": {
+      "post": {
+        "tags": [
+          "Identity"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.AddNotificationPreference"
+                }
+              }
+            },
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.AddNotificationPreference"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.AddNotificationPreference"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/Ombi.Models.Identity.AddNotificationPreference"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Identity/newsletter/unsubscribe/{userId}": {
+      "get": {
+        "tags": [
+          "Identity"
+        ],
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Images/tv/{tvdbid}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "tvdbid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/poster": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/poster/movie/{movieDbId}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "movieDbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/poster/tv/{tvdbid}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "tvdbid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/poster/tv/tmdb/{tmdbId}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "tmdbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/background/movie/{movieDbId}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "movieDbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/banner/movie/{movieDbId}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "movieDbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/background/tv/{tvdbid}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "tvdbid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/background/tv/tmdb/{id}": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Images/background": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Images/background/info": {
+      "get": {
+        "tags": [
+          "Images"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v2/Issues/{position}/{take}/{status}": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "parameters": [
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "take",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "status",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Engine.V2.IssuesSummaryModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Engine.V2.IssuesSummaryModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Engine.V2.IssuesSummaryModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Issues/details/{providerId}": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "parameters": [
+          {
+            "name": "providerId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.V2.IssuesSummaryModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.V2.IssuesSummaryModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.V2.IssuesSummaryModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/categories": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Get's all categories",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueCategory"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Creates a new category",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueCategory"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueCategory"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueCategory"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueCategory"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/categories/{catId}": {
+      "delete": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Deletes a Category",
+        "parameters": [
+          {
+            "name": "catId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Returns all the issues",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Create Movie Issue",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/{take}/{skip}/{status}": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Returns all the issues",
+        "parameters": [
+          {
+            "name": "take",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "status",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/count": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Returns all the issues count",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.IssueCountModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/{id}": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Returns the issue by Id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Issues"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/request/{id}": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/provider/{id}": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/{id}/comments": {
+      "get": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Get's all the issue comments by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.IssueCommentChatViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/comments": {
+      "post": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Adds a comment on an issue",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.NewIssueCommentViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.NewIssueCommentViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.NewIssueCommentViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.NewIssueCommentViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueComments"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/comments/{id}": {
+      "delete": {
+        "tags": [
+          "Issues"
+        ],
+        "summary": "Deletes a comment on a issue",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Issues/status": {
+      "post": {
+        "tags": [
+          "Issues"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.IssueStateViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.IssueStateViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.IssueStateViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.IssueStateViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Jellyfin": {
+      "post": {
+        "tags": [
+          "Jellyfin"
+        ],
+        "summary": "Signs into the Jellyfin Api",
+        "requestBody": {
+          "description": "The request.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Jellyfin/info": {
+      "post": {
+        "tags": [
+          "Jellyfin"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Jellyfin.Models.PublicInfo"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Jellyfin/Library": {
+      "post": {
+        "tags": [
+          "Jellyfin"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Jellyfin.Models.JellyfinItemContainer`1[[Ombi.Api.External.MediaServers.Jellyfin.Models.MediaFolders, Ombi.Api.External, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Jellyfin/users": {
+      "get": {
+        "tags": [
+          "Jellyfin"
+        ],
+        "summary": "Gets the jellyfin users.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.External.UsersViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/update": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the update job",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Checks for an update",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/plexuserimporter": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Plex User importer",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/plexwatchlist": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Plex Watchlist Importer",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/embyuserimporter": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Emby User importer",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/jellyfinuserimporter": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Jellyfin User importer",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/plexcontentcacher": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Plex Content Cacher",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/clearmediaserverdata": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Clear out the media server and resync",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/plexrecentlyadded": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs a smaller version of the content cacher",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/embycontentcacher": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Emby Content Cacher",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/embyrecentlyadded": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs a smaller version of the content cacher",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/jellyfincontentcacher": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Jellyfin Content Cacher",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/arrAvailability": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the Arr Availability Checker",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/autodeleterequests": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Job/newsletter": {
+      "post": {
+        "tags": [
+          "Job"
+        ],
+        "summary": "Runs the newsletter",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/LandingPage": {
+      "get": {
+        "tags": [
+          "LandingPage"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.MediaSeverAvailibilityViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Lidarr/enabled": {
+      "get": {
+        "tags": [
+          "Lidarr"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Lidarr/Profiles": {
+      "post": {
+        "tags": [
+          "Lidarr"
+        ],
+        "summary": "Gets the Lidarr profiles.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.LidarrProfile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Lidarr"
+        ],
+        "summary": "Gets the Lidarr profiles using the saved settings\r\n<remarks>The data is cached for an hour</remarks>",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.LidarrProfile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Lidarr/RootFolders": {
+      "post": {
+        "tags": [
+          "Lidarr"
+        ],
+        "summary": "Gets the Lidarr root folders.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.LidarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Lidarr"
+        ],
+        "summary": "Gets the Lidarr root folders using the saved settings.\r\n<remarks>The data is cached for an hour</remarks>",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.LidarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Lidarr/Metadata": {
+      "post": {
+        "tags": [
+          "Lidarr"
+        ],
+        "summary": "Gets the Lidarr metadata profiles.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.MetadataProfile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Logging": {
+      "post": {
+        "tags": [
+          "Logging"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UiLoggingModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UiLoggingModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UiLoggingModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UiLoggingModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/{count}/{position}/{orderType}/{statusType}/{availabilityType}": {
+      "get": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Gets album requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "orderType",
+            "in": "path",
+            "description": "The way we want to order.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "availabilityType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/total": {
+      "get": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Gets the total amount of album requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music": {
+      "get": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Gets all album requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.AlbumRequest"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Requests a album.",
+        "requestBody": {
+          "description": "The album.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MusicAlbumRequestViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MusicAlbumRequestViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MusicAlbumRequestViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MusicAlbumRequestViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/search/{searchTerm}": {
+      "get": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Searches for a specific album request",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "description": "The search term.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.AlbumRequest"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/{requestId}": {
+      "delete": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Deletes the specified album request.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "The request identifier.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/approve": {
+      "post": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Approves the specified album request.",
+        "requestBody": {
+          "description": "The albums's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/available": {
+      "post": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Set's the specified album as available",
+        "requestBody": {
+          "description": "The album's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/unavailable": {
+      "post": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Set's the specified album as unavailable",
+        "requestBody": {
+          "description": "The album's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.AlbumUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/deny": {
+      "put": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Denies the specified album request.",
+        "requestBody": {
+          "description": "The album's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyAlbumModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyAlbumModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyAlbumModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyAlbumModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/request/music/remaining": {
+      "get": {
+        "tags": [
+          "MusicRequest"
+        ],
+        "summary": "Gets model containing remaining number of music requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Notifications/massemail": {
+      "post": {
+        "tags": [
+          "Notifications"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.MassEmailModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.MassEmailModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.MassEmailModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.MassEmailModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex": {
+      "post": {
+        "tags": [
+          "Plex"
+        ],
+        "summary": "Signs into the Plex API.",
+        "requestBody": {
+          "description": "The request.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.PlexAuthentication"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/Libraries": {
+      "post": {
+        "tags": [
+          "Plex"
+        ],
+        "summary": "Gets the plex libraries.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.External.PlexLibrariesResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/Libraries/{machineId}": {
+      "get": {
+        "tags": [
+          "Plex"
+        ],
+        "parameters": [
+          {
+            "name": "machineId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.External.PlexLibrariesLiteResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/user": {
+      "post": {
+        "tags": [
+          "Plex"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexUserViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexUserViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexUserViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexUserViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/servers": {
+      "get": {
+        "tags": [
+          "Plex"
+        ],
+        "summary": "Gets the plex servers.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Plex"
+        ],
+        "summary": "Gets the plex servers.",
+        "requestBody": {
+          "description": "The u.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.UserRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.External.PlexServersViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/friends": {
+      "get": {
+        "tags": [
+          "Plex"
+        ],
+        "summary": "Gets the plex friends.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.External.UsersViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/oauth": {
+      "post": {
+        "tags": [
+          "Plex"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.PlexOAuthViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.PlexOAuthViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.PlexOAuthViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.PlexOAuthViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/WatchlistUsers": {
+      "get": {
+        "tags": [
+          "Plex"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.PlexUserWatchlistModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Plex/WatchlistUsers/revalidate": {
+      "post": {
+        "tags": [
+          "Plex"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Radarr/Profiles": {
+      "post": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr profiles.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr profiles using the saved settings\r\n<remarks>The data is cached for an hour</remarks>",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Radarr/enabled": {
+      "get": {
+        "tags": [
+          "Radarr"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Radarr/RootFolders": {
+      "post": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr root folders.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Radarr.Models.RadarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr root folders using the saved settings.\r\n<remarks>The data is cached for an hour</remarks>",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Radarr.Models.RadarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Radarr/Profiles/4k": {
+      "get": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr 4K profiles using the saved settings\r\n<remarks>The data is cached for an hour</remarks>",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Radarr/RootFolders/4k": {
+      "get": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr 4K root folders using the saved settings.\r\n<remarks>The data is cached for an hour</remarks>",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Radarr.Models.RadarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Radarr/tags": {
+      "post": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr tags",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Radarr.Models.Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Radarr"
+        ],
+        "summary": "Gets the Radarr tags",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Radarr.Models.Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/RecentlyAdded/movies": {
+      "get": {
+        "tags": [
+          "RecentlyAdded"
+        ],
+        "summary": "Returns the recently added movies for the past 7 days",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.RecentlyAddedMovieModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/RecentlyAdded/tv": {
+      "get": {
+        "tags": [
+          "RecentlyAdded"
+        ],
+        "summary": "Returns the recently added tv shows for the past 7 days",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.RecentlyAddedMovieModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/RecentlyAdded/tv/grouped": {
+      "get": {
+        "tags": [
+          "RecentlyAdded"
+        ],
+        "summary": "Returns the recently added tv shows for the past 7 days and groups them by season",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.RecentlyAddedMovieModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/{count}/{position}/{orderType}/{statusType}/{availabilityType}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets movie requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "orderType",
+            "in": "path",
+            "description": "The way we want to order.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "availabilityType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/info/{requestId}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Returns information about the Single Movie Request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "the movie request id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/total": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the total amount of movie requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets all movie requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Requests a movie.",
+        "requestBody": {
+          "description": "The movie.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieRequestViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieRequestViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieRequestViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieRequestViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Updates the specified movie request.",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/search/{searchTerm}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Searches for a specific movie request",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "description": "The search term.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/{requestId}": {
+      "delete": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Deletes the specified movie request.",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "The request identifier.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/all": {
+      "delete": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Deletes the all movie request.",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/approve": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Approves the specified movie request.",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/available": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Set's the specified Movie as available",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/unavailable": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Set's the specified Movie as unavailable",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MovieUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/deny": {
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Denies the specified movie request.",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyMovieModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyMovieModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyMovieModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.DenyMovieModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/total": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the total amount of TV requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/{count}/{position}/{orderType}/{statusFilterType}/{availabilityFilterType}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the tv requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "orderType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusType",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "availabilityType",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusFilterType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "availabilityFilterType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.TvRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tvlite/{count}/{position}/{orderType}/{statusFilterType}/{availabilityFilterType}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the tv requests lite.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "orderType",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusType",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "availabilityType",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "statusFilterType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "availabilityFilterType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.TvRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the tv requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Requests a tv show/episode/season.",
+        "requestBody": {
+          "description": "The tv.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Updates the a specific tv request",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tvlite": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the tv requests without the whole object graph (Does not include seasons/episodes).",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/{requestId}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Returns the full request object for the specified requestId",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Deletes the a specific tv request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "The request identifier.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/search/{searchTerm}": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Searches for a specific tv request",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "description": "The search term.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/root/{requestId}/{rootFolderId}": {
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Updates the root path for this tv show",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "rootFolderId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/quality/{requestId}/{qualityId}": {
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Updates the quality profile for this tv show",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "qualityId",
+            "in": "path",
+            "description": "",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/child": {
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Updates the a specific child request",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/deny": {
+      "put": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Denies the a specific child request",
+        "requestBody": {
+          "description": "This is the child request's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.DenyTvModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.DenyTvModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.DenyTvModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.DenyTvModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/available": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Set's the specified tv child as available",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/unavailable": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Set's the specified tv child as unavailable",
+        "requestBody": {
+          "description": "The Movie's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/approve": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Updates the a specific child request",
+        "requestBody": {
+          "description": "This is the child request's ID",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.TvUpdateModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/child/{requestId}": {
+      "delete": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Deletes the a specific tv request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "The model.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/{requestId}/child": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Retuns all children requests for the request id",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "description": "The Request Id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/count": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets the count of total requests",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Requests.RequestCountModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/userhasrequest": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Checks if the passed in user has a request",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/subscribe/{requestId}": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Subscribes for notifications to a movie request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/subscribe/{requestId}": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Subscribes for notifications to a TV request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/unsubscribe/{requestId}": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "UnSubscribes for notifications to a movie request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/unsubscribe/{requestId}": {
+      "post": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "UnSubscribes for notifications to a TV request",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/movie/remaining": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets model containing remaining number of movie requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Request/tv/remaining": {
+      "get": {
+        "tags": [
+          "Request"
+        ],
+        "summary": "Gets model containing remaining number of tv requests.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/RequestRetry": {
+      "get": {
+        "tags": [
+          "RequestRetry"
+        ],
+        "summary": "Get's all the failed requests that are currently in the queue",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.FailedRequestViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/RequestRetry/{queueId}": {
+      "delete": {
+        "tags": [
+          "RequestRetry"
+        ],
+        "parameters": [
+          {
+            "name": "queueId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "summary": "Gets movie requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return. e.g. 30",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position. e.g. position 60 for a 2nd page (since we have already got the first 30 items)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "description": "The item to sort on e.g. \"requestDate\"",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "description": "asc or desc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "description": "Optional. Only return requests made by this user id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/availble/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/available/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/processing/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/pending/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/denied/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/unavailable/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "summary": "Gets the unavailable movie requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return. e.g. 30",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position. e.g. position 60 for a 2nd page (since we have already got the first 30 items)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "description": "The item to sort on e.g. \"requestDate\"",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "description": "asc or desc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "description": "Optional. Only return requests made by this user id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "summary": "Gets Tv requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return. e.g. 30",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position. e.g. position 60 for a 2nd page (since we have already got the first 30 items)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "description": "The item to sort on e.g. \"requestDate\"",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "description": "asc or desc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "description": "Optional. Only return requests made by this user id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/pending/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/processing/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/available/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/denied/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/unavailable/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "summary": "Gets unavailable Tv requests.",
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "description": "The count of items you want to return. e.g. 30",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "description": "The position. e.g. position 60 for a 2nd page (since we have already got the first 30 items)",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "description": "The item to sort on e.g. \"requestDate\"",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "description": "asc or desc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "description": "Optional. Only return requests made by this user id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/advancedoptions": {
+      "post": {
+        "tags": [
+          "Requests"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv/advancedoptions": {
+      "post": {
+        "tags": [
+          "Requests"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.MediaAdvancedOptions"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/album/available/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/album/processing/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/album/pending/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/album/denied/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/album/{count}/{position}/{sort}/{sortOrder}": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "count",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "position",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortOrder",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "requestedBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/tv": {
+      "post": {
+        "tags": [
+          "Requests"
+        ],
+        "summary": "Requests a tv show/episode/season.",
+        "requestBody": {
+          "description": "The tv.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModelV2"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModelV2"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModelV2"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Requests.TvRequestViewModelV2"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/reprocess/{type}/{requestId}/{is4K}": {
+      "post": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+            }
+          },
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "is4K",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/movie/collection/{collectionId}": {
+      "post": {
+        "tags": [
+          "Requests"
+        ],
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.RequestEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Requests/recentlyRequested": {
+      "get": {
+        "tags": [
+          "Requests"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Requests.RecentlyRequestedModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Requests.RecentlyRequestedModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Requests.RecentlyRequestedModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/multi/{searchTerm}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns search results for both TV and Movies",
+        "description": "The ID's returned by this are all TheMovieDbID's even for the TV Shows. You can call M:Ombi.Controllers.V2.SearchController.GetTvInfoByMovieId(System.String) to get TV\r\n             Show information using the MovieDbId.",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "description": "The search you want, this can be for a movie or TV show e.g. Star Wars will return\r\n             all Star Wars movies and Star Wars Rebels the TV Sho",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Filter for the search",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchFilter"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchFilter"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchFilter"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchFilter"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchResult"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchResult"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MultiSearchResult"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/Genres/{media}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Gets the genres for either Tv or Movies depending on media type",
+        "parameters": [
+          {
+            "name": "media",
+            "in": "path",
+            "description": "Either `tv` or `movie`.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.TheMovieDbApi.Models.Genre"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.TheMovieDbApi.Models.Genre"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.TheMovieDbApi.Models.Genre"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/Languages": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.TheMovieDbApi.Models.Language"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.TheMovieDbApi.Models.Language"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.TheMovieDbApi.Models.Language"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/{movieDbId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns details for a single movie",
+        "parameters": [
+          {
+            "name": "movieDbId",
+            "in": "path",
+            "description": "The MovieDB Id",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/imdb/{imdbid}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "imdbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/request/{requestId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns details for a single movie",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieFullInfoViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/collection/{collectionId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns basic information about the provided collection",
+        "parameters": [
+          {
+            "name": "collectionId",
+            "in": "path",
+            "description": "The collection id from TheMovieDb",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieCollectionsViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieCollectionsViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieCollectionsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/{tvdbId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns details for a single show",
+        "description": "TVMaze is the TV Show Provider",
+        "parameters": [
+          {
+            "name": "tvdbid",
+            "in": "path",
+            "description": "The TVDB Id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/request/{requestId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns details for a single show",
+        "description": "TVMaze is the TV Show Provider",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/moviedb/{moviedbid}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns details for a single show",
+        "parameters": [
+          {
+            "name": "moviedbid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/similar": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns similar movies to the movie id passed in",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/popular": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Popular Movies",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/popular/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Popular Movies using paging",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/advancedSearch/movie/{currentPosition}/{amountToLoad}": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Advanced Searched Media using paging",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.DiscoverModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.DiscoverModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.DiscoverModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.DiscoverModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/seasonal/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Seasonal Movies",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/requested/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Recently Requested Movies using Paging",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/requested/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Recently Requested Tv using Paging",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/nowplaying": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Now Playing Movies",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/nowplaying/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Now Playing Movies by page",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/toprated": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns top rated movies.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/toprated/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns top rated movies by page.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/upcoming": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Upcoming movies.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/movie/upcoming/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Upcoming movies by page.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/popular/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Popular Tv Shows",
+        "description": "We use Trakt.tv as the Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/anticipated/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns most Anticipated tv shows by page.",
+        "description": "We use Trakt.tv as the Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/tv/mostwatched/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Most watched shows by page.",
+        "description": "We use Trakt.tv as the Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/v2/Search/tv/trending/{currentPosition}/{amountToLoad}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns trending shows by page",
+        "description": "We use TheMovieDb as the Provider",
+        "parameters": [
+          {
+            "name": "currentPosition",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "amountToLoad",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/actor/{actorId}/movie": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns all the movies that is by the actor id",
+        "parameters": [
+          {
+            "name": "actorId",
+            "in": "path",
+            "description": "TheMovieDb Actor ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/actor/{actorId}/tv": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns all the tv shows that is by the actor id",
+        "parameters": [
+          {
+            "name": "actorId",
+            "in": "path",
+            "description": "TheMovieDb Actor ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/artist/{artistId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "artistId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistInformation"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistInformation"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistInformation"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/artist/request/{requestId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistInformation"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistInformation"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistInformation"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/artist/album/{albumId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "albumId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ReleaseGroup"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ReleaseGroup"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ReleaseGroup"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/releasegroupart/{musicBrainzId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "musicBrainzId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.AlbumArt"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.AlbumArt"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.AlbumArt"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/ratings/movie/{name}/{year}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.RottenTomatoes.Models.MovieRatings"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.RottenTomatoes.Models.MovieRatings"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.RottenTomatoes.Models.MovieRatings"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/ratings/tv/{name}/{year}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "year",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.RottenTomatoes.Models.TvRatings"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.RottenTomatoes.Models.TvRatings"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.RottenTomatoes.Models.TvRatings"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/stream/movie/{movieDbId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "movieDBId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.StreamingData"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.StreamingData"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.StreamingData"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/Search/stream/tv/{movieDbId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "parameters": [
+          {
+            "name": "movieDbId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.StreamingData"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.StreamingData"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.StreamingData"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/{searchTerm}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Searches for a movie.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "description": "The search term.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/actor": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Searches for movies by a certain actor.",
+        "requestBody": {
+          "description": "language code is optional, by default it will be en. Language code uses ISO 639-1",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchActorModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchActorModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchActorModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchActorModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Searches for a movie.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "requestBody": {
+          "description": "The refinement model, language code and year are both optional. Language code uses ISO 639-1",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieRefineModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieRefineModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieRefineModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieRefineModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/info/{theMovieDbId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Gets extra information on the movie e.g. IMDBId",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "theMovieDbId",
+            "in": "path",
+            "description": "The movie database identifier.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/info": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Gets extra information on the movie e.g. IMDBId",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "requestBody": {
+          "description": "TheMovieDb and Language Code, Pass in the language code (ISO 639-1) to get it back in a different lang",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieExtraInfoRefineModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieExtraInfoRefineModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieExtraInfoRefineModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SearchMovieExtraInfoRefineModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/similar": {
+      "post": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns similar movies to the movie id passed in",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "requestBody": {
+          "description": "the movie",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.SimilarMoviesRefineModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/{theMovieDbId}/similar": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns similar movies to the movie id passed in",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "parameters": [
+          {
+            "name": "theMovieDbId",
+            "in": "path",
+            "description": "ID of the movie",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/popular": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Popular Movies",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/nowplaying": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Retuns Now Playing Movies",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/toprated": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns top rated movies.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/movie/upcoming": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Upcoming movies.",
+        "description": "We use TheMovieDb as the Movie Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchMovieViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/tv/{searchTerm}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Searches for a Tv Show.",
+        "description": "We use TvMaze as the Provider",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "description": "The search term.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/tv/info/{tvdbId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Gets extra show information.",
+        "description": "We use TvMaze as the Provider",
+        "parameters": [
+          {
+            "name": "tvdbId",
+            "in": "path",
+            "description": "The TVDB identifier.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/tv/popular": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Popular Tv Shows",
+        "description": "We use Trakt.tv as the Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/tv/anticipated": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns most Anticiplateds tv shows.",
+        "description": "We use Trakt.tv as the Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/tv/mostwatched": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns Most watched shows.",
+        "description": "We use Trakt.tv as the Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/v1/Search/tv/trending": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns trending shows",
+        "description": "We use Trakt.tv as the Provider",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchTvShowViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/music/artist/{searchTerm}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns the artist information we searched for",
+        "description": "We use Lidarr as the Provider",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchArtistViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/music/album/{searchTerm}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns the album information we searched for",
+        "description": "We use Lidarr as the Provider",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchAlbumViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/music/album/info/{foreignAlbumId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns the album information specified by the foreignAlbumId passed in",
+        "description": "We use Lidarr as the Provider",
+        "parameters": [
+          {
+            "name": "foreignAlbumId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchAlbumViewModel"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Search/music/artist/album/{foreignArtistId}": {
+      "get": {
+        "tags": [
+          "Search"
+        ],
+        "summary": "Returns all albums for the artist using the ForeignArtistId",
+        "description": "We use Lidarr as the Provider",
+        "parameters": [
+          {
+            "name": "foreignArtistId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.Search.SearchAlbumViewModel"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/ombi": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Ombi settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.OmbiSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Ombi settings.",
+        "requestBody": {
+          "description": "The ombi.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.OmbiSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.OmbiSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.OmbiSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.OmbiSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/baseurl": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the base url.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/about": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.AboutViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/ombi/resetApi": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/plex": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Plex Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Plex settings.",
+        "requestBody": {
+          "description": "The plex.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/clientid": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/emby": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Emby Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Emby settings.",
+        "requestBody": {
+          "description": "The emby.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/jellyfin": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Jellyfin Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Jellyfin settings.",
+        "requestBody": {
+          "description": "The jellyfin.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/landingpage": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Landing Page Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.LandingPageSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Landing Page settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.LandingPageSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.LandingPageSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.LandingPageSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.LandingPageSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/customization": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Customization Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomizationSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Customization settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomizationSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomizationSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomizationSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.CustomizationSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/defaultlanguage": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the default language set in Ombi",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/themes": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get's the preset themes available",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Models.PresetThemeViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/sonarr": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Sonarr Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Sonarr settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/radarr": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Radarr Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrCombinedModel"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Radarr settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrCombinedModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrCombinedModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrCombinedModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrCombinedModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/lidarr": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Lidarr Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Lidarr settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/lidarrenabled": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Lidarr Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/authentication": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Authentication settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.AuthenticationSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.AuthenticationSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.AuthenticationSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.AuthenticationSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Authentication Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.AuthenticationSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/Update": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Update settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UpdateSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UpdateSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UpdateSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UpdateSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Update Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UpdateSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/UserManagement": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the UserManagement Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UserManagementSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the UserManagement settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UserManagementSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UserManagementSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UserManagementSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.UserManagementSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/CouchPotato": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the CouchPotatoSettings Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the CouchPotatoSettings settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/DogNzb": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the DogNzbSettings Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.DogNzbSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the DogNzbSettings settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.DogNzbSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.DogNzbSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.DogNzbSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.DogNzbSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/SickRage": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the SickRage settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the SickRage Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/jobs": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the JobSettings Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.JobSettings"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the JobSettings settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.JobSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.JobSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.JobSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.JobSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.JobSettingsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/testcron": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.CronViewModelBody"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.CronViewModelBody"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.CronViewModelBody"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.CronViewModelBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Models.CronTestModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/Issues": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Vote settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.IssueSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.IssueSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.IssueSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.IssueSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Issues Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.IssueSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/issuesenabled": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/vote": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save the Vote settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.VoteSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.VoteSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.VoteSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.VoteSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Vote Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.VoteSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/voteenabled": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/themoviedb": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Save The Movie DB settings.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.TheMovieDbSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.TheMovieDbSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.TheMovieDbSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.TheMovieDbSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Get The Movie DB settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.TheMovieDbSettings"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/email": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the email notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.EmailNotificationsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.EmailNotificationsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.EmailNotificationsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.EmailNotificationsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Email Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.EmailNotificationsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/email/enabled": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Email Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/discord": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the discord notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.DiscordNotificationsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.DiscordNotificationsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.DiscordNotificationsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.DiscordNotificationsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the discord Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.DiscordNotificationsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/telegram": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the telegram notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TelegramNotificationsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TelegramNotificationsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TelegramNotificationsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TelegramNotificationsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the telegram Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.TelegramNotificationsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/pushbullet": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the pushbullet notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushbulletNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushbulletNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushbulletNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushbulletNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the pushbullet Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushbulletNotificationViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/pushover": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the pushover notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushoverNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushoverNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushoverNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushoverNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the pushover Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.PushoverNotificationViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/slack": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the slack notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.SlackNotificationsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.SlackNotificationsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.SlackNotificationsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.SlackNotificationsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the slack Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.SlackNotificationsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/mattermost": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the Mattermost notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MattermostNotificationsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MattermostNotificationsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MattermostNotificationsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MattermostNotificationsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Mattermost Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.MattermostNotificationsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/twilio": {
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Twilio Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.TwilioSettingsViewModel"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the Mattermost notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TwilioSettingsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TwilioSettingsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TwilioSettingsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.TwilioSettingsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/mobile": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the Mobile notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MobileNotificationsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MobileNotificationsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MobileNotificationsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.MobileNotificationsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Mobile Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.MobileNotificationsViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/gotify": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the gotify notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.GotifyNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.GotifyNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.GotifyNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.GotifyNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the gotify Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.GotifyNotificationViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/ntfy": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the ntfy notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NtfyNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NtfyNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NtfyNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NtfyNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the ntfy Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.NtfyNotificationViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/webhook": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the webhook notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WebhookNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WebhookNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WebhookNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WebhookNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the webhook notification settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.WebhookNotificationViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Settings/notifications/newsletter": {
+      "post": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Saves the Newsletter notification settings.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Settings"
+        ],
+        "summary": "Gets the Newsletter Notification Settings.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Sonarr/Profiles": {
+      "post": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr profiles.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.SonarrProfile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr profiles.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.SonarrProfile"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Sonarr/RootFolders": {
+      "post": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr root folders.",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.SonarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr root folders.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.SonarrRootFolder"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Sonarr/v3/LanguageProfiles": {
+      "get": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr V3 language profiles",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.V3.LanguageProfiles"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr V3 language profiles",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.V3.LanguageProfiles"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Sonarr/tags": {
+      "post": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr tags",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Sonarr"
+        ],
+        "summary": "Gets the Sonarr tags",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.Tag"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Sonarr/enabled": {
+      "get": {
+        "tags": [
+          "Sonarr"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Sonarr/version": {
+      "get": {
+        "tags": [
+          "Sonarr"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Stats": {
+      "get": {
+        "tags": [
+          "Stats"
+        ],
+        "parameters": [
+          {
+            "name": "from",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Engine.UserStatsSummary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Status": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "summary": "Gets the status of Ombi.",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/System.Net.HttpStatusCode"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Status/info": {
+      "get": {
+        "tags": [
+          "Status"
+        ],
+        "summary": "Returns information about this ombi instance",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/System/news": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v2/System/logs": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v2/System/logs/{logFileName}": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "parameters": [
+          {
+            "name": "logFileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v2/System/logs/download/{logFileName}": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "parameters": [
+          {
+            "name": "logFileName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/discord": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to discord using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.DiscordNotificationSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.DiscordNotificationSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.DiscordNotificationSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.DiscordNotificationSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/pushbullet": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Pushbullet using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushbulletSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushbulletSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushbulletSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushbulletSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/pushover": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Pushover using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushoverSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushoverSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushoverSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.PushoverSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/gotify": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Gotify using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.GotifySettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.GotifySettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.GotifySettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.GotifySettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/ntfy": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Ntfy using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.NtfySettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.NtfySettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.NtfySettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.NtfySettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/webhook": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to configured webhook using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.WebhookSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.WebhookSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.WebhookSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.WebhookSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/mattermost": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to mattermost using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.MattermostNotificationSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.MattermostNotificationSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.MattermostNotificationSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.MattermostNotificationSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/slack": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Slack using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.SlackNotificationSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.SlackNotificationSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.SlackNotificationSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.SlackNotificationSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/email": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message via email to the admin email using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.EmailNotificationSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.EmailNotificationSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.EmailNotificationSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.EmailNotificationSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/plex": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Checks if we can connect to Plex with the provided settings",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/emby": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Checks if we can connect to Emby with the provided settings",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/jellyfin": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Checks if we can connect to Jellyfin with the provided settings",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/radarr": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Checks if we can connect to Radarr with the provided settings",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.TesterResultModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/sonarr": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Checks if we can connect to Sonarr with the provided settings",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SonarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.TesterResultModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/couchpotato": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Checks if we can connect to CouchPotato with the provided settings",
+        "requestBody": {
+          "description": "",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.CouchPotatoSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/telegram": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Telegram using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.TelegramSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.TelegramSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.TelegramSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.TelegramSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/sickrage": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "summary": "Sends a test message to Slack using the provided settings",
+        "requestBody": {
+          "description": "The settings.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.SickRageSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/newsletter": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.NewsletterNotificationViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/mobile": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.MobileNotificationTestViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.MobileNotificationTestViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.MobileNotificationTestViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.MobileNotificationTestViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/lidarr": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.LidarrSettings"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.TesterResultModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Tester/whatsapp": {
+      "post": {
+        "tags": [
+          "Tester"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WhatsAppSettingsViewModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WhatsAppSettingsViewModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WhatsAppSettingsViewModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Core.Models.UI.WhatsAppSettingsViewModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/TheMovieDb/Keywords": {
+      "get": {
+        "tags": [
+          "TheMovieDb"
+        ],
+        "summary": "Searches for keywords matching the specified term.",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "description": "The search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.TheMovidDbKeyValue"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/TheMovieDb/Keywords/{keywordId}": {
+      "get": {
+        "tags": [
+          "TheMovieDb"
+        ],
+        "summary": "Gets the keyword matching the specified ID.",
+        "parameters": [
+          {
+            "name": "keywordId",
+            "in": "path",
+            "description": "The keyword ID.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/TheMovieDb/WatchProviders/movie": {
+      "get": {
+        "tags": [
+          "TheMovieDb"
+        ],
+        "summary": "Searches for the watch providers matching the specified term.",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "description": "The search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.WatchProvidersResults"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/TheMovieDb/WatchProviders/tv": {
+      "get": {
+        "tags": [
+          "TheMovieDb"
+        ],
+        "summary": "Searches for the watch providers matching the specified term.",
+        "parameters": [
+          {
+            "name": "searchTerm",
+            "in": "query",
+            "description": "The search term.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.WatchProvidersResults"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Token": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "summary": "Gets the token.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Controllers.V1.Token"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Token/plextoken": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "summary": "Returns the Token for the Ombi User if we can match the Plex user with a valid Ombi User",
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexTokenAuthentication"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexTokenAuthentication"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexTokenAuthentication"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.External.PlexTokenAuthentication"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Token/{pinId}": {
+      "get": {
+        "tags": [
+          "Token"
+        ],
+        "parameters": [
+          {
+            "name": "pinId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Token/refresh": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "summary": "Refreshes the token.",
+        "requestBody": {
+          "description": "The model.",
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Controllers.V1.TokenController+TokenRefresh"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Controllers.V1.TokenController+TokenRefresh"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Controllers.V1.TokenController+TokenRefresh"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Controllers.V1.TokenController+TokenRefresh"
+              }
+            }
+          }
+        },
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Token/requirePassword": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json-patch+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            },
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/Ombi.Models.UserAuthModel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Token/header_auth": {
+      "post": {
+        "tags": [
+          "Token"
+        ],
+        "responses": {
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Microsoft.AspNetCore.Mvc.ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/api/v1/Update": {
+      "get": {
+        "tags": [
+          "Update"
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Processor.UpdateModel"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote": {
+      "get": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Returns the viewmodel to render on the UI",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Core.Models.UI.VoteViewModel"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/up/movie/{requestId}": {
+      "post": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Upvotes a movie",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.VoteEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/up/tv/{requestId}": {
+      "post": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Upvotes a tv show",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.VoteEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/up/album/{requestId}": {
+      "post": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Upvotes a album",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.VoteEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/down/movie/{requestId}": {
+      "post": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Downvotes a movie",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.VoteEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/down/tv/{requestId}": {
+      "post": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Downvotes a tv show",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.VoteEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/down/album/{requestId}": {
+      "post": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Downvotes a album",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ombi.Core.Models.VoteEngineResult"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/movie/{requestId}": {
+      "get": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Get's all the votes for the request id",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Votes"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/music/{requestId}": {
+      "get": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Get's all the votes for the request id",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Votes"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/Vote/tv/{requestId}": {
+      "get": {
+        "tags": [
+          "Vote"
+        ],
+        "summary": "Get's all the votes for the request id",
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ombi.Store.Entities.Votes"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Microsoft.AspNetCore.Mvc.ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          },
+          "instance": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": { }
+      },
+      "Microsoft.Extensions.Logging.LogLevel": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Api.External.ExternalApis.CouchPotato.Models.CouchPotatoApiKey": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "api_key": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.CouchPotato.Models.CouchPotatoProfiles": {
+        "type": "object",
+        "properties": {
+          "list": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.CouchPotato.Models.ProfileList"
+            },
+            "nullable": true
+          },
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.CouchPotato.Models.ProfileList": {
+        "type": "object",
+        "properties": {
+          "core": {
+            "type": "boolean"
+          },
+          "hide": {
+            "type": "boolean"
+          },
+          "_rev": {
+            "type": "string",
+            "nullable": true
+          },
+          "finish": {
+            "type": "array",
+            "items": {
+              "type": "boolean"
+            },
+            "nullable": true
+          },
+          "qualities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "_t": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "minimum_score": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "stop_after": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "wait_for": {
+            "type": "array",
+            "items": { },
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "3d": {
+            "type": "array",
+            "items": { },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Lidarr.Models.Item": {
+        "type": "object",
+        "properties": {
+          "quality": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.Quality"
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Lidarr.Models.LidarrProfile": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.Item"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Lidarr.Models.LidarrRootFolder": {
+        "type": "object",
+        "properties": {
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "freeSpace": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "unmappedFolders": {
+            "type": "array",
+            "items": { },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Lidarr.Models.Link": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Lidarr.Models.MetadataProfile": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Lidarr.Models.Quality": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Radarr.Models.RadarrRootFolder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "freespace": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Radarr.Models.Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.RottenTomatoes.Models.MovieRatings": {
+        "type": "object",
+        "properties": {
+          "critics_rating": {
+            "type": "string",
+            "nullable": true
+          },
+          "critics_score": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audience_rating": {
+            "type": "string",
+            "nullable": true
+          },
+          "audience_score": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.RottenTomatoes.Models.TvRatings": {
+        "type": "object",
+        "properties": {
+          "class": {
+            "type": "string",
+            "nullable": true
+          },
+          "score": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.SonarrProfile": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.SonarrRootFolder": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "freespace": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.V3.Cutoff": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.V3.Language": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.V3.LanguageProfiles": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "upgradeAllowed": {
+            "type": "boolean"
+          },
+          "cutoff": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.V3.Cutoff"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.V3.Languages"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.Sonarr.Models.V3.Languages": {
+        "type": "object",
+        "properties": {
+          "languages": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Sonarr.Models.V3.Language"
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.ActorCredits": {
+        "type": "object",
+        "properties": {
+          "cast": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.Cast"
+            },
+            "nullable": true
+          },
+          "crew": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.Crew"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.Cast": {
+        "type": "object",
+        "properties": {
+          "character": {
+            "type": "string",
+            "nullable": true
+          },
+          "credit_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "poster_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "video": {
+            "type": "boolean"
+          },
+          "vote_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "adult": {
+            "type": "boolean"
+          },
+          "backdrop_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "genre_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "original_language": {
+            "type": "string",
+            "nullable": true
+          },
+          "original_title": {
+            "type": "string",
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "format": "float"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "vote_average": {
+            "type": "number",
+            "format": "float"
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "release_date": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.Crew": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "department": {
+            "type": "string",
+            "nullable": true
+          },
+          "original_language": {
+            "type": "string",
+            "nullable": true
+          },
+          "original_title": {
+            "type": "string",
+            "nullable": true
+          },
+          "job": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "vote_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "video": {
+            "type": "boolean"
+          },
+          "release_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "vote_average": {
+            "type": "number",
+            "format": "float"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "format": "float"
+          },
+          "genre_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "backdrop_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "adult": {
+            "type": "boolean"
+          },
+          "poster_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "credit_id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.DiscoverModel": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseYear": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "decade": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "genreIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "keywordIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "watchProviders": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "companies": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.RecommendationResults": {
+        "type": "object",
+        "properties": {
+          "adult": {
+            "type": "boolean"
+          },
+          "backdrop_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "genre_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "original_language": {
+            "type": "string",
+            "nullable": true
+          },
+          "original_title": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "poster_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "release_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "video": {
+            "type": "boolean"
+          },
+          "vote_average": {
+            "type": "number",
+            "format": "float"
+          },
+          "vote_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "popularity": {
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.Recommendations": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.RecommendationResults"
+            },
+            "nullable": true
+          },
+          "total_pages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_results": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDateDto": {
+        "type": "object",
+        "properties": {
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDateType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDateType": {
+        "enum": [
+          1,
+          2,
+          3,
+          4,
+          5,
+          6
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDatesDto": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseResultsDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseResultsDto": {
+        "type": "object",
+        "properties": {
+          "isoCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDateDto"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.Similar": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.SimilarResults"
+            },
+            "nullable": true
+          },
+          "total_pages": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "total_results": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.SimilarResults": {
+        "type": "object",
+        "properties": {
+          "adult": {
+            "type": "boolean"
+          },
+          "backdrop_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "genre_ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "original_language": {
+            "type": "string",
+            "nullable": true
+          },
+          "original_title": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "poster_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "release_date": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "video": {
+            "type": "boolean"
+          },
+          "vote_average": {
+            "type": "number",
+            "format": "float"
+          },
+          "vote_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "popularity": {
+            "type": "number",
+            "format": "float"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.TheMovidDbKeyValue": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.ExternalApis.TheMovieDb.Models.WatchProvidersResults": {
+        "type": "object",
+        "properties": {
+          "provider_id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "logo_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "provider_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "origin_country": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Emby.Models.EmbyItemContainer`1[[Ombi.Api.External.MediaServers.Emby.Models.Media.MediaFolders, Ombi.Api.External, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Emby.Models.Media.MediaFolders"
+            },
+            "nullable": true
+          },
+          "totalRecordCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Emby.Models.Media.MediaFolders": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "serverId": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "collectionType": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Emby.Models.PublicInfo": {
+        "type": "object",
+        "properties": {
+          "localAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "serverName": {
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "operatingSystem": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Jellyfin.Models.JellyfinItemContainer`1[[Ombi.Api.External.MediaServers.Jellyfin.Models.MediaFolders, Ombi.Api.External, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Jellyfin.Models.MediaFolders"
+            },
+            "nullable": true
+          },
+          "totalRecordCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Jellyfin.Models.MediaFolders": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "serverId": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "collectionType": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Jellyfin.Models.PublicInfo": {
+        "type": "object",
+        "properties": {
+          "localAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "serverName": {
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "operatingSystem": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Directory": {
+        "type": "object",
+        "properties": {
+          "allowSync": {
+            "type": "boolean"
+          },
+          "art": {
+            "type": "string",
+            "nullable": true
+          },
+          "composite": {
+            "type": "string",
+            "nullable": true
+          },
+          "filters": {
+            "type": "boolean"
+          },
+          "refreshing": {
+            "type": "boolean"
+          },
+          "thumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "agent": {
+            "type": "string",
+            "nullable": true
+          },
+          "scanner": {
+            "type": "string",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "uuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "updatedAt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "location": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Location"
+            },
+            "nullable": true
+          },
+          "providerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "guid": {
+            "type": "string",
+            "nullable": true
+          },
+          "genre": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Genre"
+            },
+            "nullable": true
+          },
+          "role": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Role"
+            },
+            "nullable": true
+          },
+          "librarySectionID": {
+            "type": "string",
+            "nullable": true
+          },
+          "librarySectionTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "librarySectionUUID": {
+            "type": "string",
+            "nullable": true
+          },
+          "personal": {
+            "type": "string",
+            "nullable": true
+          },
+          "sourceTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "ratingKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "studio": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Directory"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Genre": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Location": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Mediacontainer": {
+        "type": "object",
+        "properties": {
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title1": {
+            "type": "string",
+            "nullable": true
+          },
+          "directory": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Directory"
+            },
+            "nullable": true
+          },
+          "art": {
+            "type": "string",
+            "nullable": true
+          },
+          "librarySectionID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "librarySectionTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "librarySectionUUID": {
+            "type": "string",
+            "nullable": true
+          },
+          "nocache": {
+            "type": "boolean"
+          },
+          "thumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "title2": {
+            "type": "string",
+            "nullable": true
+          },
+          "viewGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "viewMode": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "metadata": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Metadata"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Medium": {
+        "type": "object",
+        "properties": {
+          "videoResolution": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "duration": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bitrate": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aspectRatio": {
+            "type": "number",
+            "format": "float"
+          },
+          "audioChannels": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audioCodec": {
+            "type": "string",
+            "nullable": true
+          },
+          "videoCodec": {
+            "type": "string",
+            "nullable": true
+          },
+          "container": {
+            "type": "string",
+            "nullable": true
+          },
+          "videoFrameRate": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioProfile": {
+            "type": "string",
+            "nullable": true
+          },
+          "videoProfile": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Metadata": {
+        "type": "object",
+        "properties": {
+          "ratingKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "studio": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "contentRating": {
+            "type": "string",
+            "nullable": true
+          },
+          "summary": {
+            "type": "string",
+            "nullable": true
+          },
+          "index": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "thumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "art": {
+            "type": "string",
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "theme": {
+            "type": "string",
+            "nullable": true
+          },
+          "leafCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "viewedLeafCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "childCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "genre": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Genre"
+            },
+            "nullable": true
+          },
+          "primaryExtraKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentRatingKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "grandparentRatingKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "guid": {
+            "type": "string",
+            "nullable": true
+          },
+          "librarySectionID": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "librarySectionKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "grandparentKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "grandparentTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "parentIndex": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "parentThumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "grandparentThumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "grandparentArt": {
+            "type": "string",
+            "nullable": true
+          },
+          "grandparentTheme": {
+            "type": "string",
+            "nullable": true
+          },
+          "chapterSource": {
+            "type": "string",
+            "nullable": true
+          },
+          "media": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Medium"
+            },
+            "nullable": true
+          },
+          "Guid": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.PlexGuids"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.OAuth.Location": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "nullable": true
+          },
+          "subdivisions": {
+            "type": "string",
+            "nullable": true
+          },
+          "coordinates": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.OAuth.OAuthPin": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "code": {
+            "type": "string",
+            "nullable": true
+          },
+          "trusted": {
+            "type": "boolean"
+          },
+          "clientIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "location": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.OAuth.Location"
+          },
+          "expiresIn": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "authToken": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.PlexAuthentication": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.User"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.PlexContainer": {
+        "type": "object",
+        "properties": {
+          "mediaContainer": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Mediacontainer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.PlexGuids": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Role": {
+        "type": "object",
+        "properties": {
+          "tag": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Roles": {
+        "type": "object",
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": { },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.SectionLite": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Server.Connection": {
+        "type": "object",
+        "properties": {
+          "protocol": {
+            "type": "string",
+            "nullable": true
+          },
+          "address": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "string",
+            "nullable": true
+          },
+          "uri": {
+            "type": "string",
+            "nullable": true
+          },
+          "local": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Server.Device": {
+        "type": "object",
+        "properties": {
+          "connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Server.Connection"
+            },
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "product": {
+            "type": "string",
+            "nullable": true
+          },
+          "productVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "platform": {
+            "type": "string",
+            "nullable": true
+          },
+          "platformVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "deviceType": {
+            "type": "string",
+            "nullable": true
+          },
+          "clientIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastSeenAt": {
+            "type": "string",
+            "nullable": true
+          },
+          "provides": {
+            "type": "string",
+            "nullable": true
+          },
+          "owned": {
+            "type": "string",
+            "nullable": true
+          },
+          "accessToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "searchEnabled": {
+            "type": "string",
+            "nullable": true
+          },
+          "publicAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "httpsRequired": {
+            "type": "string",
+            "nullable": true
+          },
+          "synced": {
+            "type": "string",
+            "nullable": true
+          },
+          "relay": {
+            "type": "string",
+            "nullable": true
+          },
+          "dnsRebindingProtection": {
+            "type": "string",
+            "nullable": true
+          },
+          "natLoopbackSupported": {
+            "type": "string",
+            "nullable": true
+          },
+          "publicAddressMatches": {
+            "type": "string",
+            "nullable": true
+          },
+          "presence": {
+            "type": "string",
+            "nullable": true
+          },
+          "ownerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "home": {
+            "type": "string",
+            "nullable": true
+          },
+          "sourceTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "localAddresses": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "machineIdentifier": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "port": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "scheme": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Server.PlexServer": {
+        "type": "object",
+        "properties": {
+          "devices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Server.Device"
+            },
+            "nullable": true
+          },
+          "friendlyName": {
+            "type": "string",
+            "nullable": true
+          },
+          "identifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "machineIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.Subscription": {
+        "type": "object",
+        "properties": {
+          "active": {
+            "type": "boolean"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "plan": {
+            "nullable": true
+          },
+          "features": {
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "uuid": {
+            "type": "string",
+            "nullable": true
+          },
+          "joined_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "thumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "hasPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "authentication_token": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscription": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Subscription"
+          },
+          "roles": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Roles"
+          },
+          "entitlements": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "confirmed_at": {
+            "nullable": true
+          },
+          "forum_id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Api.External.MediaServers.Plex.Models.UserRequest": {
+        "type": "object",
+        "properties": {
+          "login": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Controllers.V1.Token": {
+        "type": "object",
+        "properties": {
+          "access_token": {
+            "type": "string",
+            "nullable": true
+          },
+          "expiration": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Controllers.V1.TokenController+TokenRefresh": {
+        "type": "object",
+        "properties": {
+          "token": {
+            "type": "string",
+            "nullable": true
+          },
+          "userename": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Engine.ErrorCode": {
+        "enum": [
+          "AlreadyRequested",
+          "EpisodesAlreadyRequested",
+          "NoPermissionsOnBehalf",
+          "NoPermissions",
+          "RequestDoesNotExist",
+          "ChildRequestDoesNotExist",
+          "NoPermissionsRequestMovie",
+          "NoPermissionsRequestTV",
+          "NoPermissionsRequestAlbum",
+          "MovieRequestQuotaExceeded",
+          "TvRequestQuotaExceeded",
+          "AlbumRequestQuotaExceeded"
+        ],
+        "type": "string"
+      },
+      "Ombi.Core.Engine.RequestEngineResult": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "isError": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "errorCode": {
+            "$ref": "#/components/schemas/Ombi.Core.Engine.ErrorCode"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Engine.UserStatsSummary": {
+        "type": "object",
+        "properties": {
+          "totalRequests": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "totalMovieRequests": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalTvRequests": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalIssues": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "completedRequestsMovies": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "completedRequestsTv": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "completedRequests": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          },
+          "mostRequestedUserMovie": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "mostRequestedUserTv": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Engine.V2.IssuesSummaryModel": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "providerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.MassEmailModel": {
+        "type": "object",
+        "properties": {
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "body": {
+            "type": "string",
+            "nullable": true
+          },
+          "bcc": {
+            "type": "boolean"
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.PlexUserWatchlistModel": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "syncStatus": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.WatchlistSyncStatus"
+          },
+          "userName": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.RecentlyAddedMovieModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "tvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseYear": {
+            "type": "string",
+            "nullable": true
+          },
+          "addedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.RequestQuotaCountModel": {
+        "type": "object",
+        "properties": {
+          "hasLimit": {
+            "type": "boolean"
+          },
+          "limit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "remaining": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "nextRequest": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.AlbumUpdateModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.DenyAlbumModel": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.DenyMovieModel": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "is4K": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.EpisodesViewModel": {
+        "type": "object",
+        "properties": {
+          "episodeNumber": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.MediaAdvancedOptions": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rootPathOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "qualityOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languageProfile": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.MovieRequestViewModel": {
+        "type": "object",
+        "properties": {
+          "theMovieDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languageCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "is4kRequest": {
+            "type": "boolean"
+          },
+          "requestOnBehalf": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootFolderOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "qualityPathOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.MovieUpdateModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "is4K": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.MusicAlbumRequestViewModel": {
+        "type": "object",
+        "properties": {
+          "foreignAlbumId": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedByAlias": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.RecentlyRequestedModel": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "tvPartiallyAvailable": {
+            "type": "boolean"
+          },
+          "requestDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean"
+          },
+          "mediaId": {
+            "type": "string",
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "background": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.RequestCountModel": {
+        "type": "object",
+        "properties": {
+          "pending": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "denied": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.SeasonsViewModel": {
+        "type": "object",
+        "properties": {
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Requests.EpisodesViewModel"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.TvRequestViewModel": {
+        "type": "object",
+        "properties": {
+          "tvDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "requestAll": {
+            "type": "boolean"
+          },
+          "latestSeason": {
+            "type": "boolean"
+          },
+          "languageProfile": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "firstSeason": {
+            "type": "boolean"
+          },
+          "seasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Requests.SeasonsViewModel"
+            },
+            "nullable": true
+          },
+          "requestOnBehalf": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootFolderOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "qualityPathOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Requests.TvRequestViewModelV2": {
+        "type": "object",
+        "properties": {
+          "theMovieDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languageCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.RequestSource"
+          },
+          "requestAll": {
+            "type": "boolean"
+          },
+          "latestSeason": {
+            "type": "boolean"
+          },
+          "languageProfile": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "firstSeason": {
+            "type": "boolean"
+          },
+          "seasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Requests.SeasonsViewModel"
+            },
+            "nullable": true
+          },
+          "requestOnBehalf": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootFolderOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "qualityPathOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.SearchAlbumViewModel": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "foreignAlbumId": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "albumType": {
+            "type": "string",
+            "nullable": true
+          },
+          "rating": {
+            "type": "number",
+            "format": "double"
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          },
+          "foreignArtistId": {
+            "type": "string",
+            "nullable": true
+          },
+          "cover": {
+            "type": "string",
+            "nullable": true
+          },
+          "disk": {
+            "type": "string",
+            "nullable": true
+          },
+          "percentOfTracks": {
+            "type": "number",
+            "format": "double"
+          },
+          "genres": {
+            "type": "array",
+            "items": { },
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "partiallyAvailable": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "fullyAvailable": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.SearchArtistViewModel": {
+        "type": "object",
+        "properties": {
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          },
+          "forignArtistId": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "disambiguation": {
+            "type": "string",
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "poster": {
+            "type": "string",
+            "nullable": true
+          },
+          "logo": {
+            "type": "string",
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "artistType": {
+            "type": "string",
+            "nullable": true
+          },
+          "cleanName": {
+            "type": "string",
+            "nullable": true
+          },
+          "links": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.Lidarr.Models.Link"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.SearchMovieViewModel": {
+        "type": "object",
+        "properties": {
+          "adult": {
+            "type": "boolean"
+          },
+          "backdropPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "genreIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "originalLanguage": {
+            "type": "string",
+            "nullable": true
+          },
+          "originalTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "format": "double"
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "video": {
+            "type": "boolean"
+          },
+          "voteAverage": {
+            "type": "number",
+            "format": "double"
+          },
+          "voteCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alreadyInCp": {
+            "type": "boolean"
+          },
+          "trailer": {
+            "type": "string",
+            "nullable": true
+          },
+          "homepage": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootPathOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "qualityOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "releaseDates": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDatesDto"
+          },
+          "digitalReleaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "has4KRequest": {
+            "type": "boolean"
+          },
+          "approved4K": {
+            "type": "boolean"
+          },
+          "markedAsApproved4K": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestedDate4k": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "available4K": {
+            "type": "boolean"
+          },
+          "markedAsAvailable4K": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "denied4K": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "markedAsDenied4K": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deniedReason4K": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.SearchTvShowViewModel": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstAired": {
+            "type": "string",
+            "nullable": true
+          },
+          "network": {
+            "type": "string",
+            "nullable": true
+          },
+          "networkId": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtime": {
+            "type": "string",
+            "nullable": true
+          },
+          "genre": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastUpdated": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "airsDayOfWeek": {
+            "type": "string",
+            "nullable": true
+          },
+          "airsTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "rating": {
+            "type": "string",
+            "nullable": true
+          },
+          "siteRating": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trailer": {
+            "type": "string",
+            "nullable": true
+          },
+          "homepage": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonRequests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Repository.Requests.SeasonRequests"
+            },
+            "nullable": true
+          },
+          "requestAll": {
+            "type": "boolean"
+          },
+          "firstSeason": {
+            "type": "boolean"
+          },
+          "latestSeason": {
+            "type": "boolean"
+          },
+          "fullyAvailable": {
+            "type": "boolean"
+          },
+          "partlyAvailable": {
+            "type": "boolean"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "backdropPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.CalendarViewModel": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "backgroundColor": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "extraParams": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.ExtraParams"
+            },
+            "nullable": true
+          },
+          "borderColor": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.CastViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "person": {
+            "type": "string",
+            "nullable": true
+          },
+          "character": {
+            "type": "string",
+            "nullable": true
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "self": {
+            "type": "boolean"
+          },
+          "voice": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.CollectionsViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "backdropPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.CreditsViewModel": {
+        "type": "object",
+        "properties": {
+          "cast": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.FullMovieCastViewModel"
+            },
+            "nullable": true
+          },
+          "crew": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.FullMovieCrewViewModel"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.ExternalIds": {
+        "type": "object",
+        "properties": {
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "facebookId": {
+            "type": "string",
+            "nullable": true
+          },
+          "instagramId": {
+            "type": "string",
+            "nullable": true
+          },
+          "twitterId": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.ExtraParams": {
+        "type": "object",
+        "properties": {
+          "providerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestStatus": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.FullMovieCastViewModel": {
+        "type": "object",
+        "properties": {
+          "cast_id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "character": {
+            "type": "string",
+            "nullable": true
+          },
+          "credit_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "gender": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "profile_path": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.FullMovieCrewViewModel": {
+        "type": "object",
+        "properties": {
+          "credit_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "department": {
+            "type": "string",
+            "nullable": true
+          },
+          "gender": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "job": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "profile_path": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.GenreViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Images": {
+        "type": "object",
+        "properties": {
+          "medium": {
+            "type": "string",
+            "nullable": true
+          },
+          "original": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Keywords": {
+        "type": "object",
+        "properties": {
+          "keywordsValue": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.KeywordsValue"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.KeywordsValue": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.MovieCollection": {
+        "type": "object",
+        "properties": {
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.MovieCollectionsViewModel": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "collection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.MovieCollection"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.MovieFullInfoViewModel": {
+        "type": "object",
+        "properties": {
+          "adult": {
+            "type": "boolean"
+          },
+          "belongsToCollection": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.CollectionsViewModel"
+          },
+          "backdropPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "originalLanguage": {
+            "type": "string",
+            "nullable": true
+          },
+          "budget": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.GenreViewModel"
+            },
+            "nullable": true
+          },
+          "originalTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "productionCompanies": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.ProductionCompaniesViewModel"
+            },
+            "nullable": true
+          },
+          "popularity": {
+            "type": "number",
+            "format": "double"
+          },
+          "revenue": {
+            "type": "number",
+            "format": "float"
+          },
+          "runtime": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "video": {
+            "type": "boolean"
+          },
+          "tagline": {
+            "type": "string",
+            "nullable": true
+          },
+          "voteAverage": {
+            "type": "number",
+            "format": "double"
+          },
+          "voteCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "alreadyInCp": {
+            "type": "boolean"
+          },
+          "trailer": {
+            "type": "string",
+            "nullable": true
+          },
+          "homepage": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootPathOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "videos": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Videos"
+          },
+          "credits": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.CreditsViewModel"
+          },
+          "qualityOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "releaseDates": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.ReleaseDatesDto"
+          },
+          "digitalReleaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "similar": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.Similar"
+          },
+          "recommendations": {
+            "$ref": "#/components/schemas/Ombi.Api.External.ExternalApis.TheMovieDb.Models.Recommendations"
+          },
+          "externalIds": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.ExternalIds"
+          },
+          "keywords": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Keywords"
+          },
+          "has4KRequest": {
+            "type": "boolean"
+          },
+          "approved4K": {
+            "type": "boolean"
+          },
+          "markedAsApproved4K": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestedDate4k": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "available4K": {
+            "type": "boolean"
+          },
+          "markedAsAvailable4K": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "denied4K": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "markedAsDenied4K": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deniedReason4K": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.MultiSearchFilter": {
+        "type": "object",
+        "properties": {
+          "movies": {
+            "type": "boolean"
+          },
+          "tvShows": {
+            "type": "boolean"
+          },
+          "music": {
+            "type": "boolean"
+          },
+          "people": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.MultiSearchResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "mediaType": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "poster": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Music.AlbumArt": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Music.ArtistInformation": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "startYear": {
+            "type": "string",
+            "nullable": true
+          },
+          "endYear": {
+            "type": "string",
+            "nullable": true
+          },
+          "isEnded": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          },
+          "region": {
+            "type": "string",
+            "nullable": true
+          },
+          "disambiguation": {
+            "type": "string",
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "logo": {
+            "type": "string",
+            "nullable": true
+          },
+          "poster": {
+            "type": "string",
+            "nullable": true
+          },
+          "fanArt": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ReleaseGroup"
+            },
+            "nullable": true
+          },
+          "links": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.ArtistLinks"
+          },
+          "members": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Music.BandMember"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Music.ArtistLinks": {
+        "type": "object",
+        "properties": {
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdb": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastFm": {
+            "type": "string",
+            "nullable": true
+          },
+          "discogs": {
+            "type": "string",
+            "nullable": true
+          },
+          "allMusic": {
+            "type": "string",
+            "nullable": true
+          },
+          "homePage": {
+            "type": "string",
+            "nullable": true
+          },
+          "youTube": {
+            "type": "string",
+            "nullable": true
+          },
+          "facebook": {
+            "type": "string",
+            "nullable": true
+          },
+          "twitter": {
+            "type": "string",
+            "nullable": true
+          },
+          "bbcMusic": {
+            "type": "string",
+            "nullable": true
+          },
+          "mySpace": {
+            "type": "string",
+            "nullable": true
+          },
+          "onlineCommunity": {
+            "type": "string",
+            "nullable": true
+          },
+          "spotify": {
+            "type": "string",
+            "nullable": true
+          },
+          "instagram": {
+            "type": "string",
+            "nullable": true
+          },
+          "vk": {
+            "type": "string",
+            "nullable": true
+          },
+          "deezer": {
+            "type": "string",
+            "nullable": true
+          },
+          "google": {
+            "type": "string",
+            "nullable": true
+          },
+          "apple": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Music.BandMember": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "attributes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "isCurrentMember": {
+            "type": "boolean"
+          },
+          "start": {
+            "type": "string",
+            "nullable": true
+          },
+          "end": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Music.ReleaseGroup": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseType": {
+            "type": "string",
+            "nullable": true
+          },
+          "percentOfTracks": {
+            "type": "number",
+            "format": "double"
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "partiallyAvailable": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "fullyAvailable": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.NetworkViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "country": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.PersonViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.ProductionCompaniesViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "logo_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "origin_country": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.SearchFullInfoTvShowViewModel": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "banner": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "firstAired": {
+            "type": "string",
+            "nullable": true
+          },
+          "networkId": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtime": {
+            "type": "string",
+            "nullable": true
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.GenreViewModel"
+            },
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastUpdated": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "airsDayOfWeek": {
+            "type": "string",
+            "nullable": true
+          },
+          "airsTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "rating": {
+            "type": "string",
+            "nullable": true
+          },
+          "siteRating": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "network": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.NetworkViewModel"
+          },
+          "images": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Images"
+          },
+          "cast": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.CastViewModel"
+            },
+            "nullable": true
+          },
+          "crew": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.PersonViewModel"
+            },
+            "nullable": true
+          },
+          "certification": {
+            "type": "string",
+            "nullable": true
+          },
+          "tagline": {
+            "type": "string",
+            "nullable": true
+          },
+          "keywords": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.Keywords"
+          },
+          "externalIds": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.ExternalIds"
+          },
+          "trailer": {
+            "type": "string",
+            "nullable": true
+          },
+          "homepage": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonRequests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Repository.Requests.SeasonRequests"
+            },
+            "nullable": true
+          },
+          "requestAll": {
+            "type": "boolean"
+          },
+          "firstSeason": {
+            "type": "boolean"
+          },
+          "latestSeason": {
+            "type": "boolean"
+          },
+          "fullyAvailable": {
+            "type": "boolean"
+          },
+          "partlyAvailable": {
+            "type": "boolean"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "plexUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theTvDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "theMovieDbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean",
+            "deprecated": true
+          },
+          "showSubscribe": {
+            "type": "boolean",
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.StreamingData": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "streamingProvider": {
+            "type": "string",
+            "nullable": true
+          },
+          "logo": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.VideoResultsDetails": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "iso_639_1": {
+            "type": "string",
+            "nullable": true
+          },
+          "iso_3166_1": {
+            "type": "string",
+            "nullable": true
+          },
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "site": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.Search.V2.Videos": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.Search.V2.VideoResultsDetails"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.TesterResultModel": {
+        "type": "object",
+        "properties": {
+          "isValid": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "expectedSubDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "additionalInformation": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.ClaimCheckboxes": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.DiscordNotificationsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "hideUser": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.EmailNotificationsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "host": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "senderName": {
+            "type": "string",
+            "nullable": true
+          },
+          "senderAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "authentication": {
+            "type": "boolean"
+          },
+          "disableTLS": {
+            "type": "boolean"
+          },
+          "disableCertificateChecking": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.GotifyNotificationViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "baseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.MattermostNotificationsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "channel": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.MobileNotificationsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.NewsletterNotificationViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplate": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+          },
+          "disableTv": {
+            "type": "boolean"
+          },
+          "disableMovies": {
+            "type": "boolean"
+          },
+          "disableMusic": {
+            "type": "boolean"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "externalEmails": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.NtfyNotificationViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "baseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "topic": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorizationHeader": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.PushbulletNotificationViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "accessToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "channelTag": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.PushoverNotificationViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "accessToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "userToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sound": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.AlbumRequest, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.AlbumRequest"
+            },
+            "nullable": true
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.ChildRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+            },
+            "nullable": true
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.MovieRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.MovieRequests"
+            },
+            "nullable": true
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.RequestsViewModel`1[[Ombi.Store.Entities.Requests.TvRequests, Ombi.Store, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null]]": {
+        "type": "object",
+        "properties": {
+          "collection": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+            },
+            "nullable": true
+          },
+          "total": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.SlackNotificationsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "channel": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconEmoji": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.TelegramNotificationsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "botApi": {
+            "type": "string",
+            "nullable": true
+          },
+          "chatId": {
+            "type": "string",
+            "nullable": true
+          },
+          "parseMode": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.TwilioSettingsViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "whatsAppSettings": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.UI.WhatsAppSettingsViewModel"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.UserViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "userName": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "claims": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.UI.ClaimCheckboxes"
+            },
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastLoggedIn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "hasLoggedIn": {
+            "type": "boolean"
+          },
+          "userType": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.UserType"
+          },
+          "movieRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "streamingCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeRequestQuota": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+          },
+          "movieRequestQuota": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+          },
+          "musicRequestQuota": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+          },
+          "musicRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "userQualityProfiles": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.UserQualityProfiles"
+          },
+          "movieRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "musicRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "episodeRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.UserViewModelDropdown": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.VoteViewModel": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "requestType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "image": {
+            "type": "string",
+            "nullable": true
+          },
+          "background": {
+            "type": "string",
+            "nullable": true
+          },
+          "upvotes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downvotes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "alreadyVoted": {
+            "type": "boolean"
+          },
+          "myVote": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.VoteType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.WebhookNotificationViewModel": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UI.WhatsAppSettingsViewModel": {
+        "type": "object",
+        "properties": {
+          "notificationTemplates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationTemplates"
+            },
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "from": {
+            "type": "string",
+            "nullable": true
+          },
+          "accountSid": {
+            "type": "string",
+            "nullable": true
+          },
+          "authToken": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.UserType": {
+        "enum": [
+          1,
+          2,
+          3,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Core.Models.VoteEngineResult": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "isError": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Models.WatchlistSyncStatus": {
+        "enum": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Core.Processor.UpdateModel": {
+        "type": "object",
+        "properties": {
+          "updateVersionString": {
+            "type": "string",
+            "nullable": true
+          },
+          "updateVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "updateDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updateAvailable": {
+            "type": "boolean"
+          },
+          "changeLogs": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloads": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Schedule.Processor.Downloads"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.EmbySelectedLibraries": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "collectionType": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.EmbyServers": {
+        "type": "object",
+        "properties": {
+          "serverId": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "administratorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "serverHostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "enableEpisodeSearching": {
+            "type": "boolean"
+          },
+          "embySelectedLibraries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbySelectedLibraries"
+            },
+            "nullable": true
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.EmbySettings": {
+        "type": "object",
+        "properties": {
+          "enable": {
+            "type": "boolean"
+          },
+          "servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.EmbyServers"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.JellyfinSelectedLibraries": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "collectionType": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.JellyfinServers": {
+        "type": "object",
+        "properties": {
+          "serverId": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "administratorId": {
+            "type": "string",
+            "nullable": true
+          },
+          "serverHostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "enableEpisodeSearching": {
+            "type": "boolean"
+          },
+          "jellyfinSelectedLibraries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinSelectedLibraries"
+            },
+            "nullable": true
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.JellyfinSettings": {
+        "type": "object",
+        "properties": {
+          "enable": {
+            "type": "boolean"
+          },
+          "servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.JellyfinServers"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.PlexSelectedLibraries": {
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.PlexServers": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "plexAuthToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "machineIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeBatchSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "serverHostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "plexSelectedLibraries": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexSelectedLibraries"
+            },
+            "nullable": true
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.PlexSettings": {
+        "type": "object",
+        "properties": {
+          "enable": {
+            "type": "boolean"
+          },
+          "enableWatchlistImport": {
+            "type": "boolean"
+          },
+          "monitorAll": {
+            "type": "boolean"
+          },
+          "installId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Settings.Models.External.PlexServers"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.External.TheMovieDbSettings": {
+        "type": "object",
+        "properties": {
+          "showAdultMovies": {
+            "type": "boolean"
+          },
+          "excludedKeywordIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "excludedMovieGenreIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "excludedTvGenreIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "originalLanguages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Core.Settings.Models.LandingPageSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "noticeEnabled": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "noticeText": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeLimit": {
+            "type": "boolean"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "expired": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Helpers.NotificationAgent": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Helpers.NotificationType": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          8,
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Models.AboutViewModel": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "frameworkDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "osArchitecture": {
+            "type": "string",
+            "nullable": true
+          },
+          "osDescription": {
+            "type": "string",
+            "nullable": true
+          },
+          "processArchitecture": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationBasePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "ombiDatabaseType": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalDatabaseType": {
+            "type": "string",
+            "nullable": true
+          },
+          "settingsDatabaseType": {
+            "type": "string",
+            "nullable": true
+          },
+          "ombiConnectionString": {
+            "type": "string",
+            "nullable": true
+          },
+          "externalConnectionString": {
+            "type": "string",
+            "nullable": true
+          },
+          "settingsConnectionString": {
+            "type": "string",
+            "nullable": true
+          },
+          "storagePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "notSupported": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.ConnectedUsersViewModel": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "userType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.UserType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.CronTestModel": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.CronViewModelBody": {
+        "type": "object",
+        "properties": {
+          "expression": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.DenyTvModel": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.External.PlexLibrariesLiteResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.SectionLite"
+            },
+            "nullable": true
+          },
+          "successful": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.External.PlexLibrariesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.PlexContainer"
+          },
+          "successful": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.External.PlexServersViewModel": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "servers": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.Server.PlexServer"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.External.PlexTokenAuthentication": {
+        "type": "object",
+        "properties": {
+          "plexToken": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.External.PlexUserViewModel": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "machineIdentifier": {
+            "type": "string",
+            "nullable": true
+          },
+          "libsSelected": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.External.UsersViewModel": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.FailedRequestViewModel": {
+        "type": "object",
+        "properties": {
+          "failedId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseYear": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "dts": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "error": {
+            "type": "string",
+            "nullable": true
+          },
+          "retryCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.Identity.AddNotificationPreference": {
+        "type": "object",
+        "properties": {
+          "agent": {
+            "$ref": "#/components/schemas/Ombi.Helpers.NotificationAgent"
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.Identity.CountryStreamingPreference": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.Identity.IdentityResult": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "successful": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.Identity.UpdateLocalUserModel": {
+        "type": "object",
+        "properties": {
+          "currentPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "confirmNewPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "userName": {
+            "type": "string",
+            "nullable": true
+          },
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "claims": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Core.Models.UI.ClaimCheckboxes"
+            },
+            "nullable": true
+          },
+          "emailAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastLoggedIn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "hasLoggedIn": {
+            "type": "boolean"
+          },
+          "userType": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.UserType"
+          },
+          "movieRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "streamingCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeRequestQuota": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+          },
+          "movieRequestQuota": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+          },
+          "musicRequestQuota": {
+            "$ref": "#/components/schemas/Ombi.Core.Models.RequestQuotaCountModel"
+          },
+          "musicRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "userQualityProfiles": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.UserQualityProfiles"
+          },
+          "movieRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "musicRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "episodeRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.Identity.UserLanguage": {
+        "type": "object",
+        "properties": {
+          "lang": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.IssueCommentChatViewModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "adminComment": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.IssueCountModel": {
+        "type": "object",
+        "properties": {
+          "pending": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "inProgress": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "resolved": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.IssueStateViewModel": {
+        "type": "object",
+        "properties": {
+          "issueId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueStatus"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.JobSettingsViewModel": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.MediaSeverAvailibilityViewModel": {
+        "type": "object",
+        "properties": {
+          "serversAvailable": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "serversUnavailable": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "partiallyDown": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "completelyDown": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "fullyAvailable": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "totalServers": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.MobileNotificationTestViewModel": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "settings": {
+            "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Notifications.MobileNotificationSettings"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.NewIssueCommentViewModel": {
+        "type": "object",
+        "properties": {
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "issueId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.PlexOAuthViewModel": {
+        "type": "object",
+        "properties": {
+          "wizard": {
+            "type": "boolean"
+          },
+          "pin": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.OAuth.OAuthPin"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.PresetThemeViewModel": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string",
+            "nullable": true
+          },
+          "displayName": {
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.SearchActorModel": {
+        "type": "object",
+        "properties": {
+          "searchTerm": {
+            "type": "string",
+            "nullable": true
+          },
+          "languageCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.SearchMovieExtraInfoRefineModel": {
+        "type": "object",
+        "properties": {
+          "theMovieDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languageCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.SearchMovieRefineModel": {
+        "type": "object",
+        "properties": {
+          "searchTerm": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "languageCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.SimilarMoviesRefineModel": {
+        "type": "object",
+        "properties": {
+          "theMovieDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languageCode": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.TvUpdateModel": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.UiLoggingModel": {
+        "type": "object",
+        "properties": {
+          "level": {
+            "$ref": "#/components/schemas/Microsoft.Extensions.Logging.LogLevel"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "location": {
+            "type": "string",
+            "nullable": true
+          },
+          "stackTrace": {
+            "type": "string",
+            "nullable": true
+          },
+          "dateTime": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Models.UserAuthModel": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "rememberMe": {
+            "type": "boolean"
+          },
+          "usePlexAdminAccount": {
+            "type": "boolean"
+          },
+          "usePlexOAuth": {
+            "type": "boolean"
+          },
+          "plexTvPin": {
+            "$ref": "#/components/schemas/Ombi.Api.External.MediaServers.Plex.Models.OAuth.OAuthPin"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Schedule.Processor.Downloads": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.AuthenticationSettings": {
+        "type": "object",
+        "properties": {
+          "allowNoPassword": {
+            "type": "boolean"
+          },
+          "requireDigit": {
+            "type": "boolean"
+          },
+          "requiredLength": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "requireLowercase": {
+            "type": "boolean"
+          },
+          "requireNonAlphanumeric": {
+            "type": "boolean"
+          },
+          "requireUppercase": {
+            "type": "boolean"
+          },
+          "enableOAuth": {
+            "type": "boolean"
+          },
+          "enableHeaderAuth": {
+            "type": "boolean"
+          },
+          "headerAuthVariable": {
+            "type": "string",
+            "nullable": true
+          },
+          "headerAuthCreateUser": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Branch": {
+        "enum": [
+          0,
+          1
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Settings.Settings.Models.CustomPageSettings": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "html": {
+            "type": "string",
+            "nullable": true
+          },
+          "fontAwesomeIcon": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.CustomizationSettings": {
+        "type": "object",
+        "properties": {
+          "applicationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "customCss": {
+            "type": "string",
+            "nullable": true
+          },
+          "enableCustomDonations": {
+            "type": "boolean"
+          },
+          "customDonationUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "customDonationMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "logo": {
+            "type": "string",
+            "nullable": true
+          },
+          "recentlyAddedPage": {
+            "type": "boolean"
+          },
+          "useCustomPage": {
+            "type": "boolean"
+          },
+          "hideAvailableFromDiscover": {
+            "type": "boolean"
+          },
+          "favicon": {
+            "type": "string",
+            "nullable": true
+          },
+          "hideAvailableRecentlyRequested": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.CouchPotatoSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultProfileId": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.DogNzbSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "movies": {
+            "type": "boolean"
+          },
+          "tvShows": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.DropDownModel": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "display": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.LidarrSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultQualityProfile": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultRootPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "albumFolder": {
+            "type": "boolean"
+          },
+          "metadataProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "addOnly": {
+            "type": "boolean"
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.Radarr4KSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultQualityProfile": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultRootPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "addOnly": {
+            "type": "boolean"
+          },
+          "minimumAvailability": {
+            "type": "string",
+            "nullable": true
+          },
+          "scanForAvailability": {
+            "type": "boolean"
+          },
+          "prioritizeArrAvailability": {
+            "type": "boolean"
+          },
+          "tag": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sendUserTags": {
+            "type": "boolean"
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.RadarrCombinedModel": {
+        "type": "object",
+        "properties": {
+          "radarr": {
+            "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.RadarrSettings"
+          },
+          "radarr4K": {
+            "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.Radarr4KSettings"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.RadarrSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultQualityProfile": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultRootPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "addOnly": {
+            "type": "boolean"
+          },
+          "minimumAvailability": {
+            "type": "string",
+            "nullable": true
+          },
+          "scanForAvailability": {
+            "type": "boolean"
+          },
+          "prioritizeArrAvailability": {
+            "type": "boolean"
+          },
+          "tag": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sendUserTags": {
+            "type": "boolean"
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.SickRageSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfile": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualities": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.External.DropDownModel"
+            },
+            "nullable": true,
+            "readOnly": true
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.External.SonarrSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfile": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonFolders": {
+            "type": "boolean"
+          },
+          "rootPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfileAnime": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootPathAnime": {
+            "type": "string",
+            "nullable": true
+          },
+          "animeTag": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "tag": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sendUserTags": {
+            "type": "boolean"
+          },
+          "addOnly": {
+            "type": "boolean"
+          },
+          "languageProfile": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languageProfileAnime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "scanForAvailability": {
+            "type": "boolean"
+          },
+          "prioritizeArrAvailability": {
+            "type": "boolean"
+          },
+          "ssl": {
+            "type": "boolean"
+          },
+          "subDir": {
+            "type": "string",
+            "nullable": true
+          },
+          "ip": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.FeatureEnablement": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.IssueSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "enableInProgress": {
+            "type": "boolean"
+          },
+          "deleteIssues": {
+            "type": "boolean"
+          },
+          "daysAfterResolvedToDelete": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.JobSettings": {
+        "type": "object",
+        "properties": {
+          "embyContentSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "embyRecentlyAddedSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "jellyfinContentSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "sonarrSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "radarrSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "plexContentSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "plexRecentlyAddedSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "couchPotatoSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "automaticUpdater": {
+            "type": "string",
+            "nullable": true
+          },
+          "userImporter": {
+            "type": "string",
+            "nullable": true
+          },
+          "sickRageSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "newsletter": {
+            "type": "string",
+            "nullable": true
+          },
+          "lidarrArtistSync": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuesPurge": {
+            "type": "string",
+            "nullable": true
+          },
+          "retryRequests": {
+            "type": "string",
+            "nullable": true
+          },
+          "mediaDatabaseRefresh": {
+            "type": "string",
+            "nullable": true
+          },
+          "autoDeleteRequests": {
+            "type": "string",
+            "nullable": true
+          },
+          "plexWatchlistImport": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.DiscordNotificationSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "icon": {
+            "type": "string",
+            "nullable": true
+          },
+          "hideUser": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.EmailNotificationSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "host": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "senderName": {
+            "type": "string",
+            "nullable": true
+          },
+          "senderAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "authentication": {
+            "type": "boolean"
+          },
+          "disableTLS": {
+            "type": "boolean"
+          },
+          "disableCertificateChecking": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.GotifySettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "baseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.MattermostNotificationSettings": {
+        "type": "object",
+        "properties": {
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "channel": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.MobileNotificationSettings": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.NtfySettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "baseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "topic": {
+            "type": "string",
+            "nullable": true
+          },
+          "authorizationHeader": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.PushbulletSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "accessToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "channelTag": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.PushoverSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "accessToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "userToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sound": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.SlackNotificationSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "channel": {
+            "type": "string",
+            "nullable": true
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconEmoji": {
+            "type": "string",
+            "nullable": true
+          },
+          "iconUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.TelegramSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "botApi": {
+            "type": "string",
+            "nullable": true
+          },
+          "chatId": {
+            "type": "string",
+            "nullable": true
+          },
+          "parseMode": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.Notifications.WebhookSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "webhookUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.OmbiSettings": {
+        "type": "object",
+        "properties": {
+          "baseUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "collectAnalyticData": {
+            "type": "boolean"
+          },
+          "wizard": {
+            "type": "boolean"
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "doNotSendNotificationsForAutoApprove": {
+            "type": "boolean"
+          },
+          "hideRequestsUsers": {
+            "type": "boolean"
+          },
+          "disableHealthChecks": {
+            "type": "boolean"
+          },
+          "defaultLanguageCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "autoDeleteAvailableRequests": {
+            "type": "boolean"
+          },
+          "autoDeleteAfterDays": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "branch": {
+            "$ref": "#/components/schemas/Ombi.Settings.Settings.Models.Branch"
+          },
+          "hasMigratedOldTvDbData": {
+            "type": "boolean"
+          },
+          "set": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.UpdateSettings": {
+        "type": "object",
+        "properties": {
+          "autoUpdateEnabled": {
+            "type": "boolean"
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "processName": {
+            "type": "string",
+            "nullable": true
+          },
+          "useScript": {
+            "type": "boolean"
+          },
+          "scriptLocation": {
+            "type": "string",
+            "nullable": true
+          },
+          "windowsServiceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "windowsService": {
+            "type": "boolean"
+          },
+          "testMode": {
+            "type": "boolean"
+          },
+          "updateSchedule": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.UserManagementSettings": {
+        "type": "object",
+        "properties": {
+          "importPlexAdmin": {
+            "type": "boolean"
+          },
+          "importPlexUsers": {
+            "type": "boolean"
+          },
+          "cleanupPlexUsers": {
+            "type": "boolean"
+          },
+          "importEmbyUsers": {
+            "type": "boolean"
+          },
+          "importJellyfinUsers": {
+            "type": "boolean"
+          },
+          "movieRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "movieRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "episodeRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "musicRequestLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "musicRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "defaultStreamingCountry": {
+            "type": "string",
+            "nullable": true
+          },
+          "defaultRoles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "bannedPlexUserIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "bannedEmbyUserIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "bannedJellyfinUserIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Settings.Settings.Models.VoteSettings": {
+        "type": "object",
+        "properties": {
+          "enabled": {
+            "type": "boolean"
+          },
+          "movieVoteMax": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "musicVoteMax": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvShowVoteMax": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.NotificationTemplates": {
+        "type": "object",
+        "properties": {
+          "notificationType": {
+            "$ref": "#/components/schemas/Ombi.Helpers.NotificationType"
+          },
+          "agent": {
+            "$ref": "#/components/schemas/Ombi.Helpers.NotificationAgent"
+          },
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.NotificationUserId": {
+        "type": "object",
+        "properties": {
+          "playerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "addedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "user": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.OmbiUser": {
+        "required": [
+          "streamingCountry"
+        ],
+        "type": "object",
+        "properties": {
+          "alias": {
+            "type": "string",
+            "nullable": true
+          },
+          "userType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.UserType"
+          },
+          "providerUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastLoggedIn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "language": {
+            "type": "string",
+            "nullable": true
+          },
+          "streamingCountry": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "movieRequestLimit": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "episodeRequestLimit": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "musicRequestLimit": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "movieRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "episodeRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "musicRequestLimitType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestLimitType"
+          },
+          "userAccessToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "mediaServerToken": {
+            "type": "string",
+            "nullable": true
+          },
+          "notificationUserIds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.NotificationUserId"
+            },
+            "nullable": true
+          },
+          "userNotificationPreferences": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.UserNotificationPreferences"
+            },
+            "nullable": true
+          },
+          "isEmbyConnect": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "userAlias": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "emailLogin": {
+            "type": "boolean"
+          },
+          "isSystemUser": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "id": {
+            "type": "string",
+            "nullable": true
+          },
+          "userName": {
+            "type": "string",
+            "nullable": true
+          },
+          "normalizedUserName": {
+            "type": "string",
+            "nullable": true
+          },
+          "email": {
+            "type": "string",
+            "nullable": true
+          },
+          "normalizedEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "emailConfirmed": {
+            "type": "boolean"
+          },
+          "phoneNumber": {
+            "type": "string",
+            "nullable": true
+          },
+          "phoneNumberConfirmed": {
+            "type": "boolean"
+          },
+          "twoFactorEnabled": {
+            "type": "boolean"
+          },
+          "lockoutEnd": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lockoutEnabled": {
+            "type": "boolean"
+          },
+          "accessFailedCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.RequestLimitType": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.RequestType": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.Requests.AlbumRequest": {
+        "type": "object",
+        "properties": {
+          "foreignAlbumId": {
+            "type": "string",
+            "nullable": true
+          },
+          "foreignArtistId": {
+            "type": "string",
+            "nullable": true
+          },
+          "disk": {
+            "type": "string",
+            "nullable": true
+          },
+          "cover": {
+            "type": "string",
+            "nullable": true
+          },
+          "rating": {
+            "type": "number",
+            "format": "double"
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean"
+          },
+          "showSubscribe": {
+            "type": "boolean"
+          },
+          "requestStatus": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "markedAsApproved": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "markedAsAvailable": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requestedUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "markedAsDenied": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "requestedByAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedUser": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.RequestSource"
+          },
+          "canApprove": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.Requests.ChildRequests": {
+        "type": "object",
+        "properties": {
+          "parentRequest": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.TvRequests"
+          },
+          "parentRequestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "issueId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "seriesType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.SeriesType"
+          },
+          "subscribed": {
+            "type": "boolean"
+          },
+          "showSubscribe": {
+            "type": "boolean"
+          },
+          "releaseYear": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+            },
+            "nullable": true
+          },
+          "seasonRequests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Repository.Requests.SeasonRequests"
+            },
+            "nullable": true
+          },
+          "requestStatus": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "requestedUserPlayedProgress": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "markedAsApproved": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "markedAsAvailable": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requestedUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "markedAsDenied": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "requestedByAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedUser": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.RequestSource"
+          },
+          "canApprove": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.Requests.IssueCategory": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.Requests.IssueComments": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "issuesId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "issues": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+          },
+          "user": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.Requests.IssueStatus": {
+        "enum": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.Requests.Issues": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "providerId": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "subject": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "issueCategoryId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "issueCategory": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueCategory"
+          },
+          "status": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueStatus"
+          },
+          "resovledDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "createdDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "userReportedId": {
+            "type": "string",
+            "nullable": true
+          },
+          "userReported": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "comments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.IssueComments"
+            },
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.Requests.MovieRequests": {
+        "type": "object",
+        "properties": {
+          "theMovieDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "issueId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "issues": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.Issues"
+            },
+            "nullable": true
+          },
+          "subscribed": {
+            "type": "boolean"
+          },
+          "showSubscribe": {
+            "type": "boolean"
+          },
+          "is4kRequest": {
+            "type": "boolean"
+          },
+          "rootPathOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "qualityOverride": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "has4KRequest": {
+            "type": "boolean"
+          },
+          "approved4K": {
+            "type": "boolean"
+          },
+          "markedAsApproved4K": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestedDate4k": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "available4K": {
+            "type": "boolean"
+          },
+          "markedAsAvailable4K": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "denied4K": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "markedAsDenied4K": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deniedReason4K": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestCombination": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.RequestCombination"
+          },
+          "langCode": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestStatus": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "canApprove": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "watchedByRequestedUser": {
+            "type": "boolean"
+          },
+          "playedByUsersCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "digitalReleaseDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "background": {
+            "type": "string",
+            "nullable": true
+          },
+          "released": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "digitalRelease": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "markedAsApproved": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requestedDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "markedAsAvailable": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "requestedUserId": {
+            "type": "string",
+            "nullable": true
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "markedAsDenied": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "requestedByAlias": {
+            "type": "string",
+            "nullable": true
+          },
+          "requestedUser": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "source": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.RequestSource"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.Requests.RequestCombination": {
+        "enum": [
+          0,
+          1,
+          2
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.Requests.RequestSource": {
+        "enum": [
+          0,
+          1
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.Requests.SeriesType": {
+        "enum": [
+          0,
+          1
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.Requests.TvRequests": {
+        "type": "object",
+        "properties": {
+          "tvDbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "externalProviderId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityOverride": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "rootFolder": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "languageProfile": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "posterPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "background": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "nullable": true
+          },
+          "totalSeasons": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "childRequests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+            },
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.UserNotificationPreferences": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "agent": {
+            "$ref": "#/components/schemas/Ombi.Helpers.NotificationAgent"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "value": {
+            "type": "string",
+            "nullable": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.UserQualityProfiles": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "sonarrQualityProfileAnime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sonarrRootPathAnime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sonarrRootPath": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sonarrQualityProfile": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "radarrRootPath": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "radarrQualityProfile": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "radarr4KRootPath": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "radarr4KQualityProfile": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Entities.UserType": {
+        "enum": [
+          0,
+          1,
+          2,
+          3,
+          4,
+          5
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.VoteType": {
+        "enum": [
+          0,
+          1
+        ],
+        "type": "integer",
+        "format": "int32"
+      },
+      "Ombi.Store.Entities.Votes": {
+        "type": "object",
+        "properties": {
+          "requestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "voteType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.VoteType"
+          },
+          "requestType": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.RequestType"
+          },
+          "userId": {
+            "type": "string",
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "deleted": {
+            "type": "boolean"
+          },
+          "user": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.OmbiUser"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Repository.Requests.EpisodeRequests": {
+        "type": "object",
+        "properties": {
+          "episodeNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "airDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "available": {
+            "type": "boolean"
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "requested": {
+            "type": "boolean"
+          },
+          "denied": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "deniedReason": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "season": {
+            "$ref": "#/components/schemas/Ombi.Store.Repository.Requests.SeasonRequests"
+          },
+          "airDateDisplay": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "requestStatus": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.Store.Repository.Requests.SeasonRequests": {
+        "type": "object",
+        "properties": {
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ombi.Store.Repository.Requests.EpisodeRequests"
+            },
+            "nullable": true
+          },
+          "childRequestId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "childRequest": {
+            "$ref": "#/components/schemas/Ombi.Store.Entities.Requests.ChildRequests"
+          },
+          "seasonAvailable": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.TheMovieDbApi.Models.Genre": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ombi.TheMovieDbApi.Models.Language": {
+        "type": "object",
+        "properties": {
+          "iso_639_1": {
+            "type": "string",
+            "nullable": true
+          },
+          "english_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "System.Net.HttpStatusCode": {
+        "enum": [
+          100,
+          101,
+          102,
+          103,
+          200,
+          201,
+          202,
+          203,
+          204,
+          205,
+          206,
+          207,
+          208,
+          226,
+          300,
+          301,
+          302,
+          303,
+          304,
+          305,
+          306,
+          307,
+          308,
+          400,
+          401,
+          402,
+          403,
+          404,
+          405,
+          406,
+          407,
+          408,
+          409,
+          410,
+          411,
+          412,
+          413,
+          414,
+          415,
+          416,
+          417,
+          421,
+          422,
+          423,
+          424,
+          426,
+          428,
+          429,
+          431,
+          451,
+          500,
+          501,
+          502,
+          503,
+          504,
+          505,
+          506,
+          507,
+          508,
+          510,
+          511
+        ],
+        "type": "integer",
+        "format": "int32"
+      }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "description": "API Key provided by Ombi. Example: \"ApiKey: {token}\"",
+        "name": "ApiKey",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "ApiKey": [ ]
+    }
+  ]
+}

--- a/services/service_ombi/tool/openapi_parser.dart
+++ b/services/service_ombi/tool/openapi_parser.dart
@@ -1,0 +1,741 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls, avoid_redundant_argument_values, require_trailing_commas, prefer_const_declarations, prefer_single_quotes, prefer_final_locals
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> args) {
+  final inputPath = args.isNotEmpty
+      ? args[0]
+      : '${Directory.current.path}/tool/openapi.json';
+  final outputDir = args.length > 1
+      ? args[1]
+      : '${Directory.current.path}/lib/src/generated';
+
+  final file = File(inputPath);
+  if (!file.existsSync()) {
+    print('Error: Input OpenAPI JSON file not found at $inputPath');
+    exit(1);
+  }
+
+  print('Parsing Ombi OpenAPI specification from: $inputPath');
+  final jsonString = file.readAsStringSync();
+  final spec = jsonDecode(jsonString) as Map<String, dynamic>;
+
+  final parser = OmbiOpenApiParser(spec, outputDir);
+  parser.generateAll();
+  print('Successfully generated all Ombi Dart models and API clients in: $outputDir');
+}
+
+class OmbiOpenApiParser {
+  final Map<String, dynamic> spec;
+  final String outputDir;
+
+  final Map<String, String> schemaClassNames = {};
+  final Map<String, dynamic> schemas = {};
+  final Map<String, List<Map<String, dynamic>>> tagEndpoints = {};
+
+  OmbiOpenApiParser(this.spec, this.outputDir) {
+    _initSchemas();
+    _initEndpoints();
+  }
+
+  void _initSchemas() {
+    final rawSchemas =
+        (spec['components']?['schemas'] as Map<String, dynamic>?) ?? {};
+    schemas.addAll(rawSchemas);
+
+    for (final fullKey in schemas.keys) {
+      schemaClassNames[fullKey] = _resolveClassName(fullKey, rawSchemas);
+    }
+  }
+
+  void _initEndpoints() {
+    final paths = (spec['paths'] as Map<String, dynamic>?) ?? {};
+    for (final pathEntry in paths.entries) {
+      final path = pathEntry.key;
+      final methods = pathEntry.value as Map<String, dynamic>;
+
+      for (final methodEntry in methods.entries) {
+        final verb = methodEntry.key.toLowerCase();
+        if (!['get', 'post', 'put', 'delete', 'patch'].contains(verb)) continue;
+
+        final op = methodEntry.value as Map<String, dynamic>;
+        final tags = (op['tags'] as List<dynamic>?)?.cast<String>() ?? ['Default'];
+        final tag = tags.first;
+
+        tagEndpoints.putIfAbsent(tag, () => []).add({
+          'path': path,
+          'verb': verb,
+          'operation': op,
+        });
+      }
+    }
+  }
+
+  String _sanitizeIdentifier(String name) {
+    return name.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '');
+  }
+
+  String _toPascalCase(String text) {
+    final clean = text.replaceAll(RegExp(r'[^a-zA-Z0-9]'), ' ');
+    final words = clean.split(RegExp(r'\s+')).where((w) => w.isNotEmpty);
+    return words.map((w) => w[0].toUpperCase() + w.substring(1)).join('');
+  }
+
+  String _toCamelCase(String text) {
+    final pascal = _toPascalCase(text);
+    if (pascal.isEmpty) return 'item';
+    var camel = pascal[0].toLowerCase() + pascal.substring(1);
+    if (RegExp(r'^[0-9]').hasMatch(camel)) {
+      camel = 'val$camel';
+    }
+    const keywords = {
+      'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
+      'class', 'const', 'continue', 'covariant', 'default', 'deferred', 'do',
+      'dynamic', 'else', 'enum', 'export', 'extends', 'extension', 'external',
+      'factory', 'false', 'finally', 'for', 'function', 'get', 'hide',
+      'if', 'implements', 'import', 'in', 'interface', 'is', 'late', 'library',
+      'mixin', 'new', 'null', 'on', 'operator', 'part', 'required', 'rethrow',
+      'return', 'set', 'show', 'static', 'super', 'switch', 'sync', 'this',
+      'throw', 'true', 'try', 'typedef', 'var', 'void', 'while', 'with', 'yield'
+    };
+    return keywords.contains(camel) ? '${camel}Val' : camel;
+  }
+
+  String _toSnakeCase(String name) {
+    return name
+        .replaceAllMapped(RegExp(r'([A-Z])'), (m) => '_${m.group(1)!.toLowerCase()}')
+        .replaceAll(RegExp(r'^_'), '')
+        .replaceAll(RegExp(r'_+'), '_');
+  }
+
+  String _resolveClassName(String fullKey, Map<String, dynamic> rawSchemas) {
+    final genericMatch = RegExp(r'`\d+\[\[(?:[^\.,]+\.)*([^\.,]+),').firstMatch(fullKey);
+    final genericSuffix = genericMatch != null
+        ? _sanitizeIdentifier(genericMatch.group(1)!)
+        : '';
+
+    final cleanBase = fullKey.replaceAll(RegExp(r'`\d+\[\[.*'), '');
+    final parts = cleanBase.split('.');
+    final short = parts.last;
+
+    final collisions = rawSchemas.keys
+        .where((k) => k.replaceAll(RegExp(r'`\d+\[\[.*'), '').split('.').last == short)
+        .toList();
+
+    String baseName;
+    if (collisions.length == 1) {
+      baseName = _sanitizeIdentifier(short);
+    } else {
+      final meaningful = parts
+          .where((p) => !['Ombi', 'Api', 'External', 'Models', 'Core', 'V1'].contains(p))
+          .toList();
+      final effective = meaningful.isEmpty ? parts : meaningful;
+      baseName = effective.map(_sanitizeIdentifier).join('');
+    }
+
+    return '$baseName$genericSuffix';
+  }
+
+  void generateAll() {
+    _createDirectories();
+    _generateResponseFiles();
+    _generateModelFiles();
+    _generateApiFiles();
+    _generateExportFile();
+  }
+
+  void _createDirectories() {
+    final dir = Directory(outputDir);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+    Directory('$outputDir/models').createSync(recursive: true);
+    Directory('$outputDir/responses').createSync(recursive: true);
+    Directory('$outputDir/api').createSync(recursive: true);
+  }
+
+  void _generateResponseFiles() {
+    final apiResponseContent = '''
+import 'ombi_error.dart';
+
+/// Standardized API response container for Ombi API calls.
+class ApiResponse<T> {
+  final T? data;
+  final OmbiError? error;
+  final int? statusCode;
+  final bool isSuccess;
+
+  const ApiResponse.success(this.data, {this.statusCode})
+      : error = null,
+        isSuccess = true;
+
+  const ApiResponse.error(this.error, {this.statusCode})
+      : data = null,
+        isSuccess = false;
+}
+''';
+    File('$outputDir/responses/api_response.dart')
+        .writeAsStringSync(apiResponseContent);
+
+    final errorContent = '''
+import 'package:dio/dio.dart';
+
+/// Error model returned by Ombi API endpoints.
+class OmbiError {
+  final String? message;
+  final String? description;
+  final List<String> errors;
+
+  const OmbiError({
+    this.message,
+    this.description,
+    this.errors = const [],
+  });
+
+  factory OmbiError.fromJson(Map<String, dynamic> json) {
+    final errList = (json['errors'] as List<dynamic>?)
+            ?.map((e) => e.toString())
+            .toList() ??
+        [];
+    return OmbiError(
+      message: json['message'] as String? ?? json['error'] as String?,
+      description: json['description'] as String?,
+      errors: errList,
+    );
+  }
+
+  factory OmbiError.fromDio(DioException exception) {
+    if (exception.response?.data is Map<String, dynamic>) {
+      return OmbiError.fromJson(
+          exception.response!.data as Map<String, dynamic>);
+    }
+    return OmbiError(
+      message: exception.message ?? 'HTTP Error \${exception.response?.statusCode}',
+      description: exception.type.toString(),
+    );
+  }
+}
+''';
+    File('$outputDir/responses/ombi_error.dart')
+        .writeAsStringSync(errorContent);
+
+    final exceptionContent = '''
+import 'ombi_error.dart';
+
+/// Custom exception thrown on Ombi API failure.
+class OmbiException implements Exception {
+  final String message;
+  final int? statusCode;
+  final OmbiError? error;
+
+  const OmbiException(
+    this.message, {
+    this.statusCode,
+    this.error,
+  });
+
+  @override
+  String toString() =>
+      'OmbiException(statusCode: \$statusCode, message: \$message, error: \$error)';
+}
+''';
+    File('$outputDir/responses/ombi_exception.dart')
+        .writeAsStringSync(exceptionContent);
+  }
+
+  void _generateModelFiles() {
+    for (final entry in schemas.entries) {
+      final fullKey = entry.key;
+      final schema = entry.value as Map<String, dynamic>;
+      final className = schemaClassNames[fullKey]!;
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildModelCode(fullKey, className, schema);
+      File('$outputDir/models/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildModelCode(
+      String fullKey, String className, Map<String, dynamic> schema) {
+    final isEnum = schema.containsKey('enum');
+    if (isEnum) {
+      return _buildEnumCode(className, schema);
+    }
+
+    final properties = (schema['properties'] as Map<String, dynamic>?) ?? {};
+    final title = schema['title'] as String?;
+    final description = schema['description'] as String?;
+
+    final imports = <String>{};
+    final fields = <_ModelField>[];
+    final usedFieldNames = <String>{};
+
+    for (final propEntry in properties.entries) {
+      final propKey = propEntry.key;
+      final propSchema = propEntry.value as Map<String, dynamic>;
+      var fieldName = _toCamelCase(propKey);
+      if (usedFieldNames.contains(fieldName)) {
+        fieldName = '${fieldName}Alt';
+      }
+      usedFieldNames.add(fieldName);
+
+      final fieldTypeInfo = _parseType(propSchema, imports);
+      final propDesc = propSchema['description'] as String?;
+      final isDeprecated = propSchema['deprecated'] == true;
+
+      fields.add(_ModelField(
+        jsonKey: propKey,
+        fieldName: fieldName,
+        dartType: fieldTypeInfo.dartType,
+        isNullable: fieldTypeInfo.isNullable,
+        isList: fieldTypeInfo.isList,
+        isCustomClass: fieldTypeInfo.isCustomClass,
+        customClassName: fieldTypeInfo.customClassName,
+        description: propDesc,
+        isDeprecated: isDeprecated,
+      ));
+    }
+
+    final fileName = _toSnakeCase(className);
+    final buffer = StringBuffer();
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    for (final imp in imports) {
+      if (imp != className) {
+        final impFileName = _toSnakeCase(imp);
+        buffer.writeln("import '$impFileName.dart';");
+      }
+    }
+    buffer.writeln();
+    buffer.writeln("part '$fileName.freezed.dart';");
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+
+    final classDoc = description ?? title;
+    if (classDoc != null && classDoc.isNotEmpty) {
+      for (final line in classDoc.split('\n')) {
+        buffer.writeln('/// ${line.trim()}');
+      }
+      buffer.writeln('///');
+    }
+    buffer.writeln('/// Original C# Schema: `$fullKey`');
+    if (schema['deprecated'] == true) {
+      buffer.writeln("@Deprecated('Marked deprecated in OpenAPI spec')");
+    }
+    buffer.writeln('@freezed');
+    buffer.writeln('abstract class $className with _\$$className {');
+    if (fields.isEmpty) {
+      buffer.writeln('  const factory $className() = _$className;');
+    } else {
+      buffer.writeln('  const factory $className({');
+      for (final f in fields) {
+        if (f.description != null && f.description!.isNotEmpty) {
+          for (final line in f.description!.split('\n')) {
+            buffer.writeln('    /// ${line.trim()}');
+          }
+        }
+        if (f.isDeprecated) {
+          buffer.writeln("    @Deprecated('Marked deprecated in OpenAPI spec')");
+        }
+        final typeStr = f.dartType.endsWith('?') ? f.dartType : '${f.dartType}?';
+        buffer.writeln("    @JsonKey(name: '${f.jsonKey}') $typeStr ${f.fieldName},");
+      }
+      buffer.writeln('  }) = _$className;');
+    }
+    buffer.writeln();
+    buffer.writeln('  factory $className.fromJson(Map<String, dynamic> json) =>');
+    buffer.writeln('      _\$${className}FromJson(json);');
+    buffer.writeln('}');
+
+    return buffer.toString();
+  }
+
+  String _buildEnumCode(String className, Map<String, dynamic> schema) {
+    final buffer = StringBuffer();
+    final enumList = schema['enum'] as List<dynamic>;
+    final fileName = _toSnakeCase(className);
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    buffer.writeln();
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+    buffer.writeln('/// Enum `$className`');
+    buffer.writeln('@JsonEnum(alwaysCreate: true)');
+    buffer.writeln('enum $className {');
+
+    for (final item in enumList) {
+      final strVal = item.toString();
+      final identifier = _toCamelCase(strVal);
+      buffer.writeln("  @JsonValue('$strVal')");
+      buffer.writeln('  $identifier,');
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _TypeInfo _parseType(
+      Map<String, dynamic> schema, Set<String> imports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      imports.add(cls);
+      return _TypeInfo(
+          dartType: cls, isNullable: true, isCustomClass: true, customClassName: cls);
+    }
+
+    final type = schema['type'] as String?;
+    if (type == 'array') {
+      final items = (schema['items'] as Map<String, dynamic>?) ?? {};
+      final itemType = _parseType(items, imports);
+      final listDartType = 'List<${itemType.dartType}>';
+      return _TypeInfo(
+        dartType: listDartType,
+        isNullable: true,
+        isList: true,
+        customClassName: itemType.isCustomClass ? itemType.customClassName : null,
+      );
+    }
+
+    if (type == 'integer') {
+      return _TypeInfo(dartType: 'int', isNullable: true);
+    }
+    if (type == 'number') {
+      return _TypeInfo(dartType: 'double', isNullable: true);
+    }
+    if (type == 'boolean') {
+      return _TypeInfo(dartType: 'bool', isNullable: true);
+    }
+    if (type == 'string') {
+      return _TypeInfo(dartType: 'String', isNullable: true);
+    }
+
+    return _TypeInfo(dartType: 'dynamic', isNullable: true);
+  }
+
+  void _generateApiFiles() {
+    for (final entry in tagEndpoints.entries) {
+      final tag = entry.key;
+      final endpoints = entry.value;
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildApiCode(tag, className, endpoints);
+      File('$outputDir/api/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildApiCode(
+      String tag, String className, List<Map<String, dynamic>> endpoints) {
+    final buffer = StringBuffer();
+    final imports = <String>{
+      "import 'dart:convert';",
+      "import 'package:dio/dio.dart';",
+      "import '../responses/api_response.dart';",
+      "import '../responses/ombi_error.dart';",
+      "import '../responses/ombi_exception.dart';",
+    };
+
+    final modelImports = <String>{};
+
+    for (final ep in endpoints) {
+      final op = ep['operation'] as Map<String, dynamic>;
+      final respSchema = _getSuccessResponseSchema(op);
+      if (respSchema != null) {
+        _extractModelImports(respSchema, modelImports);
+      }
+      final bodySchema = _getRequestBodySchema(op);
+      if (bodySchema != null) {
+        _extractModelImports(bodySchema, modelImports);
+      }
+    }
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    for (final imp in imports) {
+      buffer.writeln(imp);
+    }
+
+    for (final mImp in modelImports) {
+      final fileName = _toSnakeCase(mImp);
+      buffer.writeln("import '../models/$fileName.dart';");
+    }
+    buffer.writeln();
+
+    buffer.writeln('/// Raw API client for `$tag` endpoints.');
+    buffer.writeln('class $className {');
+    buffer.writeln('  final Dio _dio;');
+    buffer.writeln();
+    buffer.writeln('  $className(this._dio);');
+    buffer.writeln();
+
+    final usedMethodNames = <String>{};
+    for (final ep in endpoints) {
+      final path = ep['path'] as String;
+      final verb = ep['verb'] as String;
+      final op = ep['operation'] as Map<String, dynamic>;
+
+      final summary = op['summary'] as String?;
+      final description = op['description'] as String?;
+      final operationId = op['operationId'] as String?;
+
+      var methodName = _buildMethodName(verb, path, operationId);
+      if (usedMethodNames.contains(methodName)) {
+        var count = 2;
+        while (usedMethodNames.contains('$methodName$count')) {
+          count++;
+        }
+        methodName = '$methodName$count';
+      }
+      usedMethodNames.add(methodName);
+
+      final doc = summary ?? description;
+      if (doc != null && doc.isNotEmpty) {
+        for (final line in doc.split('\n')) {
+          buffer.writeln('  /// ${line.trim()}');
+        }
+      }
+      buffer.writeln('  /// HTTP $verb $path');
+      if (op['deprecated'] == true) {
+        buffer.writeln("  @Deprecated('Marked deprecated in OpenAPI spec')");
+      }
+
+      final respSchema = _getSuccessResponseSchema(op);
+      final returnTypeInfo = _getReturnTypeInfo(respSchema);
+      final returnType = returnTypeInfo.type;
+
+      buffer.writeln('  Future<ApiResponse<$returnType>> $methodName(');
+
+      final params = (op['parameters'] as List<dynamic>?)?.cast<Map<String, dynamic>>() ?? [];
+      final pathParams = params.where((p) => p['in'] == 'path').toList();
+      final queryParams = params.where((p) => p['in'] == 'query').toList();
+      final bodySchema = _getRequestBodySchema(op);
+
+      final methodParams = <String>[];
+      for (final p in pathParams) {
+        final pName = _toCamelCase(p['name'] as String);
+        methodParams.add('required String $pName');
+      }
+      for (final q in queryParams) {
+        final qName = _toCamelCase(q['name'] as String);
+        methodParams.add('String? $qName');
+      }
+      if (bodySchema != null) {
+        methodParams.add('dynamic body');
+      }
+
+      if (methodParams.isNotEmpty) {
+        buffer.writeln('    {${methodParams.join(', ')}}');
+      }
+      buffer.writeln('  ) async {');
+
+      var interpolatedPath = path;
+      for (final p in pathParams) {
+        final rawName = p['name'] as String;
+        final pName = _toCamelCase(rawName);
+        interpolatedPath = interpolatedPath.replaceAll('{$rawName}', '\$$pName');
+      }
+
+      buffer.writeln('    try {');
+      buffer.writeln('      final Response<dynamic> resp = await _dio.$verb<dynamic>(');
+      buffer.writeln("        '$interpolatedPath',");
+      if (queryParams.isNotEmpty) {
+        buffer.writeln('        queryParameters: <String, dynamic>{');
+        for (final q in queryParams) {
+          final qRaw = q['name'] as String;
+          final qName = _toCamelCase(qRaw);
+          buffer.writeln("          if ($qName != null) '$qRaw': $qName,");
+        }
+        buffer.writeln('        },');
+      }
+      if (bodySchema != null) {
+        buffer.writeln('        data: body,');
+      }
+      buffer.writeln('      );');
+
+      buffer.writeln('      ${_buildDeserializationCode(returnTypeInfo)}');
+      buffer.writeln('      return ApiResponse.success(data, statusCode: resp.statusCode);');
+      buffer.writeln('    } on DioException catch (e) {');
+      buffer.writeln('      return ApiResponse.error(OmbiError.fromDio(e), statusCode: e.response?.statusCode);');
+      buffer.writeln('    }');
+      buffer.writeln('  }');
+      buffer.writeln();
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _ReturnTypeInfo _getReturnTypeInfo(Map<String, dynamic>? schema) {
+    if (schema == null) return _ReturnTypeInfo(type: 'void', isList: false, isCustomClass: false);
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      final isEnum = schemas[key] != null && (schemas[key] as Map<String, dynamic>).containsKey('enum');
+      return _ReturnTypeInfo(type: cls, isList: false, isCustomClass: !isEnum, isEnum: isEnum, className: cls);
+    }
+    if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null && items.containsKey('\$ref')) {
+        final ref = items['\$ref'] as String;
+        final key = ref.replaceFirst('#/components/schemas/', '');
+        final cls = schemaClassNames[key] ?? 'dynamic';
+        final isEnum = schemas[key] != null && (schemas[key] as Map<String, dynamic>).containsKey('enum');
+        return _ReturnTypeInfo(type: 'List<$cls>', isList: true, isCustomClass: !isEnum, isEnum: isEnum, className: cls);
+      }
+      return _ReturnTypeInfo(type: 'List<dynamic>', isList: true, isCustomClass: false);
+    }
+    return _ReturnTypeInfo(type: 'dynamic', isList: false, isCustomClass: false);
+  }
+
+  String _buildDeserializationCode(_ReturnTypeInfo info) {
+    if (info.type == 'void') {
+      return 'final void data = null;';
+    }
+    if (info.isEnum) {
+      return 'final ${info.className}? data = resp.data != null ? ${info.className}.values.cast<${info.className}?>().firstWhere((e) => e?.name == resp.data.toString(), orElse: () => null) : null;';
+    }
+    if (info.isList && info.isCustomClass) {
+      return 'final List<${info.className}> data = (resp.data as List<dynamic>?)?.map((e) => ${info.className}.fromJson(e as Map<String, dynamic>)).toList() ?? <${info.className}>[];';
+    }
+    if (info.isCustomClass) {
+      return 'final ${info.className}? data = resp.data is Map<String, dynamic> ? ${info.className}.fromJson(resp.data as Map<String, dynamic>) : null;';
+    }
+    return 'final dynamic data = resp.data;';
+  }
+
+  String _buildMethodName(String verb, String path, String? operationId) {
+    if (operationId != null && operationId.isNotEmpty) {
+      var clean = operationId.replaceAll(RegExp(r'ApiV\d+'), '');
+      return _toCamelCase(clean);
+    }
+    final pathParamMatches = RegExp(r'\{([^}]+)\}').allMatches(path);
+    final pathParamNames = pathParamMatches.map((m) => m.group(1)!).toList();
+
+    final cleanPath = path
+        .replaceAll(RegExp(r'^/api/v\d+/'), '/')
+        .replaceAll(RegExp(r'^/api/'), '/')
+        .replaceAll(RegExp(r'\{[^}]+\}'), '');
+    final parts = cleanPath.split('/').where((p) => p.isNotEmpty).toList();
+
+    if (pathParamNames.isNotEmpty) {
+      parts.add('by');
+      parts.addAll(pathParamNames);
+    }
+
+    final nameParts = [verb, ...parts];
+    return _toCamelCase(nameParts.join('_'));
+  }
+
+  Map<String, dynamic>? _getSuccessResponseSchema(Map<String, dynamic> op) {
+    final responses = op['responses'] as Map<String, dynamic>?;
+    if (responses == null) return null;
+    final resp200 = responses['200'] ?? responses['201'];
+    if (resp200 is Map<String, dynamic>) {
+      final content = resp200['content'] as Map<String, dynamic>?;
+      final jsonContent = content?['application/json'] ?? content?['text/json'];
+      return jsonContent?['schema'] as Map<String, dynamic>?;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _getRequestBodySchema(Map<String, dynamic> op) {
+    final reqBody = op['requestBody'] as Map<String, dynamic>?;
+    final content = reqBody?['content'] as Map<String, dynamic>?;
+    final jsonContent = content?['application/json'] ?? content?['text/json'];
+    return jsonContent?['schema'] as Map<String, dynamic>?;
+  }
+
+  void _extractModelImports(
+      Map<String, dynamic> schema, Set<String> modelImports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key];
+      if (cls != null) modelImports.add(cls);
+    } else if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null) _extractModelImports(items, modelImports);
+    }
+  }
+
+  void _generateExportFile() {
+    final buffer = StringBuffer();
+    buffer.writeln("// Autogenerated OpenAPI Exports for Ombi\n");
+    buffer.writeln("export 'responses/api_response.dart';");
+    buffer.writeln("export 'responses/ombi_error.dart';");
+    buffer.writeln("export 'responses/ombi_exception.dart';");
+
+    for (final entry in schemas.entries) {
+      final className = schemaClassNames[entry.key]!;
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'models/$fileName.dart';");
+    }
+
+    for (final tag in tagEndpoints.keys) {
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'api/$fileName.dart';");
+    }
+
+    File('$outputDir/generated.dart').writeAsStringSync(buffer.toString());
+  }
+}
+
+class _ModelField {
+  final String jsonKey;
+  final String fieldName;
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+  final String? description;
+  final bool isDeprecated;
+
+  _ModelField({
+    required this.jsonKey,
+    required this.fieldName,
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+    this.description,
+    this.isDeprecated = false,
+  });
+}
+
+class _TypeInfo {
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+
+  _TypeInfo({
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+  });
+}
+
+class _ReturnTypeInfo {
+  final String type;
+  final bool isList;
+  final bool isCustomClass;
+  final bool isEnum;
+  final String? className;
+
+  _ReturnTypeInfo({
+    required this.type,
+    required this.isList,
+    required this.isCustomClass,
+    this.isEnum = false,
+    this.className,
+  });
+}

--- a/services/service_sonarr/.gitignore
+++ b/services/service_sonarr/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated OpenAPI client & freezed model code
+lib/src/generated/

--- a/services/service_sonarr/lib/service_sonarr.dart
+++ b/services/service_sonarr/lib/service_sonarr.dart
@@ -4,11 +4,17 @@ library;
 import 'package:core_models/core_models.dart';
 import 'package:flutter_riverpod/legacy.dart';
 
+export 'src/generated/generated.dart';
 export 'src/models/sonarr_episode.dart';
 export 'src/models/sonarr_history_item.dart';
 export 'src/models/sonarr_queue_item.dart';
 export 'src/models/sonarr_series.dart';
 export 'src/series_detail_screen.dart';
+export 'src/services/sonarr_client.dart';
+export 'src/services/sonarr_command_service.dart';
+export 'src/services/sonarr_episode_service.dart';
+export 'src/services/sonarr_queue_service.dart';
+export 'src/services/sonarr_series_service.dart';
 export 'src/sonarr_add_series_search_screen.dart';
 export 'src/sonarr_add_series_sheet.dart';
 export 'src/sonarr_api.dart';

--- a/services/service_sonarr/lib/src/services/sonarr_client.dart
+++ b/services/service_sonarr/lib/src/services/sonarr_client.dart
@@ -1,0 +1,66 @@
+import 'package:dio/dio.dart';
+
+import '../generated/api/raw_command_api.dart';
+import '../generated/api/raw_episode_api.dart';
+import '../generated/api/raw_history_api.dart';
+import '../generated/api/raw_queue_api.dart';
+import '../generated/api/raw_queue_details_api.dart';
+import '../generated/api/raw_queue_status_api.dart';
+import '../generated/api/raw_release_api.dart';
+import '../generated/api/raw_series_api.dart';
+import '../generated/api/raw_series_lookup_api.dart';
+
+import 'sonarr_command_service.dart';
+import 'sonarr_episode_service.dart';
+import 'sonarr_queue_service.dart';
+import 'sonarr_series_service.dart';
+
+/// Central client for Sonarr API services.
+class SonarrClient {
+  final Dio dio;
+  final String baseUrl;
+  final String? apiKey;
+
+  late final RawSeriesApi rawSeriesApi;
+  late final RawSeriesLookupApi rawSeriesLookupApi;
+  late final RawEpisodeApi rawEpisodeApi;
+  late final RawQueueApi rawQueueApi;
+  late final RawQueueDetailsApi rawQueueDetailsApi;
+  late final RawQueueStatusApi rawQueueStatusApi;
+  late final RawReleaseApi rawReleaseApi;
+  late final RawHistoryApi rawHistoryApi;
+  late final RawCommandApi rawCommandApi;
+
+  late final SonarrSeriesService seriesService;
+  late final SonarrEpisodeService episodeService;
+  late final SonarrCommandService commandService;
+  late final SonarrQueueService queueService;
+
+  SonarrClient({
+    Dio? dio,
+    String? baseUrl,
+    this.apiKey,
+  })  : dio = dio ?? Dio(),
+        baseUrl = baseUrl ?? dio?.options.baseUrl ?? '' {
+    final effectiveBase = this.baseUrl.isNotEmpty ? this.baseUrl : this.dio.options.baseUrl;
+    this.dio.options.baseUrl = effectiveBase.endsWith('/') ? effectiveBase : '$effectiveBase/';
+    if (apiKey != null && apiKey!.isNotEmpty) {
+      this.dio.options.headers['X-Api-Key'] = apiKey;
+    }
+
+    rawSeriesApi = RawSeriesApi(this.dio);
+    rawSeriesLookupApi = RawSeriesLookupApi(this.dio);
+    rawEpisodeApi = RawEpisodeApi(this.dio);
+    rawQueueApi = RawQueueApi(this.dio);
+    rawQueueDetailsApi = RawQueueDetailsApi(this.dio);
+    rawQueueStatusApi = RawQueueStatusApi(this.dio);
+    rawReleaseApi = RawReleaseApi(this.dio);
+    rawHistoryApi = RawHistoryApi(this.dio);
+    rawCommandApi = RawCommandApi(this.dio);
+
+    seriesService = SonarrSeriesService(rawSeriesApi, rawSeriesLookupApi);
+    episodeService = SonarrEpisodeService(rawEpisodeApi);
+    commandService = SonarrCommandService(rawCommandApi);
+    queueService = SonarrQueueService(rawQueueApi, rawQueueDetailsApi, rawQueueStatusApi);
+  }
+}

--- a/services/service_sonarr/lib/src/services/sonarr_command_service.dart
+++ b/services/service_sonarr/lib/src/services/sonarr_command_service.dart
@@ -1,0 +1,57 @@
+import '../generated/api/raw_command_api.dart';
+import '../generated/models/command_resource.dart';
+import '../generated/responses/sonarr_exception.dart';
+
+/// High-level service for triggering Sonarr background commands (searches, refreshes, renames).
+class SonarrCommandService {
+  final RawCommandApi _rawCommandApi;
+
+  SonarrCommandService(this._rawCommandApi);
+
+  /// Triggers an automatic search for all monitored missing episodes in a series.
+  Future<CommandResource?> searchSeriesEpisodes(int seriesId) async {
+    return _postCommand({
+      'name': 'SeriesSearch',
+      'seriesId': seriesId,
+    });
+  }
+
+  /// Triggers an automatic search for monitored missing episodes in a specific season.
+  Future<CommandResource?> searchSeasonEpisodes(int seriesId, int seasonNumber) async {
+    return _postCommand({
+      'name': 'SeasonSearch',
+      'seriesId': seriesId,
+      'seasonNumber': seasonNumber,
+    });
+  }
+
+  /// Triggers an automatic search for specific episodes.
+  Future<CommandResource?> searchEpisodes(List<int> episodeIds) async {
+    return _postCommand({
+      'name': 'EpisodeSearch',
+      'episodeIds': episodeIds,
+    });
+  }
+
+  /// Triggers a global search for all missing monitored episodes across all series.
+  Future<CommandResource?> searchMissingEpisodes() async {
+    return _postCommand({
+      'name': 'MissingEpisodeSearch',
+    });
+  }
+
+  Future<CommandResource?> _postCommand(Map<String, dynamic> body) async {
+    final response = await _rawCommandApi.postCommand(body: body);
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Command execution failed',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Command execution failed', statusCode: response.statusCode);
+  }
+}

--- a/services/service_sonarr/lib/src/services/sonarr_episode_service.dart
+++ b/services/service_sonarr/lib/src/services/sonarr_episode_service.dart
@@ -1,0 +1,32 @@
+import '../generated/api/raw_episode_api.dart';
+import '../generated/models/episode_resource.dart';
+import '../generated/responses/sonarr_exception.dart';
+
+/// High-level service wrapper for Sonarr Episode operations.
+class SonarrEpisodeService {
+  final RawEpisodeApi _rawEpisodeApi;
+
+  SonarrEpisodeService(this._rawEpisodeApi);
+
+  /// Retrieves episodes for a series or season.
+  Future<List<EpisodeResource>> getEpisodes({
+    String? seriesId,
+    String? seasonNumber,
+  }) async {
+    final response = await _rawEpisodeApi.getEpisode(
+      seriesId: seriesId,
+      seasonNumber: seasonNumber,
+    );
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Failed to fetch episodes',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Failed to fetch episodes', statusCode: response.statusCode);
+  }
+}

--- a/services/service_sonarr/lib/src/services/sonarr_queue_service.dart
+++ b/services/service_sonarr/lib/src/services/sonarr_queue_service.dart
@@ -1,0 +1,83 @@
+import '../generated/api/raw_queue_api.dart';
+import '../generated/api/raw_queue_details_api.dart';
+import '../generated/api/raw_queue_status_api.dart';
+import '../generated/models/queue_resource.dart';
+import '../generated/models/queue_status_resource.dart';
+import '../generated/responses/sonarr_exception.dart';
+
+/// High-level service wrapper for Sonarr active download queue and sessions.
+class SonarrQueueService {
+  final RawQueueApi _rawQueueApi;
+  final RawQueueDetailsApi _rawQueueDetailsApi;
+  final RawQueueStatusApi _rawQueueStatusApi;
+
+  SonarrQueueService(
+    this._rawQueueApi,
+    this._rawQueueDetailsApi,
+    this._rawQueueStatusApi,
+  );
+
+  /// Retrieves active download queue records (with progress, time left, status).
+  Future<List<QueueResource>> getQueue({
+    String? page,
+    String? pageSize,
+    String? sortKey,
+    String? sortDirection,
+  }) async {
+    final response = await _rawQueueApi.getQueue(
+      page: page,
+      pageSize: pageSize,
+      sortKey: sortKey,
+      sortDirection: sortDirection,
+    );
+    if (response.isSuccess && response.data != null) {
+      return response.data!.records ?? [];
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Failed to fetch queue',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Failed to fetch queue', statusCode: response.statusCode);
+  }
+
+  /// Retrieves detailed download queue records, optionally filtered by seriesId or episodeIds.
+  Future<List<QueueResource>> getQueueDetails({
+    String? seriesId,
+    String? episodeId,
+  }) async {
+    final response = await _rawQueueDetailsApi.getQueueDetails(
+      seriesId: seriesId,
+      episodeIds: episodeId,
+    );
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Failed to fetch queue details',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Failed to fetch queue details', statusCode: response.statusCode);
+  }
+
+  /// Retrieves status counts for active download queues.
+  Future<QueueStatusResource?> getQueueStatus() async {
+    final response = await _rawQueueStatusApi.getQueueStatus();
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Failed to fetch queue status',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Failed to fetch queue status', statusCode: response.statusCode);
+  }
+}

--- a/services/service_sonarr/lib/src/services/sonarr_series_service.dart
+++ b/services/service_sonarr/lib/src/services/sonarr_series_service.dart
@@ -1,0 +1,60 @@
+import '../generated/api/raw_series_api.dart';
+import '../generated/api/raw_series_lookup_api.dart';
+import '../generated/models/series_resource.dart';
+import '../generated/responses/sonarr_exception.dart';
+
+/// High-level service wrapper for Sonarr Series operations.
+class SonarrSeriesService {
+  final RawSeriesApi _rawSeriesApi;
+  final RawSeriesLookupApi _rawSeriesLookupApi;
+
+  SonarrSeriesService(this._rawSeriesApi, this._rawSeriesLookupApi);
+
+  /// Retrieves all series monitored in Sonarr.
+  Future<List<SeriesResource>> getSeries({String? tvdbId}) async {
+    final response = await _rawSeriesApi.getSeries(tvdbId: tvdbId);
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Failed to fetch series',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Failed to fetch series', statusCode: response.statusCode);
+  }
+
+  /// Retrieves a specific series by ID.
+  Future<SeriesResource?> getSeriesById(String id) async {
+    final response = await _rawSeriesApi.getSeriesById(id: id);
+    if (response.isSuccess) {
+      return response.data;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Failed to fetch series',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Failed to fetch series', statusCode: response.statusCode);
+  }
+
+  /// Searches for series by term.
+  Future<List<SeriesResource>> searchSeries(String term) async {
+    final response = await _rawSeriesLookupApi.getSeriesLookup(term: term);
+    if (response.isSuccess && response.data != null) {
+      return response.data!;
+    }
+    if (response.error != null) {
+      throw SonarrException(
+        response.error!.message ?? 'Series lookup failed',
+        statusCode: response.statusCode,
+        error: response.error,
+      );
+    }
+    throw SonarrException('Series lookup failed', statusCode: response.statusCode);
+  }
+}

--- a/services/service_sonarr/lib/src/sonarr_providers.dart
+++ b/services/service_sonarr/lib/src/sonarr_providers.dart
@@ -9,10 +9,27 @@ import 'models/sonarr_episode.dart';
 import 'models/sonarr_history_item.dart';
 import 'models/sonarr_queue_item.dart';
 import 'models/sonarr_series.dart';
+import 'services/sonarr_client.dart';
 import 'sonarr_api.dart';
 
 /// How often the series library refreshes.
 const Duration sonarrLibraryPollInterval = Duration(seconds: 60);
+
+/// A [SonarrClient] bound to a specific instance.
+final sonarrClientProvider = FutureProvider.family<SonarrClient, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final dio = await ref.watch(instanceDioProvider(instance).future);
+  final String? apiKey = switch (instance.auth) {
+    InstanceAuthApiKey(:final String apiKey) => apiKey,
+    _ => null,
+  };
+  return SonarrClient(
+    dio: dio,
+    apiKey: apiKey,
+  );
+});
 
 /// A [SonarrApi] bound to a specific instance.
 final sonarrApiProvider = FutureProvider.family<SonarrApi, Instance>((

--- a/services/service_sonarr/test/sonarr_parser_test.dart
+++ b/services/service_sonarr/test/sonarr_parser_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+void main() {
+  group('Sonarr Generated Specs & Models Test', () {
+    test('SeriesResource serialization and deserialization', () {
+      final json = {
+        'id': 10,
+        'title': 'Breaking Bad',
+        'tvdbId': 81189,
+        'monitored': true,
+      };
+
+      final model = SeriesResource.fromJson(json);
+      expect(model.id, equals(10));
+      expect(model.title, equals('Breaking Bad'));
+      expect(model.tvdbId, equals(81189));
+      expect(model.monitored, equals(true));
+
+      final toJsonResult = model.toJson();
+      expect(toJsonResult['id'], equals(10));
+      expect(toJsonResult['title'], equals('Breaking Bad'));
+    });
+
+    test('SonarrError and Exception parsing', () {
+      final errorJson = {
+        'message': 'Series not found',
+        'description': 'The requested series ID does not exist',
+        'status': 404,
+      };
+
+      final sonarrError = SonarrError.fromJson(errorJson);
+      expect(sonarrError.message, equals('Series not found'));
+
+      final exception = SonarrException(
+        sonarrError.message!,
+        statusCode: 404,
+        error: sonarrError,
+      );
+      expect(exception.statusCode, equals(404));
+      expect(exception.toString(), contains('Series not found'));
+    });
+
+    test('SonarrClient initialization', () {
+      final client = SonarrClient(
+        baseUrl: 'http://localhost:8989',
+        apiKey: 'test-sonarr-api-key',
+      );
+
+      expect(client.baseUrl, equals('http://localhost:8989'));
+      expect(client.dio.options.baseUrl, equals('http://localhost:8989/'));
+      expect(client.apiKey, equals('test-sonarr-api-key'));
+    });
+  });
+}

--- a/services/service_sonarr/tool/openapi.json
+++ b/services/service_sonarr/tool/openapi.json
@@ -1,0 +1,12483 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "Sonarr",
+    "description": "Sonarr API docs - The v3 API docs apply to both v3 and v4 versions of Sonarr. Some functionality may only be available in v4 of the Sonarr application.",
+    "license": {
+      "name": "GPL-3.0",
+      "url": "https://github.com/Sonarr/Sonarr/blob/develop/LICENSE"
+    },
+    "version": "3.0.0"
+  },
+  "servers": [
+    {
+      "url": "{protocol}://{hostpath}",
+      "variables": {
+        "protocol": {
+          "default": "http",
+          "enum": [
+            "http",
+            "https"
+          ]
+        },
+        "hostpath": {
+          "default": "localhost:8989"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "tags": [
+          "ApiInfo"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/login": {
+      "post": {
+        "tags": [
+          "Authentication"
+        ],
+        "parameters": [
+          {
+            "name": "returnUrl",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "rememberMe": {
+                    "type": "string"
+                  }
+                }
+              },
+              "encoding": {
+                "username": {
+                  "style": "form"
+                },
+                "password": {
+                  "style": "form"
+                },
+                "rememberMe": {
+                  "style": "form"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/logout": {
+      "get": {
+        "tags": [
+          "Authentication"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/autotagging": {
+      "post": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoTaggingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AutoTaggingResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/autotagging/{id}": {
+      "put": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AutoTaggingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AutoTaggingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/autotagging/schema": {
+      "get": {
+        "tags": [
+          "AutoTagging"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/backup": {
+      "get": {
+        "tags": [
+          "Backup"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BackupResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BackupResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BackupResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/system/backup/{id}": {
+      "delete": {
+        "tags": [
+          "Backup"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/backup/restore/{id}": {
+      "post": {
+        "tags": [
+          "Backup"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/backup/restore/upload": {
+      "post": {
+        "tags": [
+          "Backup"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/blocklist": {
+      "get": {
+        "tags": [
+          "Blocklist"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "seriesIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "protocols",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/DownloadProtocol"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BlocklistResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/blocklist/{id}": {
+      "delete": {
+        "tags": [
+          "Blocklist"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/blocklist/bulk": {
+      "delete": {
+        "tags": [
+          "Blocklist"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistBulkResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistBulkResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/BlocklistBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/calendar": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "unmonitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisodeFile",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisodeImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EpisodeResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/calendar/{id}": {
+      "get": {
+        "tags": [
+          "Calendar"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/feed/v3/calendar/sonarr.ics": {
+      "get": {
+        "tags": [
+          "CalendarFeed"
+        ],
+        "parameters": [
+          {
+            "name": "pastDays",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 7
+            }
+          },
+          {
+            "name": "futureDays",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 28
+            }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": ""
+            }
+          },
+          {
+            "name": "unmonitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "premieresOnly",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "asAllDay",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/command": {
+      "post": {
+        "tags": [
+          "Command"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommandResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Command"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommandResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/command/{id}": {
+      "delete": {
+        "tags": [
+          "Command"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Command"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/customfilter": {
+      "get": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFilterResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFilterResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/customfilter/{id}": {
+      "put": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFilterResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "CustomFilter"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFilterResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/customformat": {
+      "get": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CustomFormatResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/customformat/{id}": {
+      "put": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/customformat/bulk": {
+      "put": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomFormatResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomFormatBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/customformat/schema": {
+      "get": {
+        "tags": [
+          "CustomFormat"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/wanted/cutoff": {
+      "get": {
+        "tags": [
+          "Cutoff"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisodeFile",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "monitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/wanted/cutoff/{id}": {
+      "get": {
+        "tags": [
+          "Cutoff"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/delayprofile": {
+      "post": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/delayprofile/{id}": {
+      "delete": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DelayProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DelayProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/delayprofile/reorder/{id}": {
+      "put": {
+        "tags": [
+          "DelayProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "after",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DelayProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/diskspace": {
+      "get": {
+        "tags": [
+          "DiskSpace"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DiskSpaceResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient": {
+      "get": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DownloadClientResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient/{id}": {
+      "put": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient/bulk": {
+      "put": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient/schema": {
+      "get": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DownloadClientResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient/test": {
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient/testall": {
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/downloadclient/action/{name}": {
+      "post": {
+        "tags": [
+          "DownloadClient"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/config/downloadclient": {
+      "get": {
+        "tags": [
+          "DownloadClientConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/downloadclient/{id}": {
+      "put": {
+        "tags": [
+          "DownloadClientConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DownloadClientConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "DownloadClientConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadClientConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/episode": {
+      "get": {
+        "tags": [
+          "Episode"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "seasonNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "episodeIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "episodeFileId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisodeFile",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EpisodeResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/episode/{id}": {
+      "put": {
+        "tags": [
+          "Episode"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EpisodeResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Episode"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/episode/monitor": {
+      "put": {
+        "tags": [
+          "Episode"
+        ],
+        "parameters": [
+          {
+            "name": "includeImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EpisodesMonitoredResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/episodefile": {
+      "get": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "episodeFileIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EpisodeFileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/episodefile/{id}": {
+      "put": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EpisodeFileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeFileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeFileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeFileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeFileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/episodefile/editor": {
+      "put": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EpisodeFileListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/episodefile/bulk": {
+      "delete": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EpisodeFileListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "EpisodeFile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/EpisodeFileResource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/filesystem": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "includeFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "allowFoldersWithoutTrailingSlashes",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/filesystem/type": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/filesystem/mediafiles": {
+      "get": {
+        "tags": [
+          "FileSystem"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/health": {
+      "get": {
+        "tags": [
+          "Health"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HealthResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/history": {
+      "get": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "includeEpisode",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "episodeId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "downloadId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "seriesIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "languages",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "quality",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoryResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/history/since": {
+      "get": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "date",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/EpisodeHistoryEventType"
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisode",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HistoryResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/history/series": {
+      "get": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "seasonNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/EpisodeHistoryEventType"
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisode",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HistoryResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/history/failed/{id}": {
+      "post": {
+        "tags": [
+          "History"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/config/host": {
+      "get": {
+        "tags": [
+          "HostConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/host/{id}": {
+      "put": {
+        "tags": [
+          "HostConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostConfigResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostConfigResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "HostConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HostConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlist": {
+      "get": {
+        "tags": [
+          "ImportList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlist/{id}": {
+      "put": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlist/bulk": {
+      "put": {
+        "tags": [
+          "ImportList"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ImportList"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/importlist/schema": {
+      "get": {
+        "tags": [
+          "ImportList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlist/test": {
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/importlist/testall": {
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/importlist/action/{name}": {
+      "post": {
+        "tags": [
+          "ImportList"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/config/importlist": {
+      "get": {
+        "tags": [
+          "ImportListConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/importlist/{id}": {
+      "put": {
+        "tags": [
+          "ImportListConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ImportListConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlistexclusion": {
+      "get": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ImportListExclusionResource"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "post": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlistexclusion/paged": {
+      "get": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlistexclusion/{id}": {
+      "put": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportListExclusionResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/importlistexclusion/bulk": {
+      "delete": {
+        "tags": [
+          "ImportListExclusion"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionBulkResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionBulkResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportListExclusionBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/indexer": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/indexer/{id}": {
+      "put": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/indexer/bulk": {
+      "put": {
+        "tags": [
+          "Indexer"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Indexer"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/indexer/schema": {
+      "get": {
+        "tags": [
+          "Indexer"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/indexer/test": {
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/indexer/testall": {
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/indexer/action/{name}": {
+      "post": {
+        "tags": [
+          "Indexer"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/config/indexer": {
+      "get": {
+        "tags": [
+          "IndexerConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/indexer/{id}": {
+      "put": {
+        "tags": [
+          "IndexerConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IndexerConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "IndexerConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/indexerflag": {
+      "get": {
+        "tags": [
+          "IndexerFlag"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerFlagResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerFlagResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/IndexerFlagResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/language": {
+      "get": {
+        "tags": [
+          "Language"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/language/{id}": {
+      "get": {
+        "tags": [
+          "Language"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/languageprofile": {
+      "post": {
+        "tags": [
+          "LanguageProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguageProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileResource"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "get": {
+        "tags": [
+          "LanguageProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LanguageProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/v3/languageprofile/{id}": {
+      "delete": {
+        "tags": [
+          "LanguageProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        },
+        "deprecated": true
+      },
+      "put": {
+        "tags": [
+          "LanguageProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LanguageProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileResource"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      },
+      "get": {
+        "tags": [
+          "LanguageProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/languageprofile/schema": {
+      "get": {
+        "tags": [
+          "LanguageProfileSchema"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LanguageProfileResource"
+                }
+              }
+            }
+          }
+        },
+        "deprecated": true
+      }
+    },
+    "/api/v3/localization": {
+      "get": {
+        "tags": [
+          "Localization"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalizationResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/localization/language": {
+      "get": {
+        "tags": [
+          "Localization"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalizationLanguageResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/localization/{id}": {
+      "get": {
+        "tags": [
+          "Localization"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalizationResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/log": {
+      "get": {
+        "tags": [
+          "Log"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "level",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LogResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/log/file": {
+      "get": {
+        "tags": [
+          "LogFile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogFileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/log/file/{filename}": {
+      "get": {
+        "tags": [
+          "LogFile"
+        ],
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "[-.a-zA-Z0-9]+?\\.txt",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/manualimport": {
+      "get": {
+        "tags": [
+          "ManualImport"
+        ],
+        "parameters": [
+          {
+            "name": "folder",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "downloadId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "seasonNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "filterExistingFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ManualImportResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "ManualImport"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ManualImportReprocessResource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/mediacover/{seriesId}/{filename}": {
+      "get": {
+        "tags": [
+          "MediaCover"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "(.+)\\.(jpg|png|gif)",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/config/mediamanagement": {
+      "get": {
+        "tags": [
+          "MediaManagementConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/mediamanagement/{id}": {
+      "put": {
+        "tags": [
+          "MediaManagementConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MediaManagementConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "MediaManagementConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MediaManagementConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/metadata": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/metadata/{id}": {
+      "put": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetadataResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/metadata/schema": {
+      "get": {
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MetadataResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/metadata/test": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/metadata/testall": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/metadata/action/{name}": {
+      "post": {
+        "tags": [
+          "Metadata"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetadataResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/wanted/missing": {
+      "get": {
+        "tags": [
+          "Missing"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "monitored",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/wanted/missing/{id}": {
+      "get": {
+        "tags": [
+          "Missing"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EpisodeResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/naming": {
+      "get": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/naming/{id}": {
+      "put": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NamingConfigResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NamingConfigResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/NamingConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NamingConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/naming/examples": {
+      "get": {
+        "tags": [
+          "NamingConfig"
+        ],
+        "parameters": [
+          {
+            "name": "renameEpisodes",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "replaceIllegalCharacters",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "colonReplacementFormat",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "customColonReplacementFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "multiEpisodeStyle",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "standardEpisodeFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dailyEpisodeFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "animeEpisodeFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "seriesFolderFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "seasonFolderFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "specialsFolderFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "resourceName",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/notification": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/notification/{id}": {
+      "put": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "forceSave",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotificationResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/notification/schema": {
+      "get": {
+        "tags": [
+          "Notification"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NotificationResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/notification/test": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "forceTest",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/notification/testall": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/notification/action/{name}": {
+      "post": {
+        "tags": [
+          "Notification"
+        ],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/parse": {
+      "get": {
+        "tags": [
+          "Parse"
+        ],
+        "parameters": [
+          {
+            "name": "title",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "path",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ParseResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ping": {
+      "get": {
+        "tags": [
+          "Ping"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "head": {
+        "tags": [
+          "Ping"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/qualitydefinition/{id}": {
+      "put": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityDefinitionResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityDefinitionResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityDefinitionResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/qualitydefinition": {
+      "get": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityDefinitionResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/qualitydefinition/update": {
+      "put": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/QualityDefinitionResource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/qualitydefinition/limits": {
+      "get": {
+        "tags": [
+          "QualityDefinition"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityDefinitionLimitsResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/qualityprofile": {
+      "post": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QualityProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/qualityprofile/{id}": {
+      "delete": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QualityProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "QualityProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/qualityprofile/schema": {
+      "get": {
+        "tags": [
+          "QualityProfileSchema"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QualityProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/queue/{id}": {
+      "delete": {
+        "tags": [
+          "Queue"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "removeFromClient",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "blocklist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "skipRedownload",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "changeCategory",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/queue/bulk": {
+      "delete": {
+        "tags": [
+          "Queue"
+        ],
+        "parameters": [
+          {
+            "name": "removeFromClient",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "blocklist",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "skipRedownload",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "changeCategory",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/queue": {
+      "get": {
+        "tags": [
+          "Queue"
+        ],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 1
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 10
+            }
+          },
+          {
+            "name": "sortKey",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sortDirection",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/SortDirection"
+            }
+          },
+          {
+            "name": "includeUnknownSeriesItems",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisode",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "seriesIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "protocol",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DownloadProtocol"
+            }
+          },
+          {
+            "name": "languages",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "quality",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/QueueStatus"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueResourcePagingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/queue/grab/{id}": {
+      "post": {
+        "tags": [
+          "QueueAction"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/queue/grab/bulk": {
+      "post": {
+        "tags": [
+          "QueueAction"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/QueueBulkResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/queue/details": {
+      "get": {
+        "tags": [
+          "QueueDetails"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "episodeIds",
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          {
+            "name": "includeSeries",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "includeEpisode",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/QueueResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/queue/status": {
+      "get": {
+        "tags": [
+          "QueueStatus"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueueStatusResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/release": {
+      "post": {
+        "tags": [
+          "Release"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Release"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "episodeId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "seasonNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/releaseprofile": {
+      "post": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseProfileResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseProfileResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseProfileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/releaseprofile/{id}": {
+      "delete": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseProfileResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "ReleaseProfile"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReleaseProfileResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/release/push": {
+      "post": {
+        "tags": [
+          "ReleasePush"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReleaseResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReleaseResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/remotepathmapping": {
+      "post": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RemotePathMappingResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/remotepathmapping/{id}": {
+      "delete": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/RemotePathMappingResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "RemotePathMapping"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RemotePathMappingResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/rename": {
+      "get": {
+        "tags": [
+          "RenameEpisode"
+        ],
+        "parameters": [
+          {
+            "name": "seriesId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "seasonNumber",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RenameEpisodeResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/rootfolder": {
+      "post": {
+        "tags": [
+          "RootFolder"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RootFolderResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "RootFolder"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/RootFolderResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/rootfolder/{id}": {
+      "delete": {
+        "tags": [
+          "RootFolder"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "RootFolder"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RootFolderResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/seasonpass": {
+      "post": {
+        "tags": [
+          "SeasonPass"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeasonPassResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/series": {
+      "get": {
+        "tags": [
+          "Series"
+        ],
+        "parameters": [
+          {
+            "name": "tvdbId",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "includeSeasonImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SeriesResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Series"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeriesResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/series/{id}": {
+      "get": {
+        "tags": [
+          "Series"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "includeSeasonImages",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeriesResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Series"
+        ],
+        "parameters": [
+          {
+            "name": "moveFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeriesResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Series"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "deleteFiles",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "addImportListExclusion",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/series/editor": {
+      "put": {
+        "tags": [
+          "SeriesEditor"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesEditorResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesEditorResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesEditorResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "SeriesEditor"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesEditorResource"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesEditorResource"
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeriesEditorResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/series/{id}/folder": {
+      "get": {
+        "tags": [
+          "SeriesFolder"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/series/import": {
+      "post": {
+        "tags": [
+          "SeriesImport"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SeriesResource"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SeriesResource"
+                }
+              }
+            },
+            "application/*+json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SeriesResource"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/series/lookup": {
+      "get": {
+        "tags": [
+          "SeriesLookup"
+        ],
+        "parameters": [
+          {
+            "name": "term",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SeriesResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SeriesResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SeriesResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/content/{path}": {
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^(?!api/).*",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/": {
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/{path}": {
+      "get": {
+        "tags": [
+          "StaticResource"
+        ],
+        "parameters": [
+          {
+            "name": "path",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "^(?!(api|feed)/).*",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/status": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SystemResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/system/routes": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/routes/duplicate": {
+      "get": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/shutdown": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/system/restart": {
+      "post": {
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/api/v3/tag": {
+      "get": {
+        "tags": [
+          "Tag"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "Tag"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/tag/{id}": {
+      "put": {
+        "tags": [
+          "Tag"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Tag"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "Tag"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/tag/detail": {
+      "get": {
+        "tags": [
+          "TagDetails"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagDetailsResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/tag/detail/{id}": {
+      "get": {
+        "tags": [
+          "TagDetails"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagDetailsResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/system/task": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskResource"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskResource"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TaskResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/system/task/{id}": {
+      "get": {
+        "tags": [
+          "Task"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaskResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/ui/{id}": {
+      "put": {
+        "tags": [
+          "UiConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UiConfigResource"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": [
+          "UiConfig"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/config/ui": {
+      "get": {
+        "tags": [
+          "UiConfig"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UiConfigResource"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/update": {
+      "get": {
+        "tags": [
+          "Update"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UpdateResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/log/file/update": {
+      "get": {
+        "tags": [
+          "UpdateLogFile"
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LogFileResource"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v3/log/file/update/{filename}": {
+      "get": {
+        "tags": [
+          "UpdateLogFile"
+        ],
+        "parameters": [
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "pattern": "[-.a-zA-Z0-9]+?\\.txt",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddSeriesOptions": {
+        "type": "object",
+        "properties": {
+          "ignoreEpisodesWithFiles": {
+            "type": "boolean"
+          },
+          "ignoreEpisodesWithoutFiles": {
+            "type": "boolean"
+          },
+          "monitor": {
+            "$ref": "#/components/schemas/MonitorTypes"
+          },
+          "searchForMissingEpisodes": {
+            "type": "boolean"
+          },
+          "searchForCutoffUnmetEpisodes": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "AlternateTitleResource": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sceneSeasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sceneOrigin": {
+            "type": "string",
+            "nullable": true
+          },
+          "comment": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ApplyTags": {
+        "enum": [
+          "add",
+          "remove",
+          "replace"
+        ],
+        "type": "string"
+      },
+      "AuthenticationRequiredType": {
+        "enum": [
+          "enabled",
+          "disabledForLocalAddresses"
+        ],
+        "type": "string"
+      },
+      "AuthenticationType": {
+        "enum": [
+          "none",
+          "basic",
+          "forms",
+          "external"
+        ],
+        "type": "string"
+      },
+      "AutoTaggingResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "removeTagsAutomatically": {
+            "type": "boolean"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "specifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AutoTaggingSpecificationSchema"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "AutoTaggingSpecificationSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "negate": {
+            "type": "boolean"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/BackupType"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BackupType": {
+        "enum": [
+          "scheduled",
+          "manual",
+          "update"
+        ],
+        "type": "string"
+      },
+      "BlocklistBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlocklistResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "sourceTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "indexer": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "series": {
+            "$ref": "#/components/schemas/SeriesResource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "BlocklistResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BlocklistResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CertificateValidationType": {
+        "enum": [
+          "enabled",
+          "disabledForLocalAddresses",
+          "disabled"
+        ],
+        "type": "string"
+      },
+      "Command": {
+        "type": "object",
+        "properties": {
+          "sendUpdatesToClient": {
+            "type": "boolean"
+          },
+          "updateScheduledTask": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "completionMessage": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "requiresDiskAccess": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isExclusive": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isLongRunning": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "lastExecutionTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastStartTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/CommandTrigger"
+          },
+          "suppressMessages": {
+            "type": "boolean"
+          },
+          "clientUserAgent": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CommandPriority": {
+        "enum": [
+          "normal",
+          "high",
+          "low"
+        ],
+        "type": "string"
+      },
+      "CommandResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "commandName": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "body": {
+            "$ref": "#/components/schemas/Command"
+          },
+          "priority": {
+            "$ref": "#/components/schemas/CommandPriority"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CommandStatus"
+          },
+          "result": {
+            "$ref": "#/components/schemas/CommandResult"
+          },
+          "queued": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "started": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "ended": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "duration": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true
+          },
+          "exception": {
+            "type": "string",
+            "nullable": true
+          },
+          "trigger": {
+            "$ref": "#/components/schemas/CommandTrigger"
+          },
+          "clientUserAgent": {
+            "type": "string",
+            "nullable": true
+          },
+          "stateChangeTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "sendUpdatesToClient": {
+            "type": "boolean"
+          },
+          "updateScheduledTask": {
+            "type": "boolean"
+          },
+          "lastExecutionTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CommandResult": {
+        "enum": [
+          "unknown",
+          "successful",
+          "unsuccessful"
+        ],
+        "type": "string"
+      },
+      "CommandStatus": {
+        "enum": [
+          "queued",
+          "started",
+          "completed",
+          "failed",
+          "aborted",
+          "cancelled",
+          "orphaned"
+        ],
+        "type": "string"
+      },
+      "CommandTrigger": {
+        "enum": [
+          "unspecified",
+          "manual",
+          "scheduled"
+        ],
+        "type": "string"
+      },
+      "CustomFilterResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": {}
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFormatBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "includeCustomFormatWhenRenaming": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFormatResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "includeCustomFormatWhenRenaming": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "specifications": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatSpecificationSchema"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "CustomFormatSpecificationSchema": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "negate": {
+            "type": "boolean"
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatSpecificationSchema"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DatabaseType": {
+        "enum": [
+          "sqLite",
+          "postgreSQL"
+        ],
+        "type": "string"
+      },
+      "DelayProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "enableUsenet": {
+            "type": "boolean"
+          },
+          "enableTorrent": {
+            "type": "boolean"
+          },
+          "preferredProtocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "usenetDelay": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "torrentDelay": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bypassIfHighestQuality": {
+            "type": "boolean"
+          },
+          "bypassIfAboveCustomFormatScore": {
+            "type": "boolean"
+          },
+          "minimumCustomFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DiskSpaceResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "freeSpace": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "totalSpace": {
+            "type": "integer",
+            "format": "int64"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadClientBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "enable": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "removeCompletedDownloads": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "removeFailedDownloads": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadClientConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadClientWorkingFolders": {
+            "type": "string",
+            "nullable": true
+          },
+          "enableCompletedDownloadHandling": {
+            "type": "boolean"
+          },
+          "autoRedownloadFailed": {
+            "type": "boolean"
+          },
+          "autoRedownloadFailedFromInteractiveSearch": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadClientResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DownloadClientResource"
+            },
+            "nullable": true
+          },
+          "enable": {
+            "type": "boolean"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "removeCompletedDownloads": {
+            "type": "boolean"
+          },
+          "removeFailedDownloads": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "DownloadProtocol": {
+        "enum": [
+          "unknown",
+          "usenet",
+          "torrent"
+        ],
+        "type": "string"
+      },
+      "EpisodeFileListResource": {
+        "type": "object",
+        "properties": {
+          "episodeFileIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "sceneName": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EpisodeFileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "relativePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "dateAdded": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "sceneName": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "releaseType": {
+            "$ref": "#/components/schemas/ReleaseType"
+          },
+          "mediaInfo": {
+            "$ref": "#/components/schemas/MediaInfoResource"
+          },
+          "qualityCutoffNotMet": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "EpisodeHistoryEventType": {
+        "enum": [
+          "unknown",
+          "grabbed",
+          "seriesFolderImported",
+          "downloadFolderImported",
+          "downloadFailed",
+          "episodeFileDeleted",
+          "episodeFileRenamed",
+          "downloadIgnored"
+        ],
+        "type": "string"
+      },
+      "EpisodeResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeFileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "airDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "airDateUtc": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastSearchTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "runtime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "finaleType": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeFile": {
+            "$ref": "#/components/schemas/EpisodeFileResource"
+          },
+          "hasFile": {
+            "type": "boolean"
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "absoluteEpisodeNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sceneAbsoluteEpisodeNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sceneEpisodeNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "sceneSeasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "unverifiedSceneNumbering": {
+            "type": "boolean"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "grabDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "series": {
+            "$ref": "#/components/schemas/SeriesResource"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EpisodeResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EpisodeResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "EpisodeTitleRequiredType": {
+        "enum": [
+          "always",
+          "bulkSeasonReleases",
+          "never"
+        ],
+        "type": "string"
+      },
+      "EpisodesMonitoredResource": {
+        "type": "object",
+        "properties": {
+          "episodeIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Field": {
+        "type": "object",
+        "properties": {
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "unit": {
+            "type": "string",
+            "nullable": true
+          },
+          "helpText": {
+            "type": "string",
+            "nullable": true
+          },
+          "helpTextWarning": {
+            "type": "string",
+            "nullable": true
+          },
+          "helpLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "value": {
+            "nullable": true
+          },
+          "type": {
+            "type": "string",
+            "nullable": true
+          },
+          "advanced": {
+            "type": "boolean"
+          },
+          "selectOptions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SelectOption"
+            },
+            "nullable": true
+          },
+          "selectOptionsProviderAction": {
+            "type": "string",
+            "nullable": true
+          },
+          "section": {
+            "type": "string",
+            "nullable": true
+          },
+          "hidden": {
+            "type": "string",
+            "nullable": true
+          },
+          "privacy": {
+            "$ref": "#/components/schemas/PrivacyLevel"
+          },
+          "placeholder": {
+            "type": "string",
+            "nullable": true
+          },
+          "isFloat": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "FileDateType": {
+        "enum": [
+          "none",
+          "localAirDate",
+          "utcAirDate"
+        ],
+        "type": "string"
+      },
+      "HealthCheckResult": {
+        "enum": [
+          "ok",
+          "notice",
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      },
+      "HealthResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "source": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/HealthCheckResult"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "wikiUrl": {
+            "$ref": "#/components/schemas/HttpUri"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HistoryResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sourceTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "qualityCutoffNotMet": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "eventType": {
+            "$ref": "#/components/schemas/EpisodeHistoryEventType"
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "nullable": true
+          },
+          "episode": {
+            "$ref": "#/components/schemas/EpisodeResource"
+          },
+          "series": {
+            "$ref": "#/components/schemas/SeriesResource"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HistoryResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HistoryResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "HostConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "bindAddress": {
+            "type": "string",
+            "nullable": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sslPort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "enableSsl": {
+            "type": "boolean"
+          },
+          "launchBrowser": {
+            "type": "boolean"
+          },
+          "authenticationMethod": {
+            "$ref": "#/components/schemas/AuthenticationType"
+          },
+          "authenticationRequired": {
+            "$ref": "#/components/schemas/AuthenticationRequiredType"
+          },
+          "analyticsEnabled": {
+            "type": "boolean"
+          },
+          "username": {
+            "type": "string",
+            "nullable": true
+          },
+          "password": {
+            "type": "string",
+            "nullable": true
+          },
+          "passwordConfirmation": {
+            "type": "string",
+            "nullable": true
+          },
+          "logLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "logSizeLimit": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "consoleLogLevel": {
+            "type": "string",
+            "nullable": true
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "apiKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sslCertPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "sslCertPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "instanceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "applicationUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "updateAutomatically": {
+            "type": "boolean"
+          },
+          "updateMechanism": {
+            "$ref": "#/components/schemas/UpdateMechanism"
+          },
+          "updateScriptPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyEnabled": {
+            "type": "boolean"
+          },
+          "proxyType": {
+            "$ref": "#/components/schemas/ProxyType"
+          },
+          "proxyHostname": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyPort": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "proxyUsername": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyPassword": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyBypassFilter": {
+            "type": "string",
+            "nullable": true
+          },
+          "proxyBypassLocalAddresses": {
+            "type": "boolean"
+          },
+          "certificateValidation": {
+            "$ref": "#/components/schemas/CertificateValidationType"
+          },
+          "backupFolder": {
+            "type": "string",
+            "nullable": true
+          },
+          "backupInterval": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "backupRetention": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "trustCgnatIpAddresses": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "HttpUri": {
+        "type": "object",
+        "properties": {
+          "fullUri": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "scheme": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "host": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "port": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true,
+            "readOnly": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "query": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          },
+          "fragment": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "enableAutomaticAdd": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "listSyncLevel": {
+            "$ref": "#/components/schemas/ListSyncLevelType"
+          },
+          "listSyncTag": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListExclusionBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListExclusionResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListExclusionResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImportListExclusionResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImportListResource"
+            },
+            "nullable": true
+          },
+          "enableAutomaticAdd": {
+            "type": "boolean"
+          },
+          "searchForMissingEpisodes": {
+            "type": "boolean"
+          },
+          "shouldMonitor": {
+            "$ref": "#/components/schemas/MonitorTypes"
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesType": {
+            "$ref": "#/components/schemas/SeriesTypes"
+          },
+          "seasonFolder": {
+            "type": "boolean"
+          },
+          "listType": {
+            "$ref": "#/components/schemas/ImportListType"
+          },
+          "listOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minRefreshInterval": {
+            "type": "string",
+            "format": "date-span"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ImportListType": {
+        "enum": [
+          "program",
+          "plex",
+          "trakt",
+          "simkl",
+          "other",
+          "advanced"
+        ],
+        "type": "string"
+      },
+      "ImportRejectionResource": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/RejectionType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "enableRss": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "enableAutomaticSearch": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "enableInteractiveSearch": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minimumAge": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "retention": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maximumSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "rssSyncInterval": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerFlagResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameLower": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "IndexerResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IndexerResource"
+            },
+            "nullable": true
+          },
+          "enableRss": {
+            "type": "boolean"
+          },
+          "enableAutomaticSearch": {
+            "type": "boolean"
+          },
+          "enableInteractiveSearch": {
+            "type": "boolean"
+          },
+          "supportsRss": {
+            "type": "boolean"
+          },
+          "supportsSearch": {
+            "type": "boolean"
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "priority": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonSearchMaximumSingleEpisodeAge": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadClientId": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Language": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LanguageProfileItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "language": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "LanguageProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "upgradeAllowed": {
+            "type": "boolean"
+          },
+          "cutoff": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LanguageProfileItemResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LanguageResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "nameLower": {
+            "type": "string",
+            "nullable": true,
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ListSyncLevelType": {
+        "enum": [
+          "disabled",
+          "logOnly",
+          "keepAndUnmonitor",
+          "keepAndTag"
+        ],
+        "type": "string"
+      },
+      "LocalizationLanguageResource": {
+        "type": "object",
+        "properties": {
+          "identifier": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LocalizationResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "strings": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string",
+              "nullable": true
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogFileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "filename": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastWriteTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "contentsUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "exception": {
+            "type": "string",
+            "nullable": true
+          },
+          "exceptionType": {
+            "type": "string",
+            "nullable": true
+          },
+          "level": {
+            "type": "string",
+            "nullable": true
+          },
+          "logger": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "method": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "LogResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LogResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManualImportReprocessResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "episodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EpisodeResource"
+            },
+            "nullable": true
+          },
+          "episodeIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "releaseType": {
+            "$ref": "#/components/schemas/ReleaseType"
+          },
+          "rejections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImportRejectionResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ManualImportResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "relativePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "folderName": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "series": {
+            "$ref": "#/components/schemas/SeriesResource"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "episodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EpisodeResource"
+            },
+            "nullable": true
+          },
+          "episodeFileId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "qualityWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "releaseType": {
+            "$ref": "#/components/schemas/ReleaseType"
+          },
+          "rejections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ImportRejectionResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaCover": {
+        "type": "object",
+        "properties": {
+          "coverType": {
+            "$ref": "#/components/schemas/MediaCoverTypes"
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "remoteUrl": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaCoverTypes": {
+        "enum": [
+          "unknown",
+          "poster",
+          "banner",
+          "fanart",
+          "screenshot",
+          "headshot",
+          "clearlogo"
+        ],
+        "type": "string"
+      },
+      "MediaInfoResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "audioBitrate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "audioChannels": {
+            "type": "number",
+            "format": "double"
+          },
+          "audioCodec": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioLanguages": {
+            "type": "string",
+            "nullable": true
+          },
+          "audioStreamCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "videoBitDepth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "videoBitrate": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "videoCodec": {
+            "type": "string",
+            "nullable": true
+          },
+          "videoFps": {
+            "type": "number",
+            "format": "double"
+          },
+          "videoDynamicRange": {
+            "type": "string",
+            "nullable": true
+          },
+          "videoDynamicRangeType": {
+            "type": "string",
+            "nullable": true
+          },
+          "resolution": {
+            "type": "string",
+            "nullable": true
+          },
+          "runTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "scanType": {
+            "type": "string",
+            "nullable": true
+          },
+          "subtitles": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "MediaManagementConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "autoUnmonitorPreviouslyDownloadedEpisodes": {
+            "type": "boolean"
+          },
+          "recycleBin": {
+            "type": "string",
+            "nullable": true
+          },
+          "recycleBinCleanupDays": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "downloadPropersAndRepacks": {
+            "$ref": "#/components/schemas/ProperDownloadTypes"
+          },
+          "createEmptySeriesFolders": {
+            "type": "boolean"
+          },
+          "deleteEmptyFolders": {
+            "type": "boolean"
+          },
+          "fileDate": {
+            "$ref": "#/components/schemas/FileDateType"
+          },
+          "rescanAfterRefresh": {
+            "$ref": "#/components/schemas/RescanAfterRefreshType"
+          },
+          "setPermissionsLinux": {
+            "type": "boolean"
+          },
+          "chmodFolder": {
+            "type": "string",
+            "nullable": true
+          },
+          "chownGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeTitleRequired": {
+            "$ref": "#/components/schemas/EpisodeTitleRequiredType"
+          },
+          "skipFreeSpaceCheckWhenImporting": {
+            "type": "boolean"
+          },
+          "minimumFreeSpaceWhenImporting": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "copyUsingHardlinks": {
+            "type": "boolean"
+          },
+          "useScriptImport": {
+            "type": "boolean"
+          },
+          "scriptImportPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "importExtraFiles": {
+            "type": "boolean"
+          },
+          "extraFileExtensions": {
+            "type": "string",
+            "nullable": true
+          },
+          "enableMediaInfo": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MetadataResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MetadataResource"
+            },
+            "nullable": true
+          },
+          "enable": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "MonitorTypes": {
+        "enum": [
+          "unknown",
+          "all",
+          "future",
+          "missing",
+          "existing",
+          "firstSeason",
+          "lastSeason",
+          "latestSeason",
+          "pilot",
+          "recent",
+          "monitorSpecials",
+          "unmonitorSpecials",
+          "none",
+          "skip"
+        ],
+        "type": "string"
+      },
+      "MonitoringOptions": {
+        "type": "object",
+        "properties": {
+          "ignoreEpisodesWithFiles": {
+            "type": "boolean"
+          },
+          "ignoreEpisodesWithoutFiles": {
+            "type": "boolean"
+          },
+          "monitor": {
+            "$ref": "#/components/schemas/MonitorTypes"
+          }
+        },
+        "additionalProperties": false
+      },
+      "NamingConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "renameEpisodes": {
+            "type": "boolean"
+          },
+          "replaceIllegalCharacters": {
+            "type": "boolean"
+          },
+          "colonReplacementFormat": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "customColonReplacementFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "multiEpisodeStyle": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "standardEpisodeFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "dailyEpisodeFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "animeEpisodeFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesFolderFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonFolderFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "specialsFolderFormat": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "NewItemMonitorTypes": {
+        "enum": [
+          "all",
+          "none"
+        ],
+        "type": "string"
+      },
+      "NotificationResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Field"
+            },
+            "nullable": true
+          },
+          "implementationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "implementation": {
+            "type": "string",
+            "nullable": true
+          },
+          "configContract": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoLink": {
+            "type": "string",
+            "nullable": true
+          },
+          "message": {
+            "$ref": "#/components/schemas/ProviderMessage"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/NotificationResource"
+            },
+            "nullable": true
+          },
+          "link": {
+            "type": "string",
+            "nullable": true
+          },
+          "onGrab": {
+            "type": "boolean"
+          },
+          "onDownload": {
+            "type": "boolean"
+          },
+          "onUpgrade": {
+            "type": "boolean"
+          },
+          "onImportComplete": {
+            "type": "boolean"
+          },
+          "onRename": {
+            "type": "boolean"
+          },
+          "onSeriesAdd": {
+            "type": "boolean"
+          },
+          "onSeriesDelete": {
+            "type": "boolean"
+          },
+          "onEpisodeFileDelete": {
+            "type": "boolean"
+          },
+          "onEpisodeFileDeleteForUpgrade": {
+            "type": "boolean"
+          },
+          "onHealthIssue": {
+            "type": "boolean"
+          },
+          "includeHealthWarnings": {
+            "type": "boolean"
+          },
+          "onHealthRestored": {
+            "type": "boolean"
+          },
+          "onApplicationUpdate": {
+            "type": "boolean"
+          },
+          "onManualInteractionRequired": {
+            "type": "boolean"
+          },
+          "supportsOnGrab": {
+            "type": "boolean"
+          },
+          "supportsOnDownload": {
+            "type": "boolean"
+          },
+          "supportsOnUpgrade": {
+            "type": "boolean"
+          },
+          "supportsOnImportComplete": {
+            "type": "boolean"
+          },
+          "supportsOnRename": {
+            "type": "boolean"
+          },
+          "supportsOnSeriesAdd": {
+            "type": "boolean"
+          },
+          "supportsOnSeriesDelete": {
+            "type": "boolean"
+          },
+          "supportsOnEpisodeFileDelete": {
+            "type": "boolean"
+          },
+          "supportsOnEpisodeFileDeleteForUpgrade": {
+            "type": "boolean"
+          },
+          "supportsOnHealthIssue": {
+            "type": "boolean"
+          },
+          "supportsOnHealthRestored": {
+            "type": "boolean"
+          },
+          "supportsOnApplicationUpdate": {
+            "type": "boolean"
+          },
+          "supportsOnManualInteractionRequired": {
+            "type": "boolean"
+          },
+          "testCommand": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParseResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "parsedEpisodeInfo": {
+            "$ref": "#/components/schemas/ParsedEpisodeInfo"
+          },
+          "series": {
+            "$ref": "#/components/schemas/SeriesResource"
+          },
+          "episodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EpisodeResource"
+            },
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ParsedEpisodeInfo": {
+        "type": "object",
+        "properties": {
+          "releaseTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesTitleInfo": {
+            "$ref": "#/components/schemas/SeriesTitleInfo"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "absoluteEpisodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "specialAbsoluteEpisodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "format": "double"
+            },
+            "nullable": true
+          },
+          "airDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "fullSeason": {
+            "type": "boolean"
+          },
+          "isPartialSeason": {
+            "type": "boolean"
+          },
+          "isMultiSeason": {
+            "type": "boolean"
+          },
+          "isSeasonExtra": {
+            "type": "boolean"
+          },
+          "isSplitEpisode": {
+            "type": "boolean"
+          },
+          "isMiniSeries": {
+            "type": "boolean"
+          },
+          "special": {
+            "type": "boolean"
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasonPart": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "releaseTokens": {
+            "type": "string",
+            "nullable": true
+          },
+          "dailyPart": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "isDaily": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isAbsoluteNumbering": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isPossibleSpecialEpisode": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "isPossibleSceneSeasonSpecial": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "releaseType": {
+            "$ref": "#/components/schemas/ReleaseType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "PingResource": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "PrivacyLevel": {
+        "enum": [
+          "normal",
+          "password",
+          "apiKey",
+          "userName"
+        ],
+        "type": "string"
+      },
+      "ProfileFormatItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "format": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "score": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProperDownloadTypes": {
+        "enum": [
+          "preferAndUpgrade",
+          "doNotUpgrade",
+          "doNotPrefer"
+        ],
+        "type": "string"
+      },
+      "ProviderMessage": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "type": {
+            "$ref": "#/components/schemas/ProviderMessageType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProviderMessageType": {
+        "enum": [
+          "info",
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      },
+      "ProxyType": {
+        "enum": [
+          "http",
+          "socks4",
+          "socks5"
+        ],
+        "type": "string"
+      },
+      "Quality": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "$ref": "#/components/schemas/QualitySource"
+          },
+          "resolution": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityDefinitionLimitsResource": {
+        "type": "object",
+        "properties": {
+          "min": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "max": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityDefinitionResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "quality": {
+            "$ref": "#/components/schemas/Quality"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "weight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "maxSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          },
+          "preferredSize": {
+            "type": "number",
+            "format": "double",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityModel": {
+        "type": "object",
+        "properties": {
+          "quality": {
+            "$ref": "#/components/schemas/Quality"
+          },
+          "revision": {
+            "$ref": "#/components/schemas/Revision"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityProfileQualityItemResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/Quality"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QualityProfileQualityItemResource"
+            },
+            "nullable": true
+          },
+          "allowed": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualityProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "upgradeAllowed": {
+            "type": "boolean"
+          },
+          "cutoff": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QualityProfileQualityItemResource"
+            },
+            "nullable": true
+          },
+          "minFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "cutoffFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "minUpgradeFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "formatItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProfileFormatItemResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QualitySource": {
+        "enum": [
+          "unknown",
+          "television",
+          "televisionRaw",
+          "web",
+          "webRip",
+          "dvd",
+          "bluray",
+          "blurayRaw"
+        ],
+        "type": "string"
+      },
+      "QueueBulkResource": {
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "episodeId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "series": {
+            "$ref": "#/components/schemas/SeriesResource"
+          },
+          "episode": {
+            "$ref": "#/components/schemas/EpisodeResource"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "type": "number",
+            "format": "double"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "estimatedCompletionTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "added": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/QueueStatus"
+          },
+          "trackedDownloadStatus": {
+            "$ref": "#/components/schemas/TrackedDownloadStatus"
+          },
+          "trackedDownloadState": {
+            "$ref": "#/components/schemas/TrackedDownloadState"
+          },
+          "statusMessages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrackedDownloadStatusMessage"
+            },
+            "nullable": true
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadId": {
+            "type": "string",
+            "nullable": true
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "downloadClient": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadClientHasPostImportCategory": {
+            "type": "boolean"
+          },
+          "indexer": {
+            "type": "string",
+            "nullable": true
+          },
+          "outputPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeHasFile": {
+            "type": "boolean"
+          },
+          "sizeleft": {
+            "type": "number",
+            "format": "double",
+            "deprecated": true
+          },
+          "timeleft": {
+            "type": "string",
+            "format": "date-span",
+            "nullable": true,
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueResourcePagingResource": {
+        "type": "object",
+        "properties": {
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sortKey": {
+            "type": "string",
+            "nullable": true
+          },
+          "sortDirection": {
+            "$ref": "#/components/schemas/SortDirection"
+          },
+          "totalRecords": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "records": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QueueResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "QueueStatus": {
+        "enum": [
+          "unknown",
+          "queued",
+          "paused",
+          "downloading",
+          "completed",
+          "failed",
+          "warning",
+          "delay",
+          "downloadClientUnavailable",
+          "fallback"
+        ],
+        "type": "string"
+      },
+      "QueueStatusResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "unknownCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "errors": {
+            "type": "boolean"
+          },
+          "warnings": {
+            "type": "boolean"
+          },
+          "unknownErrors": {
+            "type": "boolean"
+          },
+          "unknownWarnings": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "Ratings": {
+        "type": "object",
+        "properties": {
+          "votes": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "value": {
+            "type": "number",
+            "format": "double"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RejectionType": {
+        "enum": [
+          "permanent",
+          "temporary"
+        ],
+        "type": "string"
+      },
+      "ReleaseEpisodeResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "absoluteEpisodeNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReleaseProfileResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "required": {
+            "nullable": true
+          },
+          "ignored": {
+            "nullable": true
+          },
+          "indexerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReleaseResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "guid": {
+            "type": "string",
+            "nullable": true
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityModel"
+          },
+          "qualityWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "age": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ageHours": {
+            "type": "number",
+            "format": "double"
+          },
+          "ageMinutes": {
+            "type": "number",
+            "format": "double"
+          },
+          "size": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "indexerId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "indexer": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "subGroup": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "fullSeason": {
+            "type": "boolean"
+          },
+          "sceneSource": {
+            "type": "boolean"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "nullable": true
+          },
+          "languageWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "airDate": {
+            "type": "string",
+            "nullable": true
+          },
+          "seriesTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "absoluteEpisodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "mappedSeasonNumber": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "mappedEpisodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "mappedAbsoluteEpisodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "mappedSeriesId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "mappedEpisodeInfo": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ReleaseEpisodeResource"
+            },
+            "nullable": true
+          },
+          "approved": {
+            "type": "boolean"
+          },
+          "temporarilyRejected": {
+            "type": "boolean"
+          },
+          "rejected": {
+            "type": "boolean"
+          },
+          "tvdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvRageId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "rejections": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "publishDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "commentUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "downloadUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "episodeRequested": {
+            "type": "boolean"
+          },
+          "downloadAllowed": {
+            "type": "boolean"
+          },
+          "releaseWeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "customFormats": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CustomFormatResource"
+            },
+            "nullable": true
+          },
+          "customFormatScore": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sceneMapping": {
+            "$ref": "#/components/schemas/AlternateTitleResource"
+          },
+          "magnetUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "infoHash": {
+            "type": "string",
+            "nullable": true
+          },
+          "seeders": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "leechers": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "protocol": {
+            "$ref": "#/components/schemas/DownloadProtocol"
+          },
+          "indexerFlags": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isDaily": {
+            "type": "boolean"
+          },
+          "isAbsoluteNumbering": {
+            "type": "boolean"
+          },
+          "isPossibleSpecialEpisode": {
+            "type": "boolean"
+          },
+          "special": {
+            "type": "boolean"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "episodeId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "episodeIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "downloadClientId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "downloadClient": {
+            "type": "string",
+            "nullable": true
+          },
+          "shouldOverride": {
+            "type": "boolean",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReleaseType": {
+        "enum": [
+          "unknown",
+          "singleEpisode",
+          "multiEpisode",
+          "seasonPack"
+        ],
+        "type": "string"
+      },
+      "RemotePathMappingResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "host": {
+            "type": "string",
+            "nullable": true
+          },
+          "remotePath": {
+            "type": "string",
+            "nullable": true
+          },
+          "localPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RenameEpisodeResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seriesId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeNumbers": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "episodeFileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "existingPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "newPath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RescanAfterRefreshType": {
+        "enum": [
+          "always",
+          "afterManual",
+          "never"
+        ],
+        "type": "string"
+      },
+      "Revision": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "real": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isRepack": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "RootFolderResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "accessible": {
+            "type": "boolean"
+          },
+          "freeSpace": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true
+          },
+          "unmappedFolders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UnmappedFolder"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "RuntimeMode": {
+        "enum": [
+          "console",
+          "service",
+          "tray"
+        ],
+        "type": "string"
+      },
+      "SeasonPassResource": {
+        "type": "object",
+        "properties": {
+          "series": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SeasonPassSeriesResource"
+            },
+            "nullable": true
+          },
+          "monitoringOptions": {
+            "$ref": "#/components/schemas/MonitoringOptions"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeasonPassSeriesResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "monitored": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "seasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SeasonResource"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeasonResource": {
+        "type": "object",
+        "properties": {
+          "seasonNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/SeasonStatisticsResource"
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeasonStatisticsResource": {
+        "type": "object",
+        "properties": {
+          "nextAiring": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "previousAiring": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "episodeFileCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalEpisodeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sizeOnDisk": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "releaseGroups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "percentOfEpisodes": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SelectOption": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hint": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeriesEditorResource": {
+        "type": "object",
+        "properties": {
+          "seriesIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "monitored": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32",
+            "nullable": true
+          },
+          "seriesType": {
+            "$ref": "#/components/schemas/SeriesTypes"
+          },
+          "seasonFolder": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "applyTags": {
+            "$ref": "#/components/schemas/ApplyTags"
+          },
+          "moveFiles": {
+            "type": "boolean"
+          },
+          "deleteFiles": {
+            "type": "boolean"
+          },
+          "addImportListExclusion": {
+            "type": "boolean"
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeriesResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "alternateTitles": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AlternateTitleResource"
+            },
+            "nullable": true
+          },
+          "sortTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "$ref": "#/components/schemas/SeriesStatusType"
+          },
+          "ended": {
+            "type": "boolean",
+            "readOnly": true
+          },
+          "profileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "overview": {
+            "type": "string",
+            "nullable": true
+          },
+          "nextAiring": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "previousAiring": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "network": {
+            "type": "string",
+            "nullable": true
+          },
+          "airTime": {
+            "type": "string",
+            "nullable": true
+          },
+          "images": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MediaCover"
+            },
+            "nullable": true
+          },
+          "originalLanguage": {
+            "$ref": "#/components/schemas/Language"
+          },
+          "remotePoster": {
+            "type": "string",
+            "nullable": true
+          },
+          "seasons": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SeasonResource"
+            },
+            "nullable": true
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "qualityProfileId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seasonFolder": {
+            "type": "boolean"
+          },
+          "monitored": {
+            "type": "boolean"
+          },
+          "monitorNewItems": {
+            "$ref": "#/components/schemas/NewItemMonitorTypes"
+          },
+          "useSceneNumbering": {
+            "type": "boolean"
+          },
+          "runtime": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvRageId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tvMazeId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "tmdbId": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "firstAired": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "lastAired": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "seriesType": {
+            "$ref": "#/components/schemas/SeriesTypes"
+          },
+          "cleanTitle": {
+            "type": "string",
+            "nullable": true
+          },
+          "imdbId": {
+            "type": "string",
+            "nullable": true
+          },
+          "titleSlug": {
+            "type": "string",
+            "nullable": true
+          },
+          "rootFolderPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "folder": {
+            "type": "string",
+            "nullable": true
+          },
+          "certification": {
+            "type": "string",
+            "nullable": true
+          },
+          "genres": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "tags": {
+            "uniqueItems": true,
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "added": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "addOptions": {
+            "$ref": "#/components/schemas/AddSeriesOptions"
+          },
+          "ratings": {
+            "$ref": "#/components/schemas/Ratings"
+          },
+          "statistics": {
+            "$ref": "#/components/schemas/SeriesStatisticsResource"
+          },
+          "episodesChanged": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "languageProfileId": {
+            "type": "integer",
+            "format": "int32",
+            "readOnly": true,
+            "deprecated": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeriesStatisticsResource": {
+        "type": "object",
+        "properties": {
+          "seasonCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeFileCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "episodeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "totalEpisodeCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "sizeOnDisk": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "releaseGroups": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "percentOfEpisodes": {
+            "type": "number",
+            "format": "double",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeriesStatusType": {
+        "enum": [
+          "continuing",
+          "ended",
+          "upcoming",
+          "deleted"
+        ],
+        "type": "string"
+      },
+      "SeriesTitleInfo": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "titleWithoutYear": {
+            "type": "string",
+            "nullable": true
+          },
+          "year": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "allTitles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "SeriesTypes": {
+        "enum": [
+          "standard",
+          "daily",
+          "anime"
+        ],
+        "type": "string"
+      },
+      "SortDirection": {
+        "enum": [
+          "default",
+          "ascending",
+          "descending"
+        ],
+        "type": "string"
+      },
+      "SystemResource": {
+        "type": "object",
+        "properties": {
+          "appName": {
+            "type": "string",
+            "nullable": true
+          },
+          "instanceName": {
+            "type": "string",
+            "nullable": true
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "buildTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "isDebug": {
+            "type": "boolean"
+          },
+          "isProduction": {
+            "type": "boolean"
+          },
+          "isAdmin": {
+            "type": "boolean"
+          },
+          "isUserInteractive": {
+            "type": "boolean"
+          },
+          "startupPath": {
+            "type": "string",
+            "nullable": true
+          },
+          "appData": {
+            "type": "string",
+            "nullable": true
+          },
+          "osName": {
+            "type": "string",
+            "nullable": true
+          },
+          "osVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "isNetCore": {
+            "type": "boolean"
+          },
+          "isLinux": {
+            "type": "boolean"
+          },
+          "isOsx": {
+            "type": "boolean"
+          },
+          "isWindows": {
+            "type": "boolean"
+          },
+          "isDocker": {
+            "type": "boolean"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/RuntimeMode"
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "authentication": {
+            "$ref": "#/components/schemas/AuthenticationType"
+          },
+          "sqliteVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "migrationVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "urlBase": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtimeVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "runtimeName": {
+            "type": "string",
+            "nullable": true
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "packageVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "packageAuthor": {
+            "type": "string",
+            "nullable": true
+          },
+          "packageUpdateMechanism": {
+            "$ref": "#/components/schemas/UpdateMechanism"
+          },
+          "packageUpdateMechanismMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "databaseVersion": {
+            "type": "string",
+            "nullable": true
+          },
+          "databaseType": {
+            "$ref": "#/components/schemas/DatabaseType"
+          }
+        },
+        "additionalProperties": false
+      },
+      "TagDetailsResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          },
+          "delayProfileIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "importListIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "notificationIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "restrictionIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "indexerIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "downloadClientIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "autoTagIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          },
+          "seriesIds": {
+            "type": "array",
+            "items": {
+              "type": "integer",
+              "format": "int32"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TagResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "label": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TaskResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "taskName": {
+            "type": "string",
+            "nullable": true
+          },
+          "interval": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lastExecution": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastStartTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "nextExecution": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastDuration": {
+            "type": "string",
+            "format": "date-span",
+            "readOnly": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "TrackedDownloadState": {
+        "enum": [
+          "downloading",
+          "importBlocked",
+          "importPending",
+          "importing",
+          "imported",
+          "failedPending",
+          "failed",
+          "ignored"
+        ],
+        "type": "string"
+      },
+      "TrackedDownloadStatus": {
+        "enum": [
+          "ok",
+          "warning",
+          "error"
+        ],
+        "type": "string"
+      },
+      "TrackedDownloadStatusMessage": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "nullable": true
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UiConfigResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "firstDayOfWeek": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "calendarWeekColumnHeader": {
+            "type": "string",
+            "nullable": true
+          },
+          "shortDateFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "longDateFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "timeFormat": {
+            "type": "string",
+            "nullable": true
+          },
+          "showRelativeDates": {
+            "type": "boolean"
+          },
+          "enableColorImpairedMode": {
+            "type": "boolean"
+          },
+          "theme": {
+            "type": "string",
+            "nullable": true
+          },
+          "uiLanguage": {
+            "type": "integer",
+            "format": "int32"
+          }
+        },
+        "additionalProperties": false
+      },
+      "UnmappedFolder": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "path": {
+            "type": "string",
+            "nullable": true
+          },
+          "relativePath": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateChanges": {
+        "type": "object",
+        "properties": {
+          "new": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "fixed": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      },
+      "UpdateMechanism": {
+        "enum": [
+          "builtIn",
+          "script",
+          "external",
+          "apt",
+          "docker"
+        ],
+        "type": "string"
+      },
+      "UpdateResource": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "version": {
+            "type": "string",
+            "nullable": true
+          },
+          "branch": {
+            "type": "string",
+            "nullable": true
+          },
+          "releaseDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "fileName": {
+            "type": "string",
+            "nullable": true
+          },
+          "url": {
+            "type": "string",
+            "nullable": true
+          },
+          "installed": {
+            "type": "boolean"
+          },
+          "installedOn": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "installable": {
+            "type": "boolean"
+          },
+          "latest": {
+            "type": "boolean"
+          },
+          "changes": {
+            "$ref": "#/components/schemas/UpdateChanges"
+          },
+          "hash": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "X-Api-Key": {
+        "type": "apiKey",
+        "description": "Apikey passed as header",
+        "name": "X-Api-Key",
+        "in": "header"
+      },
+      "apikey": {
+        "type": "apiKey",
+        "description": "Apikey passed as query parameter",
+        "name": "apikey",
+        "in": "query"
+      }
+    }
+  },
+  "security": [
+    {
+      "X-Api-Key": []
+    },
+    {
+      "apikey": []
+    }
+  ]
+}

--- a/services/service_sonarr/tool/openapi_parser.dart
+++ b/services/service_sonarr/tool/openapi_parser.dart
@@ -1,0 +1,734 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls, avoid_redundant_argument_values, require_trailing_commas, prefer_const_declarations, prefer_single_quotes, prefer_final_locals
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> args) {
+  final inputPath = args.isNotEmpty
+      ? args[0]
+      : '${Directory.current.path}/tool/openapi.json';
+  final outputDir = args.length > 1
+      ? args[1]
+      : '${Directory.current.path}/lib/src/generated';
+
+  final file = File(inputPath);
+  if (!file.existsSync()) {
+    print('Error: Input OpenAPI JSON file not found at $inputPath');
+    exit(1);
+  }
+
+  print('Parsing Sonarr OpenAPI specification from: $inputPath');
+  final jsonString = file.readAsStringSync();
+  final spec = jsonDecode(jsonString) as Map<String, dynamic>;
+
+  final parser = SonarrOpenApiParser(spec, outputDir);
+  parser.generateAll();
+  print('Successfully generated all Sonarr Dart models and API clients in: $outputDir');
+}
+
+class SonarrOpenApiParser {
+  final Map<String, dynamic> spec;
+  final String outputDir;
+
+  final Map<String, String> schemaClassNames = {};
+  final Map<String, dynamic> schemas = {};
+  final Map<String, List<Map<String, dynamic>>> tagEndpoints = {};
+
+  SonarrOpenApiParser(this.spec, this.outputDir) {
+    _initSchemas();
+    _initEndpoints();
+  }
+
+  void _initSchemas() {
+    final rawSchemas =
+        (spec['components']?['schemas'] as Map<String, dynamic>?) ?? {};
+    schemas.addAll(rawSchemas);
+
+    for (final fullKey in schemas.keys) {
+      schemaClassNames[fullKey] = _resolveClassName(fullKey, rawSchemas);
+    }
+  }
+
+  void _initEndpoints() {
+    final paths = (spec['paths'] as Map<String, dynamic>?) ?? {};
+    for (final pathEntry in paths.entries) {
+      final path = pathEntry.key;
+      final methods = pathEntry.value as Map<String, dynamic>;
+
+      for (final methodEntry in methods.entries) {
+        final verb = methodEntry.key.toLowerCase();
+        if (!['get', 'post', 'put', 'delete', 'patch'].contains(verb)) continue;
+
+        final op = methodEntry.value as Map<String, dynamic>;
+        final tags = (op['tags'] as List<dynamic>?)?.cast<String>() ?? ['Default'];
+        final tag = tags.first;
+
+        tagEndpoints.putIfAbsent(tag, () => []).add({
+          'path': path,
+          'verb': verb,
+          'operation': op,
+        });
+      }
+    }
+  }
+
+  String _sanitizeIdentifier(String name) {
+    return name.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '');
+  }
+
+  String _toPascalCase(String text) {
+    final clean = text.replaceAll(RegExp(r'[^a-zA-Z0-9]'), ' ');
+    final words = clean.split(RegExp(r'\s+')).where((w) => w.isNotEmpty);
+    return words.map((w) => w[0].toUpperCase() + w.substring(1)).join('');
+  }
+
+  String _toCamelCase(String text) {
+    final pascal = _toPascalCase(text);
+    if (pascal.isEmpty) return 'item';
+    var camel = pascal[0].toLowerCase() + pascal.substring(1);
+    if (RegExp(r'^[0-9]').hasMatch(camel)) {
+      camel = 'val$camel';
+    }
+    const keywords = {
+      'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
+      'class', 'const', 'continue', 'covariant', 'default', 'deferred', 'do',
+      'dynamic', 'else', 'enum', 'export', 'extends', 'extension', 'external',
+      'factory', 'false', 'finally', 'for', 'function', 'get', 'hide',
+      'if', 'implements', 'import', 'in', 'interface', 'is', 'late', 'library',
+      'mixin', 'new', 'null', 'on', 'operator', 'part', 'required', 'rethrow',
+      'return', 'set', 'show', 'static', 'super', 'switch', 'sync', 'this',
+      'throw', 'true', 'try', 'typedef', 'var', 'void', 'while', 'with', 'yield'
+    };
+    return keywords.contains(camel) ? '${camel}Val' : camel;
+  }
+
+  String _toSnakeCase(String name) {
+    return name
+        .replaceAllMapped(RegExp(r'([A-Z])'), (m) => '_${m.group(1)!.toLowerCase()}')
+        .replaceAll(RegExp(r'^_'), '')
+        .replaceAll(RegExp(r'_+'), '_');
+  }
+
+  String _resolveClassName(String fullKey, Map<String, dynamic> rawSchemas) {
+    final genericMatch = RegExp(r'`\d+\[\[(?:[^\.,]+\.)*([^\.,]+),').firstMatch(fullKey);
+    final genericSuffix = genericMatch != null
+        ? _sanitizeIdentifier(genericMatch.group(1)!)
+        : '';
+
+    final cleanBase = fullKey.replaceAll(RegExp(r'`\d+\[\[.*'), '');
+    final parts = cleanBase.split('.');
+    final short = parts.last;
+
+    final collisions = rawSchemas.keys
+        .where((k) => k.replaceAll(RegExp(r'`\d+\[\[.*'), '').split('.').last == short)
+        .toList();
+
+    String baseName;
+    if (collisions.length == 1) {
+      baseName = _sanitizeIdentifier(short);
+    } else {
+      final meaningful = parts
+          .where((p) => !['Sonarr', 'Api', 'External', 'Models', 'Core', 'V3'].contains(p))
+          .toList();
+      final effective = meaningful.isEmpty ? parts : meaningful;
+      baseName = effective.map(_sanitizeIdentifier).join('');
+    }
+
+    return '$baseName$genericSuffix';
+  }
+
+  void generateAll() {
+    _createDirectories();
+    _generateResponseFiles();
+    _generateModelFiles();
+    _generateApiFiles();
+    _generateExportFile();
+  }
+
+  void _createDirectories() {
+    final dir = Directory(outputDir);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+    Directory('$outputDir/models').createSync(recursive: true);
+    Directory('$outputDir/responses').createSync(recursive: true);
+    Directory('$outputDir/api').createSync(recursive: true);
+  }
+
+  void _generateResponseFiles() {
+    final apiResponseContent = '''
+import 'sonarr_error.dart';
+
+/// Standardized API response container for Sonarr API calls.
+class ApiResponse<T> {
+  final T? data;
+  final SonarrError? error;
+  final int? statusCode;
+  final bool isSuccess;
+
+  const ApiResponse.success(this.data, {this.statusCode})
+      : error = null,
+        isSuccess = true;
+
+  const ApiResponse.error(this.error, {this.statusCode})
+      : data = null,
+        isSuccess = false;
+}
+''';
+    File('$outputDir/responses/api_response.dart')
+        .writeAsStringSync(apiResponseContent);
+
+    final errorContent = '''
+import 'package:dio/dio.dart';
+
+/// Error model returned by Sonarr API endpoints.
+class SonarrError {
+  final String? message;
+  final String? description;
+  final List<String> errors;
+
+  const SonarrError({
+    this.message,
+    this.description,
+    this.errors = const [],
+  });
+
+  factory SonarrError.fromJson(Map<String, dynamic> json) {
+    final errList = (json['errors'] as List<dynamic>?)
+            ?.map((e) => e.toString())
+            .toList() ??
+        [];
+    return SonarrError(
+      message: json['message'] as String? ?? json['error'] as String?,
+      description: json['description'] as String?,
+      errors: errList,
+    );
+  }
+
+  factory SonarrError.fromDio(DioException exception) {
+    if (exception.response?.data is Map<String, dynamic>) {
+      return SonarrError.fromJson(
+          exception.response!.data as Map<String, dynamic>);
+    }
+    return SonarrError(
+      message: exception.message ?? 'HTTP Error \${exception.response?.statusCode}',
+      description: exception.type.toString(),
+    );
+  }
+}
+''';
+    File('$outputDir/responses/sonarr_error.dart')
+        .writeAsStringSync(errorContent);
+
+    final exceptionContent = '''
+import 'sonarr_error.dart';
+
+/// Custom exception thrown on Sonarr API failure.
+class SonarrException implements Exception {
+  final String message;
+  final int? statusCode;
+  final SonarrError? error;
+
+  const SonarrException(
+    this.message, {
+    this.statusCode,
+    this.error,
+  });
+
+  @override
+  String toString() =>
+      'SonarrException(statusCode: \$statusCode, message: \$message, error: \$error)';
+}
+''';
+    File('$outputDir/responses/sonarr_exception.dart')
+        .writeAsStringSync(exceptionContent);
+  }
+
+  void _generateModelFiles() {
+    for (final entry in schemas.entries) {
+      final fullKey = entry.key;
+      final schema = entry.value as Map<String, dynamic>;
+      final className = schemaClassNames[fullKey]!;
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildModelCode(fullKey, className, schema);
+      File('$outputDir/models/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildModelCode(
+      String fullKey, String className, Map<String, dynamic> schema) {
+    final isEnum = schema.containsKey('enum');
+    if (isEnum) {
+      return _buildEnumCode(className, schema);
+    }
+
+    final properties = (schema['properties'] as Map<String, dynamic>?) ?? {};
+    final title = schema['title'] as String?;
+    final description = schema['description'] as String?;
+
+    final imports = <String>{};
+    final fields = <_ModelField>[];
+    final usedFieldNames = <String>{};
+
+    for (final propEntry in properties.entries) {
+      final propKey = propEntry.key;
+      final propSchema = propEntry.value as Map<String, dynamic>;
+      var fieldName = _toCamelCase(propKey);
+      if (usedFieldNames.contains(fieldName)) {
+        fieldName = '${fieldName}Alt';
+      }
+      usedFieldNames.add(fieldName);
+
+      final fieldTypeInfo = _parseType(propSchema, imports);
+      final propDesc = propSchema['description'] as String?;
+      final isDeprecated = propSchema['deprecated'] == true;
+
+      fields.add(_ModelField(
+        jsonKey: propKey,
+        fieldName: fieldName,
+        dartType: fieldTypeInfo.dartType,
+        isNullable: fieldTypeInfo.isNullable,
+        isList: fieldTypeInfo.isList,
+        isCustomClass: fieldTypeInfo.isCustomClass,
+        customClassName: fieldTypeInfo.customClassName,
+        description: propDesc,
+        isDeprecated: isDeprecated,
+      ));
+    }
+
+    final fileName = _toSnakeCase(className);
+    final buffer = StringBuffer();
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    for (final imp in imports) {
+      if (imp != className) {
+        final impFileName = _toSnakeCase(imp);
+        buffer.writeln("import '$impFileName.dart';");
+      }
+    }
+    buffer.writeln();
+    buffer.writeln("part '$fileName.freezed.dart';");
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+
+    final classDoc = description ?? title;
+    if (classDoc != null && classDoc.isNotEmpty) {
+      for (final line in classDoc.split('\n')) {
+        buffer.writeln('/// ${line.trim()}');
+      }
+      buffer.writeln('///');
+    }
+    buffer.writeln('/// Original C# Schema: `$fullKey`');
+    if (schema['deprecated'] == true) {
+      buffer.writeln("@Deprecated('Marked deprecated in OpenAPI spec')");
+    }
+    buffer.writeln('@freezed');
+    buffer.writeln('abstract class $className with _\$$className {');
+    if (fields.isEmpty) {
+      buffer.writeln('  const factory $className() = _$className;');
+    } else {
+      buffer.writeln('  const factory $className({');
+      for (final f in fields) {
+        if (f.description != null && f.description!.isNotEmpty) {
+          for (final line in f.description!.split('\n')) {
+            buffer.writeln('    /// ${line.trim()}');
+          }
+        }
+        if (f.isDeprecated) {
+          buffer.writeln("    @Deprecated('Marked deprecated in OpenAPI spec')");
+        }
+        final typeStr = f.dartType.endsWith('?') ? f.dartType : '${f.dartType}?';
+        buffer.writeln("    @JsonKey(name: '${f.jsonKey}') $typeStr ${f.fieldName},");
+      }
+      buffer.writeln('  }) = _$className;');
+    }
+    buffer.writeln();
+    buffer.writeln('  factory $className.fromJson(Map<String, dynamic> json) =>');
+    buffer.writeln('      _\$${className}FromJson(json);');
+    buffer.writeln('}');
+
+    return buffer.toString();
+  }
+
+  String _buildEnumCode(String className, Map<String, dynamic> schema) {
+    final buffer = StringBuffer();
+    final enumList = schema['enum'] as List<dynamic>;
+    final fileName = _toSnakeCase(className);
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    buffer.writeln();
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+    buffer.writeln('/// Enum `$className`');
+    buffer.writeln('@JsonEnum(alwaysCreate: true)');
+    buffer.writeln('enum $className {');
+
+    for (final item in enumList) {
+      final strVal = item.toString();
+      final identifier = _toCamelCase(strVal);
+      buffer.writeln("  @JsonValue('$strVal')");
+      buffer.writeln('  $identifier,');
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _TypeInfo _parseType(
+      Map<String, dynamic> schema, Set<String> imports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      imports.add(cls);
+      return _TypeInfo(
+          dartType: cls, isNullable: true, isCustomClass: true, customClassName: cls);
+    }
+
+    final type = schema['type'] as String?;
+    if (type == 'array') {
+      final items = (schema['items'] as Map<String, dynamic>?) ?? {};
+      final itemType = _parseType(items, imports);
+      final listDartType = 'List<${itemType.dartType}>';
+      return _TypeInfo(
+        dartType: listDartType,
+        isNullable: true,
+        isList: true,
+        customClassName: itemType.isCustomClass ? itemType.customClassName : null,
+      );
+    }
+
+    if (type == 'integer') {
+      return _TypeInfo(dartType: 'int', isNullable: true);
+    }
+    if (type == 'number') {
+      return _TypeInfo(dartType: 'double', isNullable: true);
+    }
+    if (type == 'boolean') {
+      return _TypeInfo(dartType: 'bool', isNullable: true);
+    }
+    if (type == 'string') {
+      return _TypeInfo(dartType: 'String', isNullable: true);
+    }
+
+    return _TypeInfo(dartType: 'dynamic', isNullable: true);
+  }
+
+  void _generateApiFiles() {
+    for (final entry in tagEndpoints.entries) {
+      final tag = entry.key;
+      final endpoints = entry.value;
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildApiCode(tag, className, endpoints);
+      File('$outputDir/api/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildApiCode(
+      String tag, String className, List<Map<String, dynamic>> endpoints) {
+    final buffer = StringBuffer();
+    final imports = <String>{
+      "import 'dart:convert';",
+      "import 'package:dio/dio.dart';",
+      "import '../responses/api_response.dart';",
+      "import '../responses/sonarr_error.dart';",
+      "import '../responses/sonarr_exception.dart';",
+    };
+
+    final modelImports = <String>{};
+
+    for (final ep in endpoints) {
+      final op = ep['operation'] as Map<String, dynamic>;
+      final respSchema = _getSuccessResponseSchema(op);
+      if (respSchema != null) {
+        _extractModelImports(respSchema, modelImports);
+      }
+      final bodySchema = _getRequestBodySchema(op);
+      if (bodySchema != null) {
+        _extractModelImports(bodySchema, modelImports);
+      }
+    }
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    for (final imp in imports) {
+      buffer.writeln(imp);
+    }
+
+    for (final mImp in modelImports) {
+      final fileName = _toSnakeCase(mImp);
+      buffer.writeln("import '../models/$fileName.dart';");
+    }
+    buffer.writeln();
+
+    buffer.writeln('/// Raw API client for `$tag` endpoints.');
+    buffer.writeln('class $className {');
+    buffer.writeln('  final Dio _dio;');
+    buffer.writeln();
+    buffer.writeln('  $className(this._dio);');
+    buffer.writeln();
+
+    final usedMethodNames = <String>{};
+    for (final ep in endpoints) {
+      final path = ep['path'] as String;
+      final verb = ep['verb'] as String;
+      final op = ep['operation'] as Map<String, dynamic>;
+
+      final summary = op['summary'] as String?;
+      final description = op['description'] as String?;
+      final operationId = op['operationId'] as String?;
+
+      var methodName = _buildMethodName(verb, path, operationId);
+      if (usedMethodNames.contains(methodName)) {
+        var count = 2;
+        while (usedMethodNames.contains('$methodName$count')) {
+          count++;
+        }
+        methodName = '$methodName$count';
+      }
+      usedMethodNames.add(methodName);
+
+      final doc = summary ?? description;
+      if (doc != null && doc.isNotEmpty) {
+        for (final line in doc.split('\n')) {
+          buffer.writeln('  /// ${line.trim()}');
+        }
+      }
+      buffer.writeln('  /// HTTP $verb $path');
+      if (op['deprecated'] == true) {
+        buffer.writeln("  @Deprecated('Marked deprecated in OpenAPI spec')");
+      }
+
+      final respSchema = _getSuccessResponseSchema(op);
+      final returnTypeInfo = _getReturnTypeInfo(respSchema);
+      final returnType = returnTypeInfo.type;
+
+      buffer.writeln('  Future<ApiResponse<$returnType>> $methodName(');
+
+      final params = (op['parameters'] as List<dynamic>?)?.cast<Map<String, dynamic>>() ?? [];
+      final pathParams = params.where((p) => p['in'] == 'path').toList();
+      final queryParams = params.where((p) => p['in'] == 'query').toList();
+      final bodySchema = _getRequestBodySchema(op);
+
+      final methodParams = <String>[];
+      for (final p in pathParams) {
+        final pName = _toCamelCase(p['name'] as String);
+        methodParams.add('required String $pName');
+      }
+      for (final q in queryParams) {
+        final qName = _toCamelCase(q['name'] as String);
+        methodParams.add('String? $qName');
+      }
+      if (bodySchema != null) {
+        methodParams.add('dynamic body');
+      }
+
+      if (methodParams.isNotEmpty) {
+        buffer.writeln('    {${methodParams.join(', ')}}');
+      }
+      buffer.writeln('  ) async {');
+
+      var interpolatedPath = path;
+      for (final p in pathParams) {
+        final rawName = p['name'] as String;
+        final pName = _toCamelCase(rawName);
+        interpolatedPath = interpolatedPath.replaceAll('{$rawName}', '\$$pName');
+      }
+
+      buffer.writeln('    try {');
+      buffer.writeln('      final Response<dynamic> resp = await _dio.$verb<dynamic>(');
+      buffer.writeln("        '$interpolatedPath',");
+      if (queryParams.isNotEmpty) {
+        buffer.writeln('        queryParameters: <String, dynamic>{');
+        for (final q in queryParams) {
+          final qRaw = q['name'] as String;
+          final qName = _toCamelCase(qRaw);
+          buffer.writeln("          if ($qName != null) '$qRaw': $qName,");
+        }
+        buffer.writeln('        },');
+      }
+      if (bodySchema != null) {
+        buffer.writeln('        data: body,');
+      }
+      buffer.writeln('      );');
+
+      buffer.writeln('      ${_buildDeserializationCode(returnTypeInfo)}');
+      buffer.writeln('      return ApiResponse.success(data, statusCode: resp.statusCode);');
+      buffer.writeln('    } on DioException catch (e) {');
+      buffer.writeln('      return ApiResponse.error(SonarrError.fromDio(e), statusCode: e.response?.statusCode);');
+      buffer.writeln('    }');
+      buffer.writeln('  }');
+      buffer.writeln();
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _ReturnTypeInfo _getReturnTypeInfo(Map<String, dynamic>? schema) {
+    if (schema == null) return _ReturnTypeInfo(type: 'void', isList: false, isCustomClass: false);
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      return _ReturnTypeInfo(type: cls, isList: false, isCustomClass: true, className: cls);
+    }
+    if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null && items.containsKey('\$ref')) {
+        final ref = items['\$ref'] as String;
+        final key = ref.replaceFirst('#/components/schemas/', '');
+        final cls = schemaClassNames[key] ?? 'dynamic';
+        return _ReturnTypeInfo(type: 'List<$cls>', isList: true, isCustomClass: true, className: cls);
+      }
+      return _ReturnTypeInfo(type: 'List<dynamic>', isList: true, isCustomClass: false);
+    }
+    return _ReturnTypeInfo(type: 'dynamic', isList: false, isCustomClass: false);
+  }
+
+  String _buildDeserializationCode(_ReturnTypeInfo info) {
+    if (info.type == 'void') {
+      return 'final void data = null;';
+    }
+    if (info.isList && info.isCustomClass) {
+      return 'final List<${info.className}> data = (resp.data as List<dynamic>?)?.map((e) => ${info.className}.fromJson(e as Map<String, dynamic>)).toList() ?? <${info.className}>[];';
+    }
+    if (info.isCustomClass) {
+      return 'final ${info.className}? data = resp.data is Map<String, dynamic> ? ${info.className}.fromJson(resp.data as Map<String, dynamic>) : null;';
+    }
+    return 'final dynamic data = resp.data;';
+  }
+
+  String _buildMethodName(String verb, String path, String? operationId) {
+    if (operationId != null && operationId.isNotEmpty) {
+      var clean = operationId.replaceAll(RegExp(r'ApiV\d+'), '');
+      return _toCamelCase(clean);
+    }
+    final pathParamMatches = RegExp(r'\{([^}]+)\}').allMatches(path);
+    final pathParamNames = pathParamMatches.map((m) => m.group(1)!).toList();
+
+    final cleanPath = path
+        .replaceAll(RegExp(r'^/api/v\d+/'), '/')
+        .replaceAll(RegExp(r'^/api/'), '/')
+        .replaceAll(RegExp(r'\{[^}]+\}'), '');
+    final parts = cleanPath.split('/').where((p) => p.isNotEmpty).toList();
+
+    if (pathParamNames.isNotEmpty) {
+      parts.add('by');
+      parts.addAll(pathParamNames);
+    }
+
+    final nameParts = [verb, ...parts];
+    return _toCamelCase(nameParts.join('_'));
+  }
+
+  Map<String, dynamic>? _getSuccessResponseSchema(Map<String, dynamic> op) {
+    final responses = op['responses'] as Map<String, dynamic>?;
+    if (responses == null) return null;
+    final resp200 = responses['200'] ?? responses['201'];
+    if (resp200 is Map<String, dynamic>) {
+      final content = resp200['content'] as Map<String, dynamic>?;
+      final jsonContent = content?['application/json'] ?? content?['text/json'];
+      return jsonContent?['schema'] as Map<String, dynamic>?;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _getRequestBodySchema(Map<String, dynamic> op) {
+    final reqBody = op['requestBody'] as Map<String, dynamic>?;
+    final content = reqBody?['content'] as Map<String, dynamic>?;
+    final jsonContent = content?['application/json'] ?? content?['text/json'];
+    return jsonContent?['schema'] as Map<String, dynamic>?;
+  }
+
+  void _extractModelImports(
+      Map<String, dynamic> schema, Set<String> modelImports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key];
+      if (cls != null) modelImports.add(cls);
+    } else if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null) _extractModelImports(items, modelImports);
+    }
+  }
+
+  void _generateExportFile() {
+    final buffer = StringBuffer();
+    buffer.writeln("// Autogenerated OpenAPI Exports for Sonarr\n");
+    buffer.writeln("export 'responses/api_response.dart';");
+    buffer.writeln("export 'responses/sonarr_error.dart';");
+    buffer.writeln("export 'responses/sonarr_exception.dart';");
+
+    for (final entry in schemas.entries) {
+      final className = schemaClassNames[entry.key]!;
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'models/$fileName.dart';");
+    }
+
+    for (final tag in tagEndpoints.keys) {
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'api/$fileName.dart';");
+    }
+
+    File('$outputDir/generated.dart').writeAsStringSync(buffer.toString());
+  }
+}
+
+class _ModelField {
+  final String jsonKey;
+  final String fieldName;
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+  final String? description;
+  final bool isDeprecated;
+
+  _ModelField({
+    required this.jsonKey,
+    required this.fieldName,
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+    this.description,
+    this.isDeprecated = false,
+  });
+}
+
+class _TypeInfo {
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+
+  _TypeInfo({
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+  });
+}
+
+class _ReturnTypeInfo {
+  final String type;
+  final bool isList;
+  final bool isCustomClass;
+  final String? className;
+
+  _ReturnTypeInfo({
+    required this.type,
+    required this.isList,
+    required this.isCustomClass,
+    this.className,
+  });
+}

--- a/services/service_tracearr/.gitignore
+++ b/services/service_tracearr/.gitignore
@@ -1,0 +1,2 @@
+# Ignore generated OpenAPI client & freezed model code
+lib/src/generated/

--- a/services/service_tracearr/test/tracearr_parser_test.dart
+++ b/services/service_tracearr/test/tracearr_parser_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_tracearr/src/generated/models/health_response.dart';
+import 'package:service_tracearr/src/generated/responses/tracearr_error.dart';
+import 'package:service_tracearr/src/generated/responses/tracearr_exception.dart';
+
+void main() {
+  group('Tracearr Generated Specs & Models Test', () {
+    test('HealthResponse serialization and deserialization', () {
+      final json = {
+        'status': 'ok',
+        'version': '1.4.22',
+        'timestamp': '2024-01-15T12:00:00.000Z',
+        'servers': [],
+      };
+
+      final model = HealthResponse.fromJson(json);
+      expect(model.status, equals('ok'));
+      expect(model.version, equals('1.4.22'));
+
+      final toJsonResult = model.toJson();
+      expect(toJsonResult['status'], equals('ok'));
+      expect(toJsonResult['version'], equals('1.4.22'));
+    });
+
+    test('TracearrError and Exception parsing', () {
+      final errorJson = {
+        'message': 'Unauthorized token',
+        'description': 'Token expired or invalid',
+      };
+
+      final error = TracearrError.fromJson(errorJson);
+      expect(error.message, equals('Unauthorized token'));
+
+      final exception = TracearrException(
+        error.message!,
+        statusCode: 401,
+        error: error,
+      );
+      expect(exception.statusCode, equals(401));
+      expect(exception.toString(), contains('Unauthorized token'));
+    });
+  });
+}

--- a/services/service_tracearr/tool/openapi_parser.dart
+++ b/services/service_tracearr/tool/openapi_parser.dart
@@ -1,0 +1,757 @@
+// ignore_for_file: avoid_print, avoid_dynamic_calls, avoid_redundant_argument_values, require_trailing_commas, prefer_const_declarations, prefer_single_quotes, prefer_final_locals
+import 'dart:convert';
+import 'dart:io';
+
+void main(List<String> args) {
+  final v1File = File('${Directory.current.path}/tool/v1.json');
+  final v2File = File('${Directory.current.path}/tool/v2.json');
+
+  final Map<String, dynamic> mergedSpec = {
+    'openapi': '3.0.0',
+    'info': {'title': 'Tracearr Public API', 'version': '1.0.0'},
+    'components': {'schemas': <String, dynamic>{}},
+    'paths': <String, dynamic>{},
+  };
+
+  if (v1File.existsSync()) {
+    print('Loading Tracearr v1.json specification...');
+    final v1 = jsonDecode(v1File.readAsStringSync()) as Map<String, dynamic>;
+    final v1Schemas = (v1['components']?['schemas'] as Map<String, dynamic>?) ?? {};
+    (mergedSpec['components']['schemas'] as Map<String, dynamic>).addAll(v1Schemas);
+    final v1Paths = (v1['paths'] as Map<String, dynamic>?) ?? {};
+    (mergedSpec['paths'] as Map<String, dynamic>).addAll(v1Paths);
+  }
+
+  if (v2File.existsSync()) {
+    print('Loading Tracearr v2.json specification...');
+    final v2 = jsonDecode(v2File.readAsStringSync()) as Map<String, dynamic>;
+    final v2Schemas = (v2['components']?['schemas'] as Map<String, dynamic>?) ?? {};
+    (mergedSpec['components']['schemas'] as Map<String, dynamic>).addAll(v2Schemas);
+    final v2Paths = (v2['paths'] as Map<String, dynamic>?) ?? {};
+    (mergedSpec['paths'] as Map<String, dynamic>).addAll(v2Paths);
+  }
+
+  final outputDir = args.length > 1
+      ? args[1]
+      : '${Directory.current.path}/lib/src/generated';
+
+  print('Parsing combined Tracearr v1 + v2 OpenAPI specification...');
+  final parser = TracearrOpenApiParser(mergedSpec, outputDir);
+  parser.generateAll();
+  print('Successfully generated all Tracearr Dart models and API clients in: $outputDir');
+}
+
+class TracearrOpenApiParser {
+  final Map<String, dynamic> spec;
+  final String outputDir;
+
+  final Map<String, String> schemaClassNames = {};
+  final Map<String, dynamic> schemas = {};
+  final Map<String, List<Map<String, dynamic>>> tagEndpoints = {};
+
+  TracearrOpenApiParser(this.spec, this.outputDir) {
+    _initSchemas();
+    _initEndpoints();
+  }
+
+  void _initSchemas() {
+    final rawSchemas =
+        (spec['components']?['schemas'] as Map<String, dynamic>?) ?? {};
+    schemas.addAll(rawSchemas);
+
+    for (final fullKey in schemas.keys) {
+      schemaClassNames[fullKey] = _resolveClassName(fullKey, rawSchemas);
+    }
+  }
+
+  void _initEndpoints() {
+    final paths = (spec['paths'] as Map<String, dynamic>?) ?? {};
+    for (final pathEntry in paths.entries) {
+      final path = pathEntry.key;
+      final methods = pathEntry.value as Map<String, dynamic>;
+
+      for (final methodEntry in methods.entries) {
+        final verb = methodEntry.key.toLowerCase();
+        if (!['get', 'post', 'put', 'delete', 'patch'].contains(verb)) continue;
+
+        final op = methodEntry.value as Map<String, dynamic>;
+        final tags = (op['tags'] as List<dynamic>?)?.cast<String>() ?? ['Default'];
+        final tag = tags.first;
+
+        tagEndpoints.putIfAbsent(tag, () => []).add({
+          'path': path,
+          'verb': verb,
+          'operation': op,
+        });
+      }
+    }
+  }
+
+  String _sanitizeIdentifier(String name) {
+    return name.replaceAll(RegExp(r'[^a-zA-Z0-9_]'), '');
+  }
+
+  String _toPascalCase(String text) {
+    final clean = text.replaceAll(RegExp(r'[^a-zA-Z0-9]'), ' ');
+    final words = clean.split(RegExp(r'\s+')).where((w) => w.isNotEmpty);
+    return words.map((w) => w[0].toUpperCase() + w.substring(1)).join('');
+  }
+
+  String _toCamelCase(String text) {
+    final pascal = _toPascalCase(text);
+    if (pascal.isEmpty) return 'item';
+    var camel = pascal[0].toLowerCase() + pascal.substring(1);
+    if (RegExp(r'^[0-9]').hasMatch(camel)) {
+      camel = 'val$camel';
+    }
+    const keywords = {
+      'abstract', 'as', 'assert', 'async', 'await', 'break', 'case', 'catch',
+      'class', 'const', 'continue', 'covariant', 'default', 'deferred', 'do',
+      'dynamic', 'else', 'enum', 'export', 'extends', 'extension', 'external',
+      'factory', 'false', 'finally', 'for', 'function', 'get', 'hide',
+      'if', 'implements', 'import', 'in', 'interface', 'is', 'late', 'library',
+      'mixin', 'new', 'null', 'on', 'operator', 'part', 'required', 'rethrow',
+      'return', 'set', 'show', 'static', 'super', 'switch', 'sync', 'this',
+      'throw', 'true', 'try', 'typedef', 'var', 'void', 'while', 'with', 'yield'
+    };
+    return keywords.contains(camel) ? '${camel}Val' : camel;
+  }
+
+  String _toSnakeCase(String name) {
+    return name
+        .replaceAllMapped(RegExp(r'([A-Z])'), (m) => '_${m.group(1)!.toLowerCase()}')
+        .replaceAll(RegExp(r'^_'), '')
+        .replaceAll(RegExp(r'_+'), '_');
+  }
+
+  String _resolveClassName(String fullKey, Map<String, dynamic> rawSchemas) {
+    final genericMatch = RegExp(r'`\d+\[\[(?:[^\.,]+\.)*([^\.,]+),').firstMatch(fullKey);
+    final genericSuffix = genericMatch != null
+        ? _sanitizeIdentifier(genericMatch.group(1)!)
+        : '';
+
+    final cleanBase = fullKey.replaceAll(RegExp(r'`\d+\[\[.*'), '');
+    final parts = cleanBase.split('.');
+    final short = parts.last;
+
+    final collisions = rawSchemas.keys
+        .where((k) => k.replaceAll(RegExp(r'`\d+\[\[.*'), '').split('.').last == short)
+        .toList();
+
+    String baseName;
+    if (collisions.length == 1) {
+      baseName = _sanitizeIdentifier(short);
+    } else {
+      final meaningful = parts
+          .where((p) => !['Tracearr', 'Api', 'External', 'Models', 'Core', 'V1', 'V2'].contains(p))
+          .toList();
+      final effective = meaningful.isEmpty ? parts : meaningful;
+      baseName = effective.map(_sanitizeIdentifier).join('');
+    }
+
+    return '$baseName$genericSuffix';
+  }
+
+  void generateAll() {
+    _createDirectories();
+    _generateResponseFiles();
+    _generateModelFiles();
+    _generateApiFiles();
+    _generateExportFile();
+  }
+
+  void _createDirectories() {
+    final dir = Directory(outputDir);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
+    Directory('$outputDir/models').createSync(recursive: true);
+    Directory('$outputDir/responses').createSync(recursive: true);
+    Directory('$outputDir/api').createSync(recursive: true);
+  }
+
+  void _generateResponseFiles() {
+    final apiResponseContent = '''
+import 'tracearr_error.dart';
+
+/// Standardized API response container for Tracearr API calls.
+class ApiResponse<T> {
+  final T? data;
+  final TracearrError? error;
+  final int? statusCode;
+  final bool isSuccess;
+
+  const ApiResponse.success(this.data, {this.statusCode})
+      : error = null,
+        isSuccess = true;
+
+  const ApiResponse.error(this.error, {this.statusCode})
+      : data = null,
+        isSuccess = false;
+}
+''';
+    File('$outputDir/responses/api_response.dart')
+        .writeAsStringSync(apiResponseContent);
+
+    final errorContent = '''
+import 'package:dio/dio.dart';
+
+/// Error model returned by Tracearr API endpoints.
+class TracearrError {
+  final String? message;
+  final String? description;
+  final List<String> errors;
+
+  const TracearrError({
+    this.message,
+    this.description,
+    this.errors = const [],
+  });
+
+  factory TracearrError.fromJson(Map<String, dynamic> json) {
+    final errList = (json['errors'] as List<dynamic>?)
+            ?.map((e) => e.toString())
+            .toList() ??
+        [];
+    return TracearrError(
+      message: json['message'] as String? ?? json['error'] as String?,
+      description: json['description'] as String?,
+      errors: errList,
+    );
+  }
+
+  factory TracearrError.fromDio(DioException exception) {
+    if (exception.response?.data is Map<String, dynamic>) {
+      return TracearrError.fromJson(
+          exception.response!.data as Map<String, dynamic>);
+    }
+    return TracearrError(
+      message: exception.message ?? 'HTTP Error \${exception.response?.statusCode}',
+      description: exception.type.toString(),
+    );
+  }
+}
+''';
+    File('$outputDir/responses/tracearr_error.dart')
+        .writeAsStringSync(errorContent);
+
+    final exceptionContent = '''
+import 'tracearr_error.dart';
+
+/// Custom exception thrown on Tracearr API failure.
+class TracearrException implements Exception {
+  final String message;
+  final int? statusCode;
+  final TracearrError? error;
+
+  const TracearrException(
+    this.message, {
+    this.statusCode,
+    this.error,
+  });
+
+  @override
+  String toString() =>
+      'TracearrException(statusCode: \$statusCode, message: \$message, error: \$error)';
+}
+''';
+    File('$outputDir/responses/tracearr_exception.dart')
+        .writeAsStringSync(exceptionContent);
+  }
+
+  void _generateModelFiles() {
+    for (final entry in schemas.entries) {
+      final fullKey = entry.key;
+      final schema = entry.value as Map<String, dynamic>;
+      final className = schemaClassNames[fullKey]!;
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildModelCode(fullKey, className, schema);
+      File('$outputDir/models/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildModelCode(
+      String fullKey, String className, Map<String, dynamic> schema) {
+    final isEnum = schema.containsKey('enum');
+    if (isEnum) {
+      return _buildEnumCode(className, schema);
+    }
+
+    final properties = (schema['properties'] as Map<String, dynamic>?) ?? {};
+    final title = schema['title'] as String?;
+    final description = schema['description'] as String?;
+
+    final imports = <String>{};
+    final fields = <_ModelField>[];
+    final usedFieldNames = <String>{};
+
+    for (final propEntry in properties.entries) {
+      final propKey = propEntry.key;
+      final propSchema = propEntry.value as Map<String, dynamic>;
+      var fieldName = _toCamelCase(propKey);
+      if (usedFieldNames.contains(fieldName)) {
+        fieldName = '${fieldName}Alt';
+      }
+      usedFieldNames.add(fieldName);
+
+      final fieldTypeInfo = _parseType(propSchema, imports);
+      final propDesc = propSchema['description'] as String?;
+      final isDeprecated = propSchema['deprecated'] == true;
+
+      fields.add(_ModelField(
+        jsonKey: propKey,
+        fieldName: fieldName,
+        dartType: fieldTypeInfo.dartType,
+        isNullable: fieldTypeInfo.isNullable,
+        isList: fieldTypeInfo.isList,
+        isCustomClass: fieldTypeInfo.isCustomClass,
+        customClassName: fieldTypeInfo.customClassName,
+        description: propDesc,
+        isDeprecated: isDeprecated,
+      ));
+    }
+
+    final fileName = _toSnakeCase(className);
+    final buffer = StringBuffer();
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    for (final imp in imports) {
+      if (imp != className) {
+        final impFileName = _toSnakeCase(imp);
+        buffer.writeln("import '$impFileName.dart';");
+      }
+    }
+    buffer.writeln();
+    buffer.writeln("part '$fileName.freezed.dart';");
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+
+    final classDoc = description ?? title;
+    if (classDoc != null && classDoc.isNotEmpty) {
+      for (final line in classDoc.split('\n')) {
+        buffer.writeln('/// ${line.trim()}');
+      }
+      buffer.writeln('///');
+    }
+    buffer.writeln('/// Original C# Schema: `$fullKey`');
+    if (schema['deprecated'] == true) {
+      buffer.writeln("@Deprecated('Marked deprecated in OpenAPI spec')");
+    }
+    buffer.writeln('@freezed');
+    buffer.writeln('abstract class $className with _\$$className {');
+    if (fields.isEmpty) {
+      buffer.writeln('  const factory $className() = _$className;');
+    } else {
+      buffer.writeln('  const factory $className({');
+      for (final f in fields) {
+        if (f.description != null && f.description!.isNotEmpty) {
+          for (final line in f.description!.split('\n')) {
+            buffer.writeln('    /// ${line.trim()}');
+          }
+        }
+        if (f.isDeprecated) {
+          buffer.writeln("    @Deprecated('Marked deprecated in OpenAPI spec')");
+        }
+        final typeStr = f.dartType.endsWith('?') ? f.dartType : '${f.dartType}?';
+        buffer.writeln("    @JsonKey(name: '${f.jsonKey}') $typeStr ${f.fieldName},");
+      }
+      buffer.writeln('  }) = _$className;');
+    }
+    buffer.writeln();
+    buffer.writeln('  factory $className.fromJson(Map<String, dynamic> json) =>');
+    buffer.writeln('      _\$${className}FromJson(json);');
+    buffer.writeln('}');
+
+    return buffer.toString();
+  }
+
+  String _buildEnumCode(String className, Map<String, dynamic> schema) {
+    final buffer = StringBuffer();
+    final enumList = schema['enum'] as List<dynamic>;
+    final fileName = _toSnakeCase(className);
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    buffer.writeln("import 'package:freezed_annotation/freezed_annotation.dart';");
+    buffer.writeln();
+    buffer.writeln("part '$fileName.g.dart';");
+    buffer.writeln();
+    buffer.writeln('/// Enum `$className`');
+    buffer.writeln('@JsonEnum(alwaysCreate: true)');
+    buffer.writeln('enum $className {');
+
+    for (final item in enumList) {
+      final strVal = item.toString();
+      final identifier = _toCamelCase(strVal);
+      buffer.writeln("  @JsonValue('$strVal')");
+      buffer.writeln('  $identifier,');
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _TypeInfo _parseType(
+      Map<String, dynamic> schema, Set<String> imports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      imports.add(cls);
+      return _TypeInfo(
+          dartType: cls, isNullable: true, isCustomClass: true, customClassName: cls);
+    }
+
+    final type = schema['type'] as String?;
+    if (type == 'array') {
+      final items = (schema['items'] as Map<String, dynamic>?) ?? {};
+      final itemType = _parseType(items, imports);
+      final listDartType = 'List<${itemType.dartType}>';
+      return _TypeInfo(
+        dartType: listDartType,
+        isNullable: true,
+        isList: true,
+        customClassName: itemType.isCustomClass ? itemType.customClassName : null,
+      );
+    }
+
+    if (type == 'integer') {
+      return _TypeInfo(dartType: 'int', isNullable: true);
+    }
+    if (type == 'number') {
+      return _TypeInfo(dartType: 'double', isNullable: true);
+    }
+    if (type == 'boolean') {
+      return _TypeInfo(dartType: 'bool', isNullable: true);
+    }
+    if (type == 'string') {
+      return _TypeInfo(dartType: 'String', isNullable: true);
+    }
+
+    return _TypeInfo(dartType: 'dynamic', isNullable: true);
+  }
+
+  void _generateApiFiles() {
+    for (final entry in tagEndpoints.entries) {
+      final tag = entry.key;
+      final endpoints = entry.value;
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+
+      final code = _buildApiCode(tag, className, endpoints);
+      File('$outputDir/api/$fileName.dart').writeAsStringSync(code);
+    }
+  }
+
+  String _buildApiCode(
+      String tag, String className, List<Map<String, dynamic>> endpoints) {
+    final buffer = StringBuffer();
+    final imports = <String>{
+      "import 'dart:convert';",
+      "import 'package:dio/dio.dart';",
+      "import '../responses/api_response.dart';",
+      "import '../responses/tracearr_error.dart';",
+      "import '../responses/tracearr_exception.dart';",
+    };
+
+    final modelImports = <String>{};
+
+    for (final ep in endpoints) {
+      final op = ep['operation'] as Map<String, dynamic>;
+      final respSchema = _getSuccessResponseSchema(op);
+      if (respSchema != null) {
+        _extractModelImports(respSchema, modelImports);
+      }
+      final bodySchema = _getRequestBodySchema(op);
+      if (bodySchema != null) {
+        _extractModelImports(bodySchema, modelImports);
+      }
+    }
+
+    buffer.writeln("// ignore_for_file: unused_import");
+    for (final imp in imports) {
+      buffer.writeln(imp);
+    }
+
+    for (final mImp in modelImports) {
+      final fileName = _toSnakeCase(mImp);
+      buffer.writeln("import '../models/$fileName.dart';");
+    }
+    buffer.writeln();
+
+    buffer.writeln('/// Raw API client for `$tag` endpoints.');
+    buffer.writeln('class $className {');
+    buffer.writeln('  final Dio _dio;');
+    buffer.writeln();
+    buffer.writeln('  $className(this._dio);');
+    buffer.writeln();
+
+    final usedMethodNames = <String>{};
+    for (final ep in endpoints) {
+      final path = ep['path'] as String;
+      final verb = ep['verb'] as String;
+      final op = ep['operation'] as Map<String, dynamic>;
+
+      final summary = op['summary'] as String?;
+      final description = op['description'] as String?;
+      final operationId = op['operationId'] as String?;
+
+      var methodName = _buildMethodName(verb, path, operationId);
+      if (usedMethodNames.contains(methodName)) {
+        var count = 2;
+        while (usedMethodNames.contains('$methodName$count')) {
+          count++;
+        }
+        methodName = '$methodName$count';
+      }
+      usedMethodNames.add(methodName);
+
+      final doc = summary ?? description;
+      if (doc != null && doc.isNotEmpty) {
+        for (final line in doc.split('\n')) {
+          buffer.writeln('  /// ${line.trim()}');
+        }
+      }
+      buffer.writeln('  /// HTTP $verb $path');
+      if (op['deprecated'] == true) {
+        buffer.writeln("  @Deprecated('Marked deprecated in OpenAPI spec')");
+      }
+
+      final respSchema = _getSuccessResponseSchema(op);
+      final returnTypeInfo = _getReturnTypeInfo(respSchema);
+      final returnType = returnTypeInfo.type;
+
+      buffer.writeln('  Future<ApiResponse<$returnType>> $methodName(');
+
+      final params = (op['parameters'] as List<dynamic>?)?.cast<Map<String, dynamic>>() ?? [];
+      final pathParams = params.where((p) => p['in'] == 'path').toList();
+      final queryParams = params.where((p) => p['in'] == 'query').toList();
+      final bodySchema = _getRequestBodySchema(op);
+
+      final methodParams = <String>[];
+      for (final p in pathParams) {
+        final pName = _toCamelCase(p['name'] as String);
+        methodParams.add('required String $pName');
+      }
+      for (final q in queryParams) {
+        final qName = _toCamelCase(q['name'] as String);
+        methodParams.add('String? $qName');
+      }
+      if (bodySchema != null) {
+        methodParams.add('dynamic body');
+      }
+
+      if (methodParams.isNotEmpty) {
+        buffer.writeln('    {${methodParams.join(', ')}}');
+      }
+      buffer.writeln('  ) async {');
+
+      var interpolatedPath = path;
+      for (final p in pathParams) {
+        final rawName = p['name'] as String;
+        final pName = _toCamelCase(rawName);
+        interpolatedPath = interpolatedPath.replaceAll('{$rawName}', '\$$pName');
+      }
+
+      buffer.writeln('    try {');
+      buffer.writeln('      final Response<dynamic> resp = await _dio.$verb<dynamic>(');
+      buffer.writeln("        '$interpolatedPath',");
+      if (queryParams.isNotEmpty) {
+        buffer.writeln('        queryParameters: <String, dynamic>{');
+        for (final q in queryParams) {
+          final qRaw = q['name'] as String;
+          final qName = _toCamelCase(qRaw);
+          buffer.writeln("          if ($qName != null) '$qRaw': $qName,");
+        }
+        buffer.writeln('        },');
+      }
+      if (bodySchema != null) {
+        buffer.writeln('        data: body,');
+      }
+      buffer.writeln('      );');
+
+      buffer.writeln('      ${_buildDeserializationCode(returnTypeInfo)}');
+      buffer.writeln('      return ApiResponse.success(data, statusCode: resp.statusCode);');
+      buffer.writeln('    } on DioException catch (e) {');
+      buffer.writeln('      return ApiResponse.error(TracearrError.fromDio(e), statusCode: e.response?.statusCode);');
+      buffer.writeln('    }');
+      buffer.writeln('  }');
+      buffer.writeln();
+    }
+
+    buffer.writeln('}');
+    return buffer.toString();
+  }
+
+  _ReturnTypeInfo _getReturnTypeInfo(Map<String, dynamic>? schema) {
+    if (schema == null) return _ReturnTypeInfo(type: 'void', isList: false, isCustomClass: false);
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key] ?? 'dynamic';
+      final isEnum = schemas[key] != null && (schemas[key] as Map<String, dynamic>).containsKey('enum');
+      return _ReturnTypeInfo(type: cls, isList: false, isCustomClass: !isEnum, isEnum: isEnum, className: cls);
+    }
+    if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null && items.containsKey('\$ref')) {
+        final ref = items['\$ref'] as String;
+        final key = ref.replaceFirst('#/components/schemas/', '');
+        final cls = schemaClassNames[key] ?? 'dynamic';
+        final isEnum = schemas[key] != null && (schemas[key] as Map<String, dynamic>).containsKey('enum');
+        return _ReturnTypeInfo(type: 'List<$cls>', isList: true, isCustomClass: !isEnum, isEnum: isEnum, className: cls);
+      }
+      return _ReturnTypeInfo(type: 'List<dynamic>', isList: true, isCustomClass: false);
+    }
+    return _ReturnTypeInfo(type: 'dynamic', isList: false, isCustomClass: false);
+  }
+
+  String _buildDeserializationCode(_ReturnTypeInfo info) {
+    if (info.type == 'void') {
+      return 'final void data = null;';
+    }
+    if (info.isEnum) {
+      return 'final ${info.className}? data = resp.data != null ? ${info.className}.values.cast<${info.className}?>().firstWhere((e) => e?.name == resp.data.toString(), orElse: () => null) : null;';
+    }
+    if (info.isList && info.isCustomClass) {
+      return 'final List<${info.className}> data = (resp.data as List<dynamic>?)?.map((e) => ${info.className}.fromJson(e as Map<String, dynamic>)).toList() ?? <${info.className}>[];';
+    }
+    if (info.isCustomClass) {
+      return 'final ${info.className}? data = resp.data is Map<String, dynamic> ? ${info.className}.fromJson(resp.data as Map<String, dynamic>) : null;';
+    }
+    return 'final dynamic data = resp.data;';
+  }
+
+  String _buildMethodName(String verb, String path, String? operationId) {
+    if (operationId != null && operationId.isNotEmpty) {
+      var clean = operationId.replaceAll(RegExp(r'ApiV\d+'), '');
+      return _toCamelCase(clean);
+    }
+    final pathParamMatches = RegExp(r'\{([^}]+)\}').allMatches(path);
+    final pathParamNames = pathParamMatches.map((m) => m.group(1)!).toList();
+
+    final cleanPath = path
+        .replaceAll(RegExp(r'^/api/v\d+/'), '/')
+        .replaceAll(RegExp(r'^/api/'), '/')
+        .replaceAll(RegExp(r'\{[^}]+\}'), '');
+    final parts = cleanPath.split('/').where((p) => p.isNotEmpty).toList();
+
+    if (pathParamNames.isNotEmpty) {
+      parts.add('by');
+      parts.addAll(pathParamNames);
+    }
+
+    final nameParts = [verb, ...parts];
+    return _toCamelCase(nameParts.join('_'));
+  }
+
+  Map<String, dynamic>? _getSuccessResponseSchema(Map<String, dynamic> op) {
+    final responses = op['responses'] as Map<String, dynamic>?;
+    if (responses == null) return null;
+    final resp200 = responses['200'] ?? responses['201'];
+    if (resp200 is Map<String, dynamic>) {
+      final content = resp200['content'] as Map<String, dynamic>?;
+      final jsonContent = content?['application/json'] ?? content?['text/json'];
+      return jsonContent?['schema'] as Map<String, dynamic>?;
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _getRequestBodySchema(Map<String, dynamic> op) {
+    final reqBody = op['requestBody'] as Map<String, dynamic>?;
+    final content = reqBody?['content'] as Map<String, dynamic>?;
+    final jsonContent = content?['application/json'] ?? content?['text/json'];
+    return jsonContent?['schema'] as Map<String, dynamic>?;
+  }
+
+  void _extractModelImports(
+      Map<String, dynamic> schema, Set<String> modelImports) {
+    if (schema.containsKey('\$ref')) {
+      final ref = schema['\$ref'] as String;
+      final key = ref.replaceFirst('#/components/schemas/', '');
+      final cls = schemaClassNames[key];
+      if (cls != null) modelImports.add(cls);
+    } else if (schema['type'] == 'array') {
+      final items = schema['items'] as Map<String, dynamic>?;
+      if (items != null) _extractModelImports(items, modelImports);
+    }
+  }
+
+  void _generateExportFile() {
+    final buffer = StringBuffer();
+    buffer.writeln("// Autogenerated OpenAPI Exports for Tracearr\n");
+    buffer.writeln("export 'responses/api_response.dart';");
+    buffer.writeln("export 'responses/tracearr_error.dart';");
+    buffer.writeln("export 'responses/tracearr_exception.dart';");
+
+    for (final entry in schemas.entries) {
+      final className = schemaClassNames[entry.key]!;
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'models/$fileName.dart';");
+    }
+
+    for (final tag in tagEndpoints.keys) {
+      final className = 'Raw${_toPascalCase(tag)}Api';
+      final fileName = _toSnakeCase(className);
+      buffer.writeln("export 'api/$fileName.dart';");
+    }
+
+    File('$outputDir/generated.dart').writeAsStringSync(buffer.toString());
+  }
+}
+
+class _ModelField {
+  final String jsonKey;
+  final String fieldName;
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+  final String? description;
+  final bool isDeprecated;
+
+  _ModelField({
+    required this.jsonKey,
+    required this.fieldName,
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+    this.description,
+    this.isDeprecated = false,
+  });
+}
+
+class _TypeInfo {
+  final String dartType;
+  final bool isNullable;
+  final bool isList;
+  final bool isCustomClass;
+  final String? customClassName;
+
+  _TypeInfo({
+    required this.dartType,
+    required this.isNullable,
+    this.isList = false,
+    this.isCustomClass = false,
+    this.customClassName,
+  });
+}
+
+class _ReturnTypeInfo {
+  final String type;
+  final bool isList;
+  final bool isCustomClass;
+  final bool isEnum;
+  final String? className;
+
+  _ReturnTypeInfo({
+    required this.type,
+    required this.isList,
+    required this.isCustomClass,
+    this.isEnum = false,
+    this.className,
+  });
+}

--- a/services/service_tracearr/tool/v1.json
+++ b/services/service_tracearr/tool/v1.json
@@ -1,0 +1,2271 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Tracearr Public API",
+    "version": "1.0.0",
+    "description": "External API for third-party integrations.\n\nAvailable in Tracearr 1.4.6 and later.\n\n## Authentication\n\nAll endpoints require Bearer token authentication:\n\n```\nAuthorization: Bearer trr_pub_<your_token>\n```\n\nGenerate your API key in **Settings > General**.\n\n## Pagination\n\nPaginated endpoints support `page` (1-indexed) and `pageSize` (max 100, default 25).\n\n## Filtering\n\nMost endpoints support `serverId` to filter by media server.",
+    "contact": {
+      "name": "Tracearr",
+      "url": "https://github.com/connorgallopo/Tracearr"
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key format: trr_pub_<token>. Generate in Settings > General."
+      }
+    },
+    "schemas": {
+      "HealthResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ]
+          },
+          "version": {
+            "type": "string",
+            "description": "Tracearr server version",
+            "example": "1.4.22"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2024-01-15T12:00:00.000Z"
+          },
+          "servers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerStatus"
+            }
+          }
+        },
+        "required": [
+          "status",
+          "version",
+          "timestamp",
+          "servers"
+        ]
+      },
+      "ServerStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string",
+            "example": "Main Plex Server"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "plex",
+              "jellyfin",
+              "emby"
+            ]
+          },
+          "online": {
+            "type": "boolean"
+          },
+          "activeStreams": {
+            "type": "integer",
+            "example": 3
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "type",
+          "online",
+          "activeStreams"
+        ]
+      },
+      "StatsResponse": {
+        "type": "object",
+        "properties": {
+          "activeStreams": {
+            "type": "integer",
+            "example": 5
+          },
+          "totalUsers": {
+            "type": "integer",
+            "example": 24
+          },
+          "totalSessions": {
+            "type": "integer",
+            "description": "Sessions in last 30 days",
+            "example": 1847
+          },
+          "recentViolations": {
+            "type": "integer",
+            "description": "Violations in last 7 days",
+            "example": 3
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "activeStreams",
+          "totalUsers",
+          "totalSessions",
+          "recentViolations",
+          "timestamp"
+        ]
+      },
+      "StatsTodayResponse": {
+        "type": "object",
+        "properties": {
+          "activeStreams": {
+            "type": "integer",
+            "example": 5
+          },
+          "todayPlays": {
+            "type": "integer",
+            "description": "Validated plays (>= 2 min)",
+            "example": 47
+          },
+          "watchTimeHours": {
+            "type": "number",
+            "description": "Hours watched today",
+            "example": 12.5
+          },
+          "alertsLast24h": {
+            "type": "integer",
+            "example": 3
+          },
+          "activeUsersToday": {
+            "type": "integer",
+            "example": 8
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "activeStreams",
+          "todayPlays",
+          "watchTimeHours",
+          "alertsLast24h",
+          "activeUsersToday",
+          "timestamp"
+        ]
+      },
+      "ActivityResponse": {
+        "type": "object",
+        "properties": {
+          "period": {
+            "type": "string",
+            "enum": [
+              "week",
+              "month",
+              "year"
+            ]
+          },
+          "range": {
+            "type": "object",
+            "properties": {
+              "start": {
+                "type": "string",
+                "format": "date-time",
+                "example": "2026-02-08T05:00:00.000Z"
+              },
+              "end": {
+                "type": "string",
+                "format": "date-time",
+                "example": "2026-03-10T14:30:00.000Z"
+              }
+            },
+            "required": [
+              "start",
+              "end"
+            ]
+          },
+          "plays": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "date": {
+                  "type": "string",
+                  "description": "Bucket start time",
+                  "example": "2026-02-08 00:00:00"
+                },
+                "count": {
+                  "type": "integer",
+                  "example": 45
+                }
+              },
+              "required": [
+                "date",
+                "count"
+              ]
+            },
+            "description": "Play counts bucketed over time. Engagement-based: only sessions >= 2 min. Bucket size is 6 hours for week, 1 day for month/year."
+          },
+          "concurrent": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "date": {
+                  "type": "string",
+                  "description": "Bucket start time",
+                  "example": "2026-02-08 00:00:00"
+                },
+                "total": {
+                  "type": "integer",
+                  "example": 7
+                },
+                "direct": {
+                  "type": "integer",
+                  "description": "Direct play streams",
+                  "example": 4
+                },
+                "directStream": {
+                  "type": "integer",
+                  "description": "Direct stream (remux)",
+                  "example": 1
+                },
+                "transcode": {
+                  "type": "integer",
+                  "example": 2
+                }
+              },
+              "required": [
+                "date",
+                "total",
+                "direct",
+                "directStream",
+                "transcode"
+              ]
+            },
+            "description": "Peak concurrent streams per time bucket, broken down by playback type."
+          },
+          "byDayOfWeek": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "day": {
+                  "type": "integer",
+                  "description": "0 = Sunday, 6 = Saturday",
+                  "example": 5
+                },
+                "name": {
+                  "type": "string",
+                  "example": "Fri"
+                },
+                "count": {
+                  "type": "integer",
+                  "example": 120
+                }
+              },
+              "required": [
+                "day",
+                "name",
+                "count"
+              ]
+            },
+            "description": "Play distribution across days of the week. Always 7 entries."
+          },
+          "byHourOfDay": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "hour": {
+                  "type": "integer",
+                  "description": "0-23",
+                  "example": 20
+                },
+                "count": {
+                  "type": "integer",
+                  "example": 35
+                }
+              },
+              "required": [
+                "hour",
+                "count"
+              ]
+            },
+            "description": "Play distribution across hours of the day. Always 24 entries."
+          },
+          "platforms": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "platform": {
+                  "type": "string",
+                  "nullable": true,
+                  "example": "Chrome"
+                },
+                "count": {
+                  "type": "integer",
+                  "example": 89
+                }
+              },
+              "required": [
+                "platform",
+                "count"
+              ]
+            },
+            "description": "Session counts by client platform, sorted by count descending."
+          },
+          "quality": {
+            "$ref": "#/components/schemas/QualityBreakdown"
+          }
+        },
+        "required": [
+          "period",
+          "range",
+          "plays",
+          "concurrent",
+          "byDayOfWeek",
+          "byHourOfDay",
+          "platforms",
+          "quality"
+        ]
+      },
+      "QualityBreakdown": {
+        "type": "object",
+        "properties": {
+          "directPlay": {
+            "type": "integer",
+            "example": 234
+          },
+          "directStream": {
+            "type": "integer",
+            "example": 56
+          },
+          "transcode": {
+            "type": "integer",
+            "example": 120
+          },
+          "total": {
+            "type": "integer",
+            "example": 410
+          },
+          "directPlayPercent": {
+            "type": "integer",
+            "description": "Rounded percentage",
+            "example": 57
+          },
+          "directStreamPercent": {
+            "type": "integer",
+            "example": 14
+          },
+          "transcodePercent": {
+            "type": "integer",
+            "example": 29
+          }
+        },
+        "required": [
+          "directPlay",
+          "directStream",
+          "transcode",
+          "total",
+          "directPlayPercent",
+          "directStreamPercent",
+          "transcodePercent"
+        ]
+      },
+      "StreamsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Stream"
+            }
+          },
+          "summary": {
+            "$ref": "#/components/schemas/StreamsSummary"
+          }
+        },
+        "required": [
+          "data",
+          "summary"
+        ]
+      },
+      "Stream": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverName": {
+            "type": "string",
+            "example": "Main Plex Server"
+          },
+          "username": {
+            "type": "string",
+            "example": "John Doe"
+          },
+          "userThumb": {
+            "type": "string",
+            "nullable": true
+          },
+          "userAvatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "mediaTitle": {
+            "type": "string",
+            "example": "Inception"
+          },
+          "mediaType": {
+            "type": "string",
+            "enum": [
+              "movie",
+              "episode",
+              "track",
+              "live",
+              "photo",
+              "unknown"
+            ]
+          },
+          "showTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Show name (episodes only)",
+            "example": "Breaking Bad"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "nullable": true,
+            "example": 5
+          },
+          "episodeNumber": {
+            "type": "integer",
+            "nullable": true,
+            "example": 16
+          },
+          "year": {
+            "type": "integer",
+            "nullable": true,
+            "example": 2010
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Artist name (music tracks only)",
+            "example": "Pink Floyd"
+          },
+          "albumName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Album name (music tracks only)",
+            "example": "The Dark Side of the Moon"
+          },
+          "trackNumber": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Track number (music tracks only)",
+            "example": 3
+          },
+          "discNumber": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Disc number (music tracks only)",
+            "example": 1
+          },
+          "thumbPath": {
+            "type": "string",
+            "nullable": true,
+            "description": "Poster path"
+          },
+          "posterUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Proxied poster URL"
+          },
+          "durationMs": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Total media length",
+            "example": 8880000
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "playing",
+              "paused",
+              "stopped"
+            ]
+          },
+          "progressMs": {
+            "type": "integer",
+            "example": 3600000
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "isTranscode": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "videoDecision": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "directplay",
+              "copy",
+              "transcode",
+              null
+            ]
+          },
+          "audioDecision": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "directplay",
+              "copy",
+              "transcode",
+              null
+            ]
+          },
+          "bitrate": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Bitrate in kbps",
+            "example": 20000
+          },
+          "sourceVideoCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "hevc"
+          },
+          "sourceAudioCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "truehd"
+          },
+          "sourceAudioChannels": {
+            "type": "integer",
+            "nullable": true,
+            "example": 8
+          },
+          "sourceVideoWidth": {
+            "type": "integer",
+            "nullable": true,
+            "example": 3840
+          },
+          "sourceVideoHeight": {
+            "type": "integer",
+            "nullable": true,
+            "example": 2160
+          },
+          "sourceVideoDetails": {
+            "$ref": "#/components/schemas/SourceVideoDetails"
+          },
+          "sourceAudioDetails": {
+            "$ref": "#/components/schemas/SourceAudioDetails"
+          },
+          "streamVideoCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "h264"
+          },
+          "streamAudioCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "aac"
+          },
+          "streamVideoDetails": {
+            "$ref": "#/components/schemas/StreamVideoDetails"
+          },
+          "streamAudioDetails": {
+            "$ref": "#/components/schemas/StreamAudioDetails"
+          },
+          "transcodeInfo": {
+            "$ref": "#/components/schemas/TranscodeInfo"
+          },
+          "subtitleInfo": {
+            "$ref": "#/components/schemas/SubtitleInfo"
+          },
+          "resolution": {
+            "type": "string",
+            "nullable": true,
+            "description": "4K, 1080p, 720p, etc.",
+            "example": "4K"
+          },
+          "sourceVideoCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "HEVC"
+          },
+          "sourceAudioCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "TrueHD"
+          },
+          "audioChannelsDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "7.1"
+          },
+          "streamVideoCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "H.264"
+          },
+          "streamAudioCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "AAC"
+          },
+          "device": {
+            "type": "string",
+            "nullable": true,
+            "example": "Apple TV"
+          },
+          "player": {
+            "type": "string",
+            "nullable": true,
+            "example": "Plex for Apple TV"
+          },
+          "product": {
+            "type": "string",
+            "nullable": true,
+            "example": "Plex for Apple TV"
+          },
+          "platform": {
+            "type": "string",
+            "nullable": true,
+            "example": "tvOS"
+          }
+        },
+        "required": [
+          "id",
+          "serverId",
+          "serverName",
+          "username",
+          "userThumb",
+          "userAvatarUrl",
+          "mediaTitle",
+          "mediaType",
+          "showTitle",
+          "seasonNumber",
+          "episodeNumber",
+          "year",
+          "artistName",
+          "albumName",
+          "trackNumber",
+          "discNumber",
+          "thumbPath",
+          "posterUrl",
+          "durationMs",
+          "state",
+          "progressMs",
+          "startedAt",
+          "isTranscode",
+          "videoDecision",
+          "audioDecision",
+          "bitrate",
+          "sourceVideoCodec",
+          "sourceAudioCodec",
+          "sourceAudioChannels",
+          "sourceVideoWidth",
+          "sourceVideoHeight",
+          "sourceVideoDetails",
+          "sourceAudioDetails",
+          "streamVideoCodec",
+          "streamAudioCodec",
+          "streamVideoDetails",
+          "streamAudioDetails",
+          "transcodeInfo",
+          "subtitleInfo",
+          "resolution",
+          "sourceVideoCodecDisplay",
+          "sourceAudioCodecDisplay",
+          "audioChannelsDisplay",
+          "streamVideoCodecDisplay",
+          "streamAudioCodecDisplay",
+          "device",
+          "player",
+          "product",
+          "platform"
+        ]
+      },
+      "SourceVideoDetails": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "bitrate": {
+            "type": "number"
+          },
+          "framerate": {
+            "type": "string",
+            "example": "23.976"
+          },
+          "dynamicRange": {
+            "type": "string",
+            "example": "HDR10"
+          },
+          "aspectRatio": {
+            "type": "number",
+            "example": 1.78
+          },
+          "profile": {
+            "type": "string",
+            "example": "main 10"
+          },
+          "level": {
+            "type": "string",
+            "example": "5.1"
+          },
+          "colorSpace": {
+            "type": "string",
+            "example": "bt2020nc"
+          },
+          "colorDepth": {
+            "type": "number",
+            "example": 10
+          }
+        }
+      },
+      "SourceAudioDetails": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "bitrate": {
+            "type": "number"
+          },
+          "channelLayout": {
+            "type": "string",
+            "example": "7.1"
+          },
+          "language": {
+            "type": "string",
+            "example": "eng"
+          },
+          "sampleRate": {
+            "type": "number",
+            "example": 48000
+          }
+        }
+      },
+      "StreamVideoDetails": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "bitrate": {
+            "type": "number"
+          },
+          "width": {
+            "type": "number",
+            "example": 1920
+          },
+          "height": {
+            "type": "number",
+            "example": 1080
+          },
+          "framerate": {
+            "type": "string",
+            "example": "23.976"
+          },
+          "dynamicRange": {
+            "type": "string",
+            "example": "SDR"
+          }
+        }
+      },
+      "StreamAudioDetails": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "bitrate": {
+            "type": "number"
+          },
+          "channels": {
+            "type": "number",
+            "example": 2
+          },
+          "language": {
+            "type": "string",
+            "example": "eng"
+          }
+        }
+      },
+      "TranscodeInfo": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "containerDecision": {
+            "type": "string",
+            "enum": [
+              "directplay",
+              "copy",
+              "transcode"
+            ]
+          },
+          "sourceContainer": {
+            "type": "string",
+            "example": "mkv"
+          },
+          "streamContainer": {
+            "type": "string",
+            "example": "mpegts"
+          },
+          "hwRequested": {
+            "type": "boolean"
+          },
+          "hwDecoding": {
+            "type": "string",
+            "example": "videotoolbox"
+          },
+          "hwEncoding": {
+            "type": "string",
+            "example": "videotoolbox"
+          },
+          "speed": {
+            "type": "number",
+            "description": "Transcode speed multiplier",
+            "example": 2.5
+          },
+          "throttled": {
+            "type": "boolean"
+          },
+          "reasons": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SubtitleInfo": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "decision": {
+            "type": "string",
+            "example": "burn"
+          },
+          "codec": {
+            "type": "string",
+            "example": "srt"
+          },
+          "language": {
+            "type": "string",
+            "example": "eng"
+          },
+          "forced": {
+            "type": "boolean"
+          }
+        }
+      },
+      "StreamsSummary": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "example": 5
+          },
+          "transcodes": {
+            "type": "integer",
+            "example": 2
+          },
+          "directStreams": {
+            "type": "integer",
+            "example": 1
+          },
+          "directPlays": {
+            "type": "integer",
+            "example": 2
+          },
+          "totalBitrate": {
+            "type": "string",
+            "example": "45.2 Mbps"
+          },
+          "byServer": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ServerStreamSummary"
+            }
+          }
+        },
+        "required": [
+          "total",
+          "transcodes",
+          "directStreams",
+          "directPlays",
+          "totalBitrate",
+          "byServer"
+        ]
+      },
+      "ServerStreamSummary": {
+        "type": "object",
+        "properties": {
+          "serverId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverName": {
+            "type": "string",
+            "example": "Main Plex Server"
+          },
+          "total": {
+            "type": "integer",
+            "example": 3
+          },
+          "transcodes": {
+            "type": "integer",
+            "example": 1
+          },
+          "directStreams": {
+            "type": "integer",
+            "example": 1
+          },
+          "directPlays": {
+            "type": "integer",
+            "example": 1
+          },
+          "totalBitrate": {
+            "type": "string",
+            "example": "22.5 Mbps"
+          }
+        },
+        "required": [
+          "serverId",
+          "serverName",
+          "total",
+          "transcodes",
+          "directStreams",
+          "directPlays",
+          "totalBitrate"
+        ]
+      },
+      "StreamsSummaryOnlyResponse": {
+        "type": "object",
+        "properties": {
+          "summary": {
+            "$ref": "#/components/schemas/StreamsSummary"
+          }
+        },
+        "required": [
+          "summary"
+        ]
+      },
+      "TerminateStreamResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              true
+            ]
+          },
+          "terminationLogId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "message": {
+            "type": "string",
+            "example": "Stream termination command sent successfully"
+          }
+        },
+        "required": [
+          "success",
+          "terminationLogId",
+          "message"
+        ]
+      },
+      "TerminateStreamErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "error": {
+            "type": "string"
+          },
+          "terminationLogId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": [
+          "success",
+          "error",
+          "terminationLogId"
+        ]
+      },
+      "TerminateStreamBody": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Message to display to user before termination"
+          }
+        }
+      },
+      "UsersResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/User"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "username": {
+            "type": "string",
+            "example": "john_doe"
+          },
+          "displayName": {
+            "type": "string",
+            "example": "John Doe"
+          },
+          "thumbUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "enum": [
+              "owner",
+              "admin",
+              "viewer",
+              "member",
+              "disabled",
+              "pending"
+            ]
+          },
+          "trustScore": {
+            "type": "integer",
+            "description": "0-100",
+            "example": 95
+          },
+          "totalViolations": {
+            "type": "integer",
+            "example": 2
+          },
+          "serverId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverName": {
+            "type": "string",
+            "example": "Main Plex Server"
+          },
+          "lastActivityAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "sessionCount": {
+            "type": "integer",
+            "example": 147
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "id",
+          "username",
+          "displayName",
+          "thumbUrl",
+          "avatarUrl",
+          "role",
+          "trustScore",
+          "totalViolations",
+          "serverId",
+          "serverName",
+          "lastActivityAt",
+          "sessionCount",
+          "createdAt"
+        ]
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "example": 42
+          },
+          "page": {
+            "type": "integer",
+            "example": 1
+          },
+          "pageSize": {
+            "type": "integer",
+            "example": 25
+          }
+        },
+        "required": [
+          "total",
+          "page",
+          "pageSize"
+        ]
+      },
+      "ViolationsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Violation"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "Violation": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverName": {
+            "type": "string",
+            "example": "Main Plex Server"
+          },
+          "severity": {
+            "type": "string",
+            "enum": [
+              "low",
+              "warning",
+              "high"
+            ]
+          },
+          "acknowledged": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {
+              "nullable": true
+            },
+            "description": "Rule-specific violation data"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "rule": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "type": {
+                "type": "string",
+                "example": "concurrent_streams"
+              },
+              "name": {
+                "type": "string",
+                "example": "Max 2 concurrent streams"
+              }
+            },
+            "required": [
+              "id",
+              "type",
+              "name"
+            ]
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "username": {
+                "type": "string",
+                "example": "john_doe"
+              },
+              "thumbUrl": {
+                "type": "string",
+                "nullable": true,
+                "description": "Avatar path from media server"
+              },
+              "avatarUrl": {
+                "type": "string",
+                "nullable": true,
+                "description": "Proxied avatar URL"
+              }
+            },
+            "required": [
+              "id",
+              "username",
+              "thumbUrl",
+              "avatarUrl"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "serverId",
+          "serverName",
+          "severity",
+          "acknowledged",
+          "data",
+          "createdAt",
+          "rule",
+          "user"
+        ]
+      },
+      "HistoryResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SessionHistory"
+            }
+          },
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          }
+        },
+        "required": [
+          "data",
+          "meta"
+        ]
+      },
+      "SessionHistory": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serverName": {
+            "type": "string",
+            "example": "Main Plex Server"
+          },
+          "state": {
+            "type": "string",
+            "enum": [
+              "playing",
+              "paused",
+              "stopped"
+            ]
+          },
+          "mediaTitle": {
+            "type": "string",
+            "example": "Inception"
+          },
+          "mediaType": {
+            "type": "string",
+            "enum": [
+              "movie",
+              "episode",
+              "track",
+              "live",
+              "photo",
+              "unknown"
+            ]
+          },
+          "showTitle": {
+            "type": "string",
+            "nullable": true,
+            "description": "Show name (episodes only)",
+            "example": "Breaking Bad"
+          },
+          "seasonNumber": {
+            "type": "integer",
+            "nullable": true,
+            "example": 5
+          },
+          "episodeNumber": {
+            "type": "integer",
+            "nullable": true,
+            "example": 16
+          },
+          "year": {
+            "type": "integer",
+            "nullable": true,
+            "example": 2010
+          },
+          "artistName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Artist name (music tracks only)",
+            "example": "Pink Floyd"
+          },
+          "albumName": {
+            "type": "string",
+            "nullable": true,
+            "description": "Album name (music tracks only)",
+            "example": "The Dark Side of the Moon"
+          },
+          "trackNumber": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Track number (music tracks only)",
+            "example": 3
+          },
+          "discNumber": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Disc number (music tracks only)",
+            "example": 1
+          },
+          "thumbPath": {
+            "type": "string",
+            "nullable": true,
+            "description": "Poster path"
+          },
+          "posterUrl": {
+            "type": "string",
+            "nullable": true,
+            "description": "Proxied poster URL"
+          },
+          "durationMs": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Total watch time across segments"
+          },
+          "progressMs": {
+            "type": "integer",
+            "nullable": true
+          },
+          "totalDurationMs": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Media length"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "stoppedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "watched": {
+            "type": "boolean",
+            "description": "True if watched 85%+"
+          },
+          "segmentCount": {
+            "type": "integer",
+            "description": "Pause/resume segment count",
+            "example": 1
+          },
+          "device": {
+            "type": "string",
+            "nullable": true,
+            "example": "Apple TV"
+          },
+          "player": {
+            "type": "string",
+            "nullable": true,
+            "example": "Plex for Apple TV"
+          },
+          "product": {
+            "type": "string",
+            "nullable": true,
+            "example": "Plex for Apple TV"
+          },
+          "platform": {
+            "type": "string",
+            "nullable": true,
+            "example": "tvOS"
+          },
+          "isTranscode": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "videoDecision": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "directplay",
+              "copy",
+              "transcode",
+              null
+            ]
+          },
+          "audioDecision": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "directplay",
+              "copy",
+              "transcode",
+              null
+            ]
+          },
+          "bitrate": {
+            "type": "integer",
+            "nullable": true,
+            "description": "Bitrate in kbps",
+            "example": 20000
+          },
+          "sourceVideoCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "hevc"
+          },
+          "sourceAudioCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "truehd"
+          },
+          "sourceAudioChannels": {
+            "type": "integer",
+            "nullable": true,
+            "example": 8
+          },
+          "sourceVideoWidth": {
+            "type": "integer",
+            "nullable": true,
+            "example": 3840
+          },
+          "sourceVideoHeight": {
+            "type": "integer",
+            "nullable": true,
+            "example": 2160
+          },
+          "sourceVideoDetails": {
+            "$ref": "#/components/schemas/SourceVideoDetails"
+          },
+          "sourceAudioDetails": {
+            "$ref": "#/components/schemas/SourceAudioDetails"
+          },
+          "streamVideoCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "h264"
+          },
+          "streamAudioCodec": {
+            "type": "string",
+            "nullable": true,
+            "example": "aac"
+          },
+          "streamVideoDetails": {
+            "$ref": "#/components/schemas/StreamVideoDetails"
+          },
+          "streamAudioDetails": {
+            "$ref": "#/components/schemas/StreamAudioDetails"
+          },
+          "transcodeInfo": {
+            "$ref": "#/components/schemas/TranscodeInfo"
+          },
+          "subtitleInfo": {
+            "$ref": "#/components/schemas/SubtitleInfo"
+          },
+          "resolution": {
+            "type": "string",
+            "nullable": true,
+            "description": "4K, 1080p, 720p, etc.",
+            "example": "4K"
+          },
+          "sourceVideoCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "HEVC"
+          },
+          "sourceAudioCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "TrueHD"
+          },
+          "audioChannelsDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "7.1"
+          },
+          "streamVideoCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "H.264"
+          },
+          "streamAudioCodecDisplay": {
+            "type": "string",
+            "nullable": true,
+            "example": "AAC"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "username": {
+                "type": "string",
+                "example": "john_doe"
+              },
+              "thumbUrl": {
+                "type": "string",
+                "nullable": true,
+                "description": "Avatar path from media server"
+              },
+              "avatarUrl": {
+                "type": "string",
+                "nullable": true,
+                "description": "Proxied avatar URL"
+              }
+            },
+            "required": [
+              "id",
+              "username",
+              "thumbUrl",
+              "avatarUrl"
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "serverId",
+          "serverName",
+          "state",
+          "mediaTitle",
+          "mediaType",
+          "showTitle",
+          "seasonNumber",
+          "episodeNumber",
+          "year",
+          "artistName",
+          "albumName",
+          "trackNumber",
+          "discNumber",
+          "thumbPath",
+          "posterUrl",
+          "durationMs",
+          "progressMs",
+          "totalDurationMs",
+          "startedAt",
+          "stoppedAt",
+          "watched",
+          "segmentCount",
+          "device",
+          "player",
+          "product",
+          "platform",
+          "isTranscode",
+          "videoDecision",
+          "audioDecision",
+          "bitrate",
+          "sourceVideoCodec",
+          "sourceAudioCodec",
+          "sourceAudioChannels",
+          "sourceVideoWidth",
+          "sourceVideoHeight",
+          "sourceVideoDetails",
+          "sourceAudioDetails",
+          "streamVideoCodec",
+          "streamAudioCodec",
+          "streamVideoDetails",
+          "streamAudioDetails",
+          "transcodeInfo",
+          "subtitleInfo",
+          "resolution",
+          "sourceVideoCodecDisplay",
+          "sourceAudioCodecDisplay",
+          "audioChannelsDisplay",
+          "streamVideoCodecDisplay",
+          "streamAudioCodecDisplay",
+          "user"
+        ]
+      }
+    },
+    "parameters": {}
+  },
+  "paths": {
+    "/api/v1/public/health": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Check server connectivity",
+        "description": "Returns connection status for all configured media servers.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Health check successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    },
+    "/api/v1/public/stats": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Dashboard statistics",
+        "description": "Aggregate counts for dashboard display. Optionally filter by server.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Statistics retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    },
+    "/api/v1/public/stats/today": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Today's dashboard statistics",
+        "description": "Dashboard metrics for \"today\" in the specified timezone. Includes active streams, validated plays (>= 2 min), watch time, alerts, and active users.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": "UTC",
+              "description": "IANA timezone for \"today\" calculation",
+              "example": "America/New_York"
+            },
+            "required": false,
+            "description": "IANA timezone for \"today\" calculation",
+            "name": "timezone",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Statistics retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StatsTodayResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid timezone or serverId"
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    },
+    "/api/v1/public/activity": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Playback activity trends",
+        "description": "Consolidated activity data across six dimensions: plays over time, concurrent streams, day-of-week and hour-of-day distributions, platform usage, and playback quality. Time-series data is bucketed by 6 hours (week) or 1 day (month/year). Play counts use engagement-based filtering (sessions >= 2 minutes).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "week",
+                "month",
+                "year"
+              ],
+              "default": "month",
+              "description": "Time range for activity data",
+              "example": "month"
+            },
+            "required": false,
+            "description": "Time range for activity data",
+            "name": "period",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": "UTC",
+              "description": "IANA timezone for date bucketing",
+              "example": "America/New_York"
+            },
+            "required": false,
+            "description": "IANA timezone for date bucketing",
+            "name": "timezone",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Activity data retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters"
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/api/v1/public/streams": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Active playback sessions",
+        "description": "Real-time active streams with codec and quality details. Use summary=true for lightweight dashboard polling (omits data array).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true,
+              "description": "Return only summary (omit data array)",
+              "example": false
+            },
+            "required": false,
+            "description": "Return only summary (omit data array)",
+            "name": "summary",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Active streams retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/components/schemas/StreamsResponse"
+                    },
+                    {
+                      "$ref": "#/components/schemas/StreamsSummaryOnlyResponse"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    },
+    "/api/v1/public/streams/{id}/terminate": {
+      "post": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Terminate active stream",
+        "description": "Stop an active playback session. Optionally display a message to the user (supported on all platforms).",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Session ID from /streams"
+            },
+            "required": true,
+            "description": "Session ID from /streams",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TerminateStreamBody"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Termination successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TerminateStreamResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid session ID or request body"
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          },
+          "404": {
+            "description": "Session not found"
+          },
+          "409": {
+            "description": "Session already ended"
+          },
+          "500": {
+            "description": "Termination failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TerminateStreamErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/public/users": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "User list with activity metrics",
+        "description": "Paginated users with session counts and trust scores. Users with accounts on multiple servers appear once per server.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1,
+              "example": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "default": 25,
+              "example": 25
+            },
+            "required": false,
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Users retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    },
+    "/api/v1/public/violations": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Rule violations",
+        "description": "Paginated violations in descending order. Filter by server, severity, or acknowledged status.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1,
+              "example": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "default": 25,
+              "example": 25
+            },
+            "required": false,
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "low",
+                "warning",
+                "high"
+              ]
+            },
+            "required": false,
+            "name": "severity",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "boolean",
+              "nullable": true
+            },
+            "required": false,
+            "name": "acknowledged",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Violations retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ViolationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    },
+    "/api/v1/public/history": {
+      "get": {
+        "tags": [
+          "Public API"
+        ],
+        "summary": "Session history",
+        "description": "Paginated session history grouped by unique plays. Multiple pause/resume cycles are aggregated into a single entry with combined duration and segment count.",
+        "security": [
+          {
+            "bearerAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1,
+              "example": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "default": 25,
+              "example": 25
+            },
+            "required": false,
+            "name": "pageSize",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Filter by server",
+              "example": "550e8400-e29b-41d4-a716-446655440000"
+            },
+            "required": false,
+            "description": "Filter by server",
+            "name": "serverId",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "playing",
+                "paused",
+                "stopped"
+              ]
+            },
+            "required": false,
+            "name": "state",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "movie",
+                "episode",
+                "track",
+                "live",
+                "photo",
+                "unknown"
+              ]
+            },
+            "required": false,
+            "name": "mediaType",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "format": "date-time",
+              "description": "Sessions on or after this date (start of day in timezone)"
+            },
+            "required": false,
+            "description": "Sessions on or after this date (start of day in timezone)",
+            "name": "startDate",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "nullable": true,
+              "format": "date-time",
+              "description": "Sessions on or before this date (end of day in timezone)"
+            },
+            "required": false,
+            "description": "Sessions on or before this date (end of day in timezone)",
+            "name": "endDate",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "default": "UTC",
+              "description": "IANA timezone for date interpretation",
+              "example": "America/New_York"
+            },
+            "required": false,
+            "description": "IANA timezone for date interpretation",
+            "name": "timezone",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "History retrieved",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HistoryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid or missing API key"
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://{host}",
+      "description": "Your Tracearr instance",
+      "variables": {
+        "host": {
+          "default": "tracearr.example.com",
+          "description": "Hostname of your Tracearr instance, including any base path (e.g. media.example.com/tracearr)"
+        }
+      }
+    }
+  ]
+}

--- a/tool/build_all.dart
+++ b/tool/build_all.dart
@@ -141,6 +141,24 @@ Future<BuildResult> runBuildRunner(
       dir.path.replaceFirst(rootDir.path + Platform.pathSeparator, '');
 
   try {
+    final openApiParserScript = File('${dir.path}/tool/openapi_parser.dart');
+    if (openApiParserScript.existsSync()) {
+      final parserProcess = await Process.run(
+        Platform.resolvedExecutable,
+        ['run', 'tool/openapi_parser.dart'],
+        workingDirectory: dir.path,
+      );
+      if (parserProcess.exitCode != 0) {
+        return BuildResult(
+          relativePath: relativePath,
+          exitCode: parserProcess.exitCode,
+          stdout: parserProcess.stdout.toString(),
+          stderr: parserProcess.stderr.toString(),
+          duration: stopwatch.elapsed,
+        );
+      }
+    }
+
     final process = await Process.start(
       Platform.resolvedExecutable,
       ['run', 'build_runner', ...commandArgs],


### PR DESCRIPTION
### OpenAPI 2-Tier Architecture Refactoring

We have updated service_sonarr, service_lidarr, service_ombi, and service_tracearr to address all 4 points of maintainer feedback:

#### Why a Standalone Generator Script (tool/openapi_parser.dart)?
We evaluated third-party packages like swagger_parser, but encountered Pub dependency version locks: swagger_parser depends on retrofit_generator, which requires source_gen <3.0.0, while the repo's freezed ^3.2.5 requires source_gen >=3.0.0 <5.0.0.

Instead of introducing dependency version conflicts, we based our approach on Google's official googleapis.dart generator pattern (google/googleapis.dart):
- A lightweight, 0-dependency Dart script in tool/openapi_parser.dart that generates pure @freezed models and strongly-typed Dio controllers in under 1 second.
- Eliminates generator package version lock during future Dart/Flutter SDK upgrades.
- Gives full control over method naming and directory structure without third-party generator lock-in.

---

#### Summary of Changes

1. **Gitignored lib/src/generated/**:
   Added .gitignore for lib/src/generated/ across all service packages. The OpenAPI specs (tool/openapi.json, tool/v1.json, tool/v2.json) and generator scripts remain committed in tool/ as the single source of truth.

2. **End-to-End Strongly-Typed ApiResponse<T>**:
   Raw API controller methods deserialize JSON responses internally and return typed models (e.g. Future<ApiResponse<List<SeriesResource>>>, Future<ApiResponse<SeriesResource>>). High-level services consume strongly-typed models directly without manual dynamic casting.

3. **@freezed and json_serializable Models**:
   Generated @freezed data models and @JsonEnum definitions (part '*.freezed.dart'; part '*.g.dart';). Handles empty schema objects cleanly.

4. **Clean Method Names and Direct Dio Binding**:
   Cleaned operation method names (getSeries, getSeriesById, postCommand, getQueue, getQueueDetails, getQueueStatus). Raw API controllers take Dio directly via constructor injection.

5. **Tracearr Multi-Spec Support (v1.json + v2.json)**:
   service_tracearr's generator automatically loads and merges both v1.json and v2.json into a single, unified model/API client suite.

---

#### Verification

All packages analyze cleanly (dart analyze with 0 errors) and 100% of unit tests pass (flutter test).
