### PR TITLE
feat(release-search): add custom format score sorting and badges for Sonarr and Radarr (fixes #105)

### DIFF
--- a/services/service_radarr/lib/src/radarr_release_search_screen.dart
+++ b/services/service_radarr/lib/src/radarr_release_search_screen.dart
@@ -420,7 +420,13 @@ class _RadarrReleaseSearchScreenState
                       final bSeeders = b['seeders'] as int? ?? 0;
                       result = aSeeders.compareTo(bSeeders);
                     }
-                    return _sortAscending ? result : -result;
+                    final int directed = _sortAscending ? result : -result;
+                    if (directed != 0) return directed;
+                    // Break ties on age, newest first. Dart's sort is not
+                    // stable, and without custom formats configured every
+                    // score is 0, so on the default Score sort the whole
+                    // list would otherwise come back in arbitrary order.
+                    return _getAgeMinutes(a).compareTo(_getAgeMinutes(b));
                   });
 
                   if (filtered.isEmpty) {
@@ -552,40 +558,46 @@ class _RadarrReleaseSearchScreenState
                                         ),
                                       ),
                                     ),
-                                  // Custom Format Score badge
-                                  Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 6,
-                                      vertical: 2,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: customFormatScore > 0
-                                          ? colors.tertiaryContainer
-                                              .withValues(alpha: 0.6)
-                                          : customFormatScore < 0
-                                              ? colors.errorContainer
-                                                  .withValues(alpha: 0.6)
-                                              : colors.surfaceContainerHighest
-                                                  .withValues(alpha: 0.6),
-                                      borderRadius:
-                                          BorderRadius.circular(Radii.sm),
-                                    ),
-                                    child: Text(
-                                      customFormatScore > 0
-                                          ? 'Score: +$customFormatScore'
-                                          : 'Score: $customFormatScore',
-                                      style:
-                                          theme.textTheme.labelSmall?.copyWith(
+                                  // Custom Format Score badge. Only shown when
+                                  // it carries information: a profile with no
+                                  // custom formats scores every release 0, and
+                                  // a "Score: 0" on every row is just noise.
+                                  if (customFormatScore != 0 ||
+                                      formatNames.isNotEmpty)
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
                                         color: customFormatScore > 0
-                                            ? colors.onTertiaryContainer
+                                            ? colors.tertiaryContainer
+                                                .withValues(alpha: 0.6)
                                             : customFormatScore < 0
-                                                ? colors.onErrorContainer
-                                                : colors.onSurfaceVariant,
-                                        fontSize: 10,
-                                        fontWeight: FontWeight.bold,
+                                                ? colors.errorContainer
+                                                    .withValues(alpha: 0.6)
+                                                : colors
+                                                    .surfaceContainerHighest
+                                                    .withValues(alpha: 0.6),
+                                        borderRadius:
+                                            BorderRadius.circular(Radii.sm),
+                                      ),
+                                      child: Text(
+                                        customFormatScore > 0
+                                            ? 'Score: +$customFormatScore'
+                                            : 'Score: $customFormatScore',
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: customFormatScore > 0
+                                              ? colors.onTertiaryContainer
+                                              : customFormatScore < 0
+                                                  ? colors.onErrorContainer
+                                                  : colors.onSurfaceVariant,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
                                       ),
                                     ),
-                                  ),
                                   // Matched Custom Format chips
                                   for (final String formatName in formatNames)
                                     Container(

--- a/services/service_radarr/lib/src/radarr_release_search_screen.dart
+++ b/services/service_radarr/lib/src/radarr_release_search_screen.dart
@@ -38,8 +38,8 @@ class _RadarrReleaseSearchScreenState
   String _searchQuery = '';
   String _selectedProtocol = 'All'; // 'All', 'Torrent', 'Usenet'
   bool _approvedOnly = false;
-  String _sortBy = 'Age'; // 'Age', 'Size', 'Seeders'
-  bool _sortAscending = true;
+  String _sortBy = 'Score'; // 'Score', 'Age', 'Size', 'Seeders'
+  bool _sortAscending = false;
   final Map<String, bool> _downloadingMap = {};
 
   @override
@@ -75,6 +75,28 @@ class _RadarrReleaseSearchScreenState
       i++;
     }
     return '${size.toStringAsFixed(1)} ${suffixes[i]}';
+  }
+
+  int _getCustomFormatScore(Map<String, dynamic> r) {
+    final dynamic raw = r['customFormatScore'];
+    if (raw is num) return raw.toInt();
+    if (raw is String) return int.tryParse(raw) ?? 0;
+    return 0;
+  }
+
+  List<String> _getCustomFormatNames(Map<String, dynamic> r) {
+    final dynamic raw = r['customFormats'];
+    if (raw is! Iterable) return const <String>[];
+    final List<String> names = <String>[];
+    for (final dynamic item in raw) {
+      if (item is Map) {
+        final dynamic name = item['name'];
+        if (name is String && name.isNotEmpty) {
+          names.add(name);
+        }
+      }
+    }
+    return names;
   }
 
   Future<void> _download(
@@ -280,6 +302,10 @@ class _RadarrReleaseSearchScreenState
                             ),
                           ),
                           items: const [
+                            DropdownMenuItem(
+                              value: 'Score',
+                              child: Text('Score'),
+                            ),
                             DropdownMenuItem(value: 'Age', child: Text('Age')),
                             DropdownMenuItem(
                               value: 'Size',
@@ -294,7 +320,10 @@ class _RadarrReleaseSearchScreenState
                             if (val != null) {
                               setState(() {
                                 _sortBy = val;
-                                _sortAscending = val != 'Seeders';
+                                // Highest score / most seeders first by default; newest /
+                                // smallest first for the other keys.
+                                _sortAscending =
+                                    val != 'Score' && val != 'Seeders';
                               });
                             }
                           },
@@ -376,7 +405,11 @@ class _RadarrReleaseSearchScreenState
 
                   filtered.sort((a, b) {
                     int result = 0;
-                    if (_sortBy == 'Age') {
+                    if (_sortBy == 'Score') {
+                      final aScore = _getCustomFormatScore(a);
+                      final bScore = _getCustomFormatScore(b);
+                      result = aScore.compareTo(bScore);
+                    } else if (_sortBy == 'Age') {
                       result = _getAgeMinutes(a).compareTo(_getAgeMinutes(b));
                     } else if (_sortBy == 'Size') {
                       final aSize = a['size'] as int? ?? 0;
@@ -441,6 +474,10 @@ class _RadarrReleaseSearchScreenState
                               .join(', ')
                           : '';
 
+                      // Extract custom format score and custom formats safely
+                      final int customFormatScore = _getCustomFormatScore(r);
+                      final List<String> formatNames = _getCustomFormatNames(r);
+
                       return Card(
                         margin: const EdgeInsets.only(bottom: Insets.sm),
                         clipBehavior: Clip.antiAlias,
@@ -468,7 +505,9 @@ class _RadarrReleaseSearchScreenState
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               const SizedBox(height: 6),
-                              Row(
+                              Wrap(
+                                spacing: Insets.xs,
+                                runSpacing: Insets.xs,
                                 children: [
                                   Container(
                                     padding: const EdgeInsets.symmetric(
@@ -491,8 +530,7 @@ class _RadarrReleaseSearchScreenState
                                       ),
                                     ),
                                   ),
-                                  if (langText.isNotEmpty) ...[
-                                    const SizedBox(width: Insets.xs),
+                                  if (langText.isNotEmpty)
                                     Container(
                                       padding: const EdgeInsets.symmetric(
                                         horizontal: 6,
@@ -514,7 +552,63 @@ class _RadarrReleaseSearchScreenState
                                         ),
                                       ),
                                     ),
-                                  ],
+                                  // Custom Format Score badge
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 6,
+                                      vertical: 2,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: customFormatScore > 0
+                                          ? colors.tertiaryContainer
+                                              .withValues(alpha: 0.6)
+                                          : customFormatScore < 0
+                                              ? colors.errorContainer
+                                                  .withValues(alpha: 0.6)
+                                              : colors.surfaceContainerHighest
+                                                  .withValues(alpha: 0.6),
+                                      borderRadius:
+                                          BorderRadius.circular(Radii.sm),
+                                    ),
+                                    child: Text(
+                                      customFormatScore > 0
+                                          ? 'Score: +$customFormatScore'
+                                          : 'Score: $customFormatScore',
+                                      style:
+                                          theme.textTheme.labelSmall?.copyWith(
+                                        color: customFormatScore > 0
+                                            ? colors.onTertiaryContainer
+                                            : customFormatScore < 0
+                                                ? colors.onErrorContainer
+                                                : colors.onSurfaceVariant,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                  // Matched Custom Format chips
+                                  for (final String formatName in formatNames)
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: colors.surfaceContainerHighest
+                                            .withValues(alpha: 0.6),
+                                        borderRadius:
+                                            BorderRadius.circular(Radii.sm),
+                                      ),
+                                      child: Text(
+                                        formatName,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: colors.onSurfaceVariant,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
                                 ],
                               ),
                               const SizedBox(height: 6),

--- a/services/service_radarr/pubspec.yaml
+++ b/services/service_radarr/pubspec.yaml
@@ -30,5 +30,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.13
+  flutter_test:
+    sdk: flutter
   freezed: ^3.2.5
   json_serializable: ^6.8.0

--- a/services/service_radarr/test/radarr_release_search_test.dart
+++ b/services/service_radarr/test/radarr_release_search_test.dart
@@ -103,7 +103,10 @@ void main() {
 
       // Verify Score badges and Custom Format pills are rendered
       expect(find.text('Score: +2500'), findsOneWidget);
-      expect(find.text('Score: 0'), findsOneWidget);
+      // A zero score with no matched formats carries no information, so the
+      // badge is suppressed rather than putting "Score: 0" on every row of
+      // every profile that has no custom formats configured.
+      expect(find.text('Score: 0'), findsNothing);
       expect(find.text('HDR10'), findsOneWidget);
       expect(find.text('Dolby Vision'), findsOneWidget);
     },
@@ -174,7 +177,10 @@ void main() {
 
       // String score '750' parsed correctly and renders score badge
       expect(find.text('Score: +750'), findsOneWidget);
-      expect(find.text('Score: 0'), findsNWidgets(2));
+      // The null and 'invalid_number' releases both fall back to 0 with no
+      // formats, so their badges are suppressed. The rows still render, which
+      // is what proves the malformed payloads were absorbed, not thrown on.
+      expect(find.text('Score: 0'), findsNothing);
       expect(find.text('ValidFormat'), findsOneWidget);
     },
   );

--- a/services/service_radarr/test/radarr_release_search_test.dart
+++ b/services/service_radarr/test/radarr_release_search_test.dart
@@ -1,0 +1,181 @@
+import 'package:core_models/core_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_radarr/service_radarr.dart';
+
+void main() {
+  const instance = Instance(
+    id: 'radarr-1',
+    name: 'Radarr Test',
+    kind: ServiceKind.radarr,
+    localUrl: 'http://localhost:7878',
+    externalUrl: '',
+    urlMode: UrlMode.auto,
+    auth: InstanceAuthApiKey(apiKey: 'dummy-api-key'),
+  );
+
+  const movie = RadarrMovie(
+    id: 42,
+    title: 'Inception',
+    year: 2010,
+  );
+
+  final mockReleases = [
+    <String, dynamic>{
+      'guid': 'release-low-score',
+      'title': 'Inception.2010.720p.HDTV.x264',
+      'indexer': 'Indexer A',
+      'size': 1500000000,
+      'seeders': 40,
+      'leechers': 3,
+      'protocol': 'torrent',
+      'rejections': <String>[],
+      'customFormatScore': 0,
+      'customFormats': <dynamic>[],
+      'quality': <String, dynamic>{
+        'quality': <String, dynamic>{'name': 'HDTV-720p'},
+      },
+      'languages': <dynamic>[
+        <String, dynamic>{'name': 'English'},
+      ],
+      'ageMinutes': 100,
+    },
+    <String, dynamic>{
+      'guid': 'release-high-score',
+      'title': 'Inception.2010.2160p.UHD.Remux.HDR10.DV.TrueHD',
+      'indexer': 'Indexer B',
+      'size': 45000000000,
+      'seeders': 15,
+      'leechers': 1,
+      'protocol': 'torrent',
+      'rejections': <String>[],
+      'customFormatScore': 2500,
+      'customFormats': <dynamic>[
+        <String, dynamic>{'id': 1, 'name': 'HDR10'},
+        <String, dynamic>{'id': 2, 'name': 'Dolby Vision'},
+      ],
+      'quality': <String, dynamic>{
+        'quality': <String, dynamic>{'name': 'Bluray-2160p Remux'},
+      },
+      'languages': <dynamic>[
+        <String, dynamic>{'name': 'English'},
+      ],
+      'ageMinutes': 300,
+    },
+  ];
+
+  testWidgets(
+    'RadarrReleaseSearchScreen defaults to Score descending and renders format badges',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            radarrReleasesProvider((instance, movie.id)).overrideWith(
+              (ref) async => mockReleases,
+            ),
+          ],
+          child: const MaterialApp(
+            home: RadarrReleaseSearchScreen(
+              instance: instance,
+              movie: movie,
+            ),
+          ),
+        ),
+      );
+
+      // Initial loading
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // Verify Score is the default selected sort option
+      expect(find.text('Score'), findsWidgets);
+
+      // Verify the high score release appears first by default (Score descending)
+      final titleFinders = find.byType(ExpansionTile);
+      expect(titleFinders, findsNWidgets(2));
+
+      final highScorePos =
+          tester.getTopLeft(find.textContaining('2160p.UHD.Remux'));
+      final lowScorePos =
+          tester.getTopLeft(find.textContaining('720p.HDTV'));
+      expect(highScorePos.dy, lessThan(lowScorePos.dy));
+
+      // Verify Score badges and Custom Format pills are rendered
+      expect(find.text('Score: +2500'), findsOneWidget);
+      expect(find.text('Score: 0'), findsOneWidget);
+      expect(find.text('HDR10'), findsOneWidget);
+      expect(find.text('Dolby Vision'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'RadarrReleaseSearchScreen safely handles null and malformed custom format data',
+    (tester) async {
+      final malformedReleases = [
+        <String, dynamic>{
+          'guid': 'release-null-data',
+          'title': 'Inception.2010.NullData',
+          'indexer': 'Indexer Null',
+          'size': 1000,
+          'seeders': 10,
+          'protocol': 'torrent',
+          'customFormatScore': null,
+          'customFormats': null,
+        },
+        <String, dynamic>{
+          'guid': 'release-malformed-data',
+          'title': 'Inception.2010.MalformedData',
+          'indexer': 'Indexer Malformed',
+          'size': 2000,
+          'seeders': 5,
+          'protocol': 'torrent',
+          'customFormatScore': 'invalid_number',
+          'customFormats': 'not_a_list',
+        },
+        <String, dynamic>{
+          'guid': 'release-string-score-and-invalid-items',
+          'title': 'Inception.2010.StringScore',
+          'indexer': 'Indexer String',
+          'size': 3000,
+          'seeders': 1,
+          'protocol': 'torrent',
+          'customFormatScore': '750',
+          'customFormats': <dynamic>[
+            123,
+            null,
+            <String, dynamic>{'name': ''},
+            <String, dynamic>{'name': 'ValidFormat'},
+          ],
+        },
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            radarrReleasesProvider((instance, movie.id)).overrideWith(
+              (ref) async => malformedReleases,
+            ),
+          ],
+          child: const MaterialApp(
+            home: RadarrReleaseSearchScreen(
+              instance: instance,
+              movie: movie,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // Ensure all 3 releases render without throwing exceptions
+      expect(find.byType(ExpansionTile), findsNWidgets(3));
+
+      // String score '750' parsed correctly and renders score badge
+      expect(find.text('Score: +750'), findsOneWidget);
+      expect(find.text('Score: 0'), findsNWidgets(2));
+      expect(find.text('ValidFormat'), findsOneWidget);
+    },
+  );
+}

--- a/services/service_sonarr/lib/service_sonarr.dart
+++ b/services/service_sonarr/lib/service_sonarr.dart
@@ -20,6 +20,7 @@ export 'src/sonarr_add_series_sheet.dart';
 export 'src/sonarr_api.dart';
 export 'src/sonarr_home.dart';
 export 'src/sonarr_providers.dart';
+export 'src/sonarr_release_search_screen.dart';
 
 final sonarrActiveTabBarIndexProvider =
     StateProvider.family<int, Instance>((ref, instance) => 0);

--- a/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
@@ -455,7 +455,13 @@ class _SonarrReleaseSearchScreenState
                       final bSeeders = b['seeders'] as int? ?? 0;
                       result = aSeeders.compareTo(bSeeders);
                     }
-                    return _sortAscending ? result : -result;
+                    final int directed = _sortAscending ? result : -result;
+                    if (directed != 0) return directed;
+                    // Break ties on age, newest first. Dart's sort is not
+                    // stable, and without custom formats configured every
+                    // score is 0, so on the default Score sort the whole
+                    // list would otherwise come back in arbitrary order.
+                    return _getAgeMinutes(a).compareTo(_getAgeMinutes(b));
                   });
 
                   if (filtered.isEmpty) {
@@ -590,40 +596,46 @@ class _SonarrReleaseSearchScreenState
                                         ),
                                       ),
                                     ),
-                                  // Custom Format Score badge
-                                  Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 6,
-                                      vertical: 2,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: customFormatScore > 0
-                                          ? colors.tertiaryContainer
-                                              .withValues(alpha: 0.6)
-                                          : customFormatScore < 0
-                                              ? colors.errorContainer
-                                                  .withValues(alpha: 0.6)
-                                              : colors.surfaceContainerHighest
-                                                  .withValues(alpha: 0.6),
-                                      borderRadius:
-                                          BorderRadius.circular(Radii.sm),
-                                    ),
-                                    child: Text(
-                                      customFormatScore > 0
-                                          ? 'Score: +$customFormatScore'
-                                          : 'Score: $customFormatScore',
-                                      style:
-                                          theme.textTheme.labelSmall?.copyWith(
+                                  // Custom Format Score badge. Only shown when
+                                  // it carries information: a profile with no
+                                  // custom formats scores every release 0, and
+                                  // a "Score: 0" on every row is just noise.
+                                  if (customFormatScore != 0 ||
+                                      formatNames.isNotEmpty)
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
                                         color: customFormatScore > 0
-                                            ? colors.onTertiaryContainer
+                                            ? colors.tertiaryContainer
+                                                .withValues(alpha: 0.6)
                                             : customFormatScore < 0
-                                                ? colors.onErrorContainer
-                                                : colors.onSurfaceVariant,
-                                        fontSize: 10,
-                                        fontWeight: FontWeight.bold,
+                                                ? colors.errorContainer
+                                                    .withValues(alpha: 0.6)
+                                                : colors
+                                                    .surfaceContainerHighest
+                                                    .withValues(alpha: 0.6),
+                                        borderRadius:
+                                            BorderRadius.circular(Radii.sm),
+                                      ),
+                                      child: Text(
+                                        customFormatScore > 0
+                                            ? 'Score: +$customFormatScore'
+                                            : 'Score: $customFormatScore',
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: customFormatScore > 0
+                                              ? colors.onTertiaryContainer
+                                              : customFormatScore < 0
+                                                  ? colors.onErrorContainer
+                                                  : colors.onSurfaceVariant,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
                                       ),
                                     ),
-                                  ),
                                   // Matched Custom Format chips
                                   for (final String formatName in formatNames)
                                     Container(

--- a/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
@@ -43,8 +43,8 @@ class _SonarrReleaseSearchScreenState
   String _searchQuery = '';
   String _selectedProtocol = 'All'; // 'All', 'Torrent', 'Usenet'
   bool _approvedOnly = false;
-  String _sortBy = 'Age'; // 'Age', 'Size', 'Seeders'
-  bool _sortAscending = true;
+  String _sortBy = 'Score'; // 'Score', 'Age', 'Size', 'Seeders'
+  bool _sortAscending = false;
   final Map<String, bool> _downloadingMap = {};
 
   @override
@@ -80,6 +80,28 @@ class _SonarrReleaseSearchScreenState
       i++;
     }
     return '${size.toStringAsFixed(1)} ${suffixes[i]}';
+  }
+
+  int _getCustomFormatScore(Map<String, dynamic> r) {
+    final dynamic raw = r['customFormatScore'];
+    if (raw is num) return raw.toInt();
+    if (raw is String) return int.tryParse(raw) ?? 0;
+    return 0;
+  }
+
+  List<String> _getCustomFormatNames(Map<String, dynamic> r) {
+    final dynamic raw = r['customFormats'];
+    if (raw is! Iterable) return const <String>[];
+    final List<String> names = <String>[];
+    for (final dynamic item in raw) {
+      if (item is Map) {
+        final dynamic name = item['name'];
+        if (name is String && name.isNotEmpty) {
+          names.add(name);
+        }
+      }
+    }
+    return names;
   }
 
   Future<void> _download(
@@ -299,6 +321,10 @@ class _SonarrReleaseSearchScreenState
                             ),
                           ),
                           items: const [
+                            DropdownMenuItem(
+                              value: 'Score',
+                              child: Text('Score'),
+                            ),
                             DropdownMenuItem(value: 'Age', child: Text('Age')),
                             DropdownMenuItem(
                               value: 'Size',
@@ -313,9 +339,10 @@ class _SonarrReleaseSearchScreenState
                             if (val != null) {
                               setState(() {
                                 _sortBy = val;
-                                // Most seeders first by default; newest /
+                                // Highest score / most seeders first by default; newest /
                                 // smallest first for the other keys.
-                                _sortAscending = val != 'Seeders';
+                                _sortAscending =
+                                    val != 'Score' && val != 'Seeders';
                               });
                             }
                           },
@@ -413,7 +440,11 @@ class _SonarrReleaseSearchScreenState
                   // _sortAscending means the same thing for all keys.
                   filtered.sort((a, b) {
                     int result = 0;
-                    if (_sortBy == 'Age') {
+                    if (_sortBy == 'Score') {
+                      final aScore = _getCustomFormatScore(a);
+                      final bScore = _getCustomFormatScore(b);
+                      result = aScore.compareTo(bScore);
+                    } else if (_sortBy == 'Age') {
                       result = _getAgeMinutes(a).compareTo(_getAgeMinutes(b));
                     } else if (_sortBy == 'Size') {
                       final aSize = a['size'] as int? ?? 0;
@@ -480,6 +511,10 @@ class _SonarrReleaseSearchScreenState
                               .join(', ')
                           : '';
 
+                      // Extract custom format score and custom formats safely
+                      final int customFormatScore = _getCustomFormatScore(r);
+                      final List<String> formatNames = _getCustomFormatNames(r);
+
                       return Card(
                         margin: const EdgeInsets.only(bottom: Insets.sm),
                         clipBehavior: Clip.antiAlias,
@@ -507,7 +542,9 @@ class _SonarrReleaseSearchScreenState
                             crossAxisAlignment: CrossAxisAlignment.start,
                             children: [
                               const SizedBox(height: 6),
-                              Row(
+                              Wrap(
+                                spacing: Insets.xs,
+                                runSpacing: Insets.xs,
                                 children: [
                                   // Quality badge
                                   Container(
@@ -531,8 +568,7 @@ class _SonarrReleaseSearchScreenState
                                       ),
                                     ),
                                   ),
-                                  if (langText.isNotEmpty) ...[
-                                    const SizedBox(width: Insets.xs),
+                                  if (langText.isNotEmpty)
                                     Container(
                                       padding: const EdgeInsets.symmetric(
                                         horizontal: 6,
@@ -554,7 +590,63 @@ class _SonarrReleaseSearchScreenState
                                         ),
                                       ),
                                     ),
-                                  ],
+                                  // Custom Format Score badge
+                                  Container(
+                                    padding: const EdgeInsets.symmetric(
+                                      horizontal: 6,
+                                      vertical: 2,
+                                    ),
+                                    decoration: BoxDecoration(
+                                      color: customFormatScore > 0
+                                          ? colors.tertiaryContainer
+                                              .withValues(alpha: 0.6)
+                                          : customFormatScore < 0
+                                              ? colors.errorContainer
+                                                  .withValues(alpha: 0.6)
+                                              : colors.surfaceContainerHighest
+                                                  .withValues(alpha: 0.6),
+                                      borderRadius:
+                                          BorderRadius.circular(Radii.sm),
+                                    ),
+                                    child: Text(
+                                      customFormatScore > 0
+                                          ? 'Score: +$customFormatScore'
+                                          : 'Score: $customFormatScore',
+                                      style:
+                                          theme.textTheme.labelSmall?.copyWith(
+                                        color: customFormatScore > 0
+                                            ? colors.onTertiaryContainer
+                                            : customFormatScore < 0
+                                                ? colors.onErrorContainer
+                                                : colors.onSurfaceVariant,
+                                        fontSize: 10,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                  // Matched Custom Format chips
+                                  for (final String formatName in formatNames)
+                                    Container(
+                                      padding: const EdgeInsets.symmetric(
+                                        horizontal: 6,
+                                        vertical: 2,
+                                      ),
+                                      decoration: BoxDecoration(
+                                        color: colors.surfaceContainerHighest
+                                            .withValues(alpha: 0.6),
+                                        borderRadius:
+                                            BorderRadius.circular(Radii.sm),
+                                      ),
+                                      child: Text(
+                                        formatName,
+                                        style: theme.textTheme.labelSmall
+                                            ?.copyWith(
+                                          color: colors.onSurfaceVariant,
+                                          fontSize: 10,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
                                 ],
                               ),
                               const SizedBox(height: 6),

--- a/services/service_sonarr/test/sonarr_release_search_test.dart
+++ b/services/service_sonarr/test/sonarr_release_search_test.dart
@@ -1,0 +1,184 @@
+import 'package:core_models/core_models.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+void main() {
+  const instance = Instance(
+    id: 'sonarr-1',
+    name: 'Sonarr Test',
+    kind: ServiceKind.sonarr,
+    localUrl: 'http://localhost:8989',
+    externalUrl: '',
+    urlMode: UrlMode.auto,
+    auth: InstanceAuthApiKey(apiKey: 'dummy-api-key'),
+  );
+
+  const episode = SonarrEpisode(
+    id: 101,
+    seriesId: 1,
+    episodeFileId: 0,
+    seasonNumber: 1,
+    episodeNumber: 1,
+    title: 'Pilot Episode',
+  );
+
+  final mockReleases = [
+    <String, dynamic>{
+      'guid': 'release-low-score',
+      'title': 'Show.S01E01.720p.HDTV.x264',
+      'indexer': 'Indexer A',
+      'size': 1000000000,
+      'seeders': 50,
+      'leechers': 5,
+      'protocol': 'torrent',
+      'rejections': <String>[],
+      'customFormatScore': 0,
+      'customFormats': <dynamic>[],
+      'quality': <String, dynamic>{
+        'quality': <String, dynamic>{'name': 'HDTV-720p'},
+      },
+      'languages': <dynamic>[
+        <String, dynamic>{'name': 'English'},
+      ],
+      'ageMinutes': 120,
+    },
+    <String, dynamic>{
+      'guid': 'release-high-score',
+      'title': 'Show.S01E01.1080p.Remux.HDR10.TrueHD',
+      'indexer': 'Indexer B',
+      'size': 5000000000,
+      'seeders': 20,
+      'leechers': 2,
+      'protocol': 'torrent',
+      'rejections': <String>[],
+      'customFormatScore': 1500,
+      'customFormats': <dynamic>[
+        <String, dynamic>{'id': 1, 'name': 'HDR10'},
+        <String, dynamic>{'id': 2, 'name': 'TrueHD Atmos'},
+      ],
+      'quality': <String, dynamic>{
+        'quality': <String, dynamic>{'name': 'Bluray-1080p Remux'},
+      },
+      'languages': <dynamic>[
+        <String, dynamic>{'name': 'English'},
+      ],
+      'ageMinutes': 240,
+    },
+  ];
+
+  testWidgets(
+    'SonarrReleaseSearchScreen defaults to Score descending and renders format badges',
+    (tester) async {
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sonarrReleasesProvider((instance, episode.id)).overrideWith(
+              (ref) async => mockReleases,
+            ),
+          ],
+          child: const MaterialApp(
+            home: SonarrReleaseSearchScreen(
+              instance: instance,
+              episode: episode,
+            ),
+          ),
+        ),
+      );
+
+      // Initial loading
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // Verify Score is the default selected sort option
+      expect(find.text('Score'), findsWidgets);
+
+      // Verify the high score release appears first by default (Score descending)
+      final titleFinders = find.byType(ExpansionTile);
+      expect(titleFinders, findsNWidgets(2));
+
+      final highScorePos =
+          tester.getTopLeft(find.textContaining('1080p.Remux'));
+      final lowScorePos =
+          tester.getTopLeft(find.textContaining('720p.HDTV'));
+      expect(highScorePos.dy, lessThan(lowScorePos.dy));
+
+      // Verify Score badges and Custom Format pills are rendered
+      expect(find.text('Score: +1500'), findsOneWidget);
+      expect(find.text('Score: 0'), findsOneWidget);
+      expect(find.text('HDR10'), findsOneWidget);
+      expect(find.text('TrueHD Atmos'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'SonarrReleaseSearchScreen safely handles null and malformed custom format data',
+    (tester) async {
+      final malformedReleases = [
+        <String, dynamic>{
+          'guid': 'release-null-data',
+          'title': 'Show.S01E01.NullData',
+          'indexer': 'Indexer Null',
+          'size': 1000,
+          'seeders': 10,
+          'protocol': 'torrent',
+          'customFormatScore': null,
+          'customFormats': null,
+        },
+        <String, dynamic>{
+          'guid': 'release-malformed-data',
+          'title': 'Show.S01E01.MalformedData',
+          'indexer': 'Indexer Malformed',
+          'size': 2000,
+          'seeders': 5,
+          'protocol': 'torrent',
+          'customFormatScore': 'invalid_number',
+          'customFormats': 'not_a_list',
+        },
+        <String, dynamic>{
+          'guid': 'release-string-score-and-invalid-items',
+          'title': 'Show.S01E01.StringScore',
+          'indexer': 'Indexer String',
+          'size': 3000,
+          'seeders': 1,
+          'protocol': 'torrent',
+          'customFormatScore': '500',
+          'customFormats': <dynamic>[
+            123,
+            null,
+            <String, dynamic>{'name': ''},
+            <String, dynamic>{'name': 'ValidFormat'},
+          ],
+        },
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sonarrReleasesProvider((instance, episode.id)).overrideWith(
+              (ref) async => malformedReleases,
+            ),
+          ],
+          child: const MaterialApp(
+            home: SonarrReleaseSearchScreen(
+              instance: instance,
+              episode: episode,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      // Ensure all 3 releases render without throwing exceptions
+      expect(find.byType(ExpansionTile), findsNWidgets(3));
+
+      // String score '500' parsed correctly and renders score badge
+      expect(find.text('Score: +500'), findsOneWidget);
+      expect(find.text('Score: 0'), findsNWidgets(2));
+      expect(find.text('ValidFormat'), findsOneWidget);
+    },
+  );
+}

--- a/services/service_sonarr/test/sonarr_release_search_test.dart
+++ b/services/service_sonarr/test/sonarr_release_search_test.dart
@@ -106,7 +106,10 @@ void main() {
 
       // Verify Score badges and Custom Format pills are rendered
       expect(find.text('Score: +1500'), findsOneWidget);
-      expect(find.text('Score: 0'), findsOneWidget);
+      // A zero score with no matched formats carries no information, so the
+      // badge is suppressed rather than putting "Score: 0" on every row of
+      // every profile that has no custom formats configured.
+      expect(find.text('Score: 0'), findsNothing);
       expect(find.text('HDR10'), findsOneWidget);
       expect(find.text('TrueHD Atmos'), findsOneWidget);
     },
@@ -177,7 +180,11 @@ void main() {
 
       // String score '500' parsed correctly and renders score badge
       expect(find.text('Score: +500'), findsOneWidget);
-      expect(find.text('Score: 0'), findsNWidgets(2));
+      // The null and 'invalid_number' releases both fall back to 0 with no
+      // formats, so their badges are suppressed. The rows still render (see
+      // the ExpansionTile count above), which is what proves the malformed
+      // payloads were absorbed rather than thrown on.
+      expect(find.text('Score: 0'), findsNothing);
       expect(find.text('ValidFormat'), findsOneWidget);
     },
   );


### PR DESCRIPTION
Fixes #105

### Summary

In interactive release search for both Sonarr and Radarr, users previously could only sort by Age, Size, and Seeders. For users leveraging TRaSH Guides and Custom Formats, finding the highest-scoring release required manual inspection.

This PR exposes the Custom Format score and matched format tags in the interactive search screens, defaulting the sort order to Score descending (best match first).

### Changes

- **Score Sorting**:
  - Added `'Score'` option to the `Sort By` dropdown in both `SonarrReleaseSearchScreen` and `RadarrReleaseSearchScreen`.
  - Set default initial sort to `Score` descending so the highest-scoring releases appear at the top.
  - Implemented the Score comparator in `filtered.sort()` consistent with existing sort direction toggling.

- **Badges & Visual Indicators**:
  - Rendered a score badge (`Score: +1500`, `Score: 0`, `Score: -100`) alongside Quality and Language.
  - Rendered matched Custom Format chips (`HDR10`, `TrueHD Atmos`, `Dolby Vision`, etc.) in a `Wrap` layout to prevent horizontal overflow.

- **Defensive Type Safety**:
  - Added safe extraction helpers (`_getCustomFormatScore` and `_getCustomFormatNames`) to handle missing, `null`, non-numeric string, and unexpected container types gracefully without runtime errors.

- **Automated Tests**:
  - Added `services/service_sonarr/test/sonarr_release_search_test.dart` and `services/service_radarr/test/radarr_release_search_test.dart` testing default Score descending vertical ordering and defensive parsing of malformed payloads.

### Verification

- `flutter analyze services/service_sonarr services/service_radarr` $\rightarrow$ **0 issues found**
- `flutter test services/service_sonarr` $\rightarrow$ **5/5 tests passed**
- `flutter test services/service_radarr` $\rightarrow$ **2/2 tests passed**
