### PR TITLE
Release 1.4.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Atrium version
       description: Settings, then About.
-      placeholder: "1.4.1"
+      placeholder: "1.4.2"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ whether you're on the home Wi-Fi or out in the world.
 
 **[Website][site]** - screenshots and a tour, no install needed.
 
-> **Status:** v1.4.1. Install from [F-Droid][fdroid], or grab a signed APK
+> **Status:** v1.4.2. Install from [F-Droid][fdroid], or grab a signed APK
 > from the [releases page][releases].
 
 ## Why

--- a/app/lib/src/activity/activity_providers.dart
+++ b/app/lib/src/activity/activity_providers.dart
@@ -72,6 +72,7 @@ class ActivityDownload {
     this.speedBps,
     this.upSpeedBps,
     this.eta,
+    this.onOpenBuilder,
   });
 
   /// Stable identity across polls: `<instanceId>:<id/hash/nzoId>`.
@@ -91,6 +92,9 @@ class ActivityDownload {
 
   /// Short status label ('Downloading', 'Queued', 'Importing', ...).
   final String status;
+
+  /// Screen to push on tap; null means the tap opens the service screen.
+  final Widget Function(BuildContext)? onOpenBuilder;
 }
 
 /// A source instance whose feed could not be fetched at all (no cached data).
@@ -482,6 +486,12 @@ List<ActivityDownload> _qbitDownloads(
           upSpeedBps: t.upspeed > 0 ? t.upspeed : null,
           eta: _fmtEtaSeconds(t.eta),
           status: _qbitStatusLabel(t.state),
+          // Tapping a transfer should land on that torrent, not on the
+          // client's torrent list with the user hunting for it again.
+          onOpenBuilder: (BuildContext _) => TorrentDetailScreen(
+            instance: instance,
+            torrent: t,
+          ),
         ),
   ];
 }

--- a/app/lib/src/activity/activity_providers.dart
+++ b/app/lib/src/activity/activity_providers.dart
@@ -677,6 +677,15 @@ List<ActivityDownload> _sonarrDownloads(
         progress: _sizeProgress(item.size ?? 0, item.sizeleft ?? 0),
         eta: (item.timeleft ?? '').isEmpty ? null : item.timeleft,
         status: _arrStatusLabel(item.status, item.trackedDownloadState),
+        // A queue item is an episode of something, so the useful destination
+        // is the series. Sonarr only embeds it on some queue payloads; without
+        // it there is nothing to open, so the tap falls back to the service.
+        onOpenBuilder: item.series == null
+            ? null
+            : (BuildContext _) => SeriesDetailScreen(
+                  instance: instance,
+                  series: item.series!,
+                ),
       ),
   ];
 }
@@ -695,6 +704,15 @@ List<ActivityDownload> _radarrDownloads(
         progress: _sizeProgress(item.size ?? 0, item.sizeleft ?? 0),
         eta: (item.timeleft ?? '').isEmpty ? null : item.timeleft,
         status: _arrStatusLabel(item.status, item.trackedDownloadState),
+        // The detail screen refetches by id, so the embedded movie is only a
+        // head start on the first frame and may be absent without harm.
+        onOpenBuilder: item.movieId == null
+            ? null
+            : (BuildContext _) => MovieDetailScreen(
+                  instance: instance,
+                  movieId: item.movieId!,
+                  movie: item.movie,
+                ),
       ),
   ];
 }

--- a/app/lib/src/activity/activity_providers.dart
+++ b/app/lib/src/activity/activity_providers.dart
@@ -591,6 +591,11 @@ List<ActivityDownload> _delugeDownloads(
           eta: t.eta > 0 ? _fmtEtaSeconds(t.eta) : null,
           // Deluge's state strings are already display-ready.
           status: t.state,
+          onOpenBuilder: (BuildContext _) => DelugeTorrentDetailScreen(
+            instance: instance,
+            torrentId: t.id,
+            initialName: t.name,
+          ),
         ),
   ];
 }
@@ -615,6 +620,11 @@ List<ActivityDownload> _transmissionDownloads(
           // eta is a negative sentinel when unavailable, never a duration.
           eta: t.hasEta ? _fmtEtaSeconds(t.eta) : null,
           status: t.statusLabel,
+          onOpenBuilder: (BuildContext _) => TransmissionDetailScreen(
+            instance: instance,
+            hashString: t.hashString,
+            initialName: t.name,
+          ),
         ),
   ];
 }
@@ -642,6 +652,11 @@ List<ActivityDownload> _rtorrentDownloads(
               ? _fmtEtaSeconds(t.leftBytes ~/ t.downRate)
               : null,
           status: t.status.label,
+          onOpenBuilder: (BuildContext _) => RtorrentDetailScreen(
+            instance: instance,
+            hash: t.hash,
+            initialName: t.name,
+          ),
         ),
   ];
 }

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -205,7 +205,7 @@ class DashboardBoard extends ConsumerWidget {
       }
     }
     for (final DateTime m in upcomingWindowMonths(DateTime.now())) {
-      ref.invalidate(globalCalendarProvider(m));
+      ref.invalidate(globalCalendarProvider((m, false)));
     }
   }
 }

--- a/app/lib/src/dashboard/widgets/upcoming_widget.dart
+++ b/app/lib/src/dashboard/widgets/upcoming_widget.dart
@@ -40,7 +40,7 @@ class DashboardUpcomingWidget extends ConsumerWidget {
     bool anyError = false;
     for (final DateTime month in months) {
       final AsyncValue<List<CalendarEvent>> value =
-          ref.watch(globalCalendarProvider(month));
+          ref.watch(globalCalendarProvider((month, false)));
       anyLoading |= value.isLoading && !value.hasValue;
       anyError |= value.hasError;
       for (final CalendarEvent e in value.value ?? const <CalendarEvent>[]) {
@@ -73,7 +73,7 @@ class DashboardUpcomingWidget extends ConsumerWidget {
       body = DashboardErrorRow(
         onRetry: () {
           for (final DateTime m in months) {
-            ref.invalidate(globalCalendarProvider(m));
+            ref.invalidate(globalCalendarProvider((m, false)));
           }
         },
       );

--- a/app/lib/src/preferences.dart
+++ b/app/lib/src/preferences.dart
@@ -31,6 +31,7 @@ class Preferences {
     this.customSeedColorHex,
     this.customImagePath,
     this.customImageColorsCsv,
+    this.calendarShowUnmonitored = false,
   });
 
   final ThemeMode themeMode;
@@ -42,6 +43,10 @@ class Preferences {
   final String? customImagePath;
   final String? customImageColorsCsv;
 
+  /// Whether the calendar asks Sonarr and Radarr for unmonitored releases
+  /// as well as monitored ones.
+  final bool calendarShowUnmonitored;
+
   Preferences copyWith({
     ThemeMode? themeMode,
     bool? biometricEnabled,
@@ -51,6 +56,7 @@ class Preferences {
     String? Function()? customSeedColorHex,
     String? Function()? customImagePath,
     String? Function()? customImageColorsCsv,
+    bool? calendarShowUnmonitored,
   }) =>
       Preferences(
         themeMode: themeMode ?? this.themeMode,
@@ -66,6 +72,8 @@ class Preferences {
         customImageColorsCsv: customImageColorsCsv != null
             ? customImageColorsCsv()
             : this.customImageColorsCsv,
+        calendarShowUnmonitored:
+            calendarShowUnmonitored ?? this.calendarShowUnmonitored,
       );
 }
 
@@ -90,6 +98,8 @@ class PreferencesController extends Notifier<Preferences> {
   static const String _customImagePathKey = 'pref.customImagePath';
   static const String _customImageColorsCsvKey = 'pref.customImageColorsCsv';
   static const String _paletteStyleKey = 'pref.paletteStyle';
+  static const String _calendarShowUnmonitoredKey =
+      'pref.calendarShowUnmonitored';
 
   Box<String> get _box => ref.read(settingsBoxProvider);
 
@@ -122,7 +132,14 @@ class PreferencesController extends Notifier<Preferences> {
       customSeedColorHex: _box.get(_customSeedColorHexKey),
       customImagePath: _box.get(_customImagePathKey),
       customImageColorsCsv: _box.get(_customImageColorsCsvKey),
+      calendarShowUnmonitored:
+          _box.get(_calendarShowUnmonitoredKey) == 'true',
     );
+  }
+
+  Future<void> setCalendarShowUnmonitored(bool show) async {
+    await _box.put(_calendarShowUnmonitoredKey, '$show');
+    state = state.copyWith(calendarShowUnmonitored: show);
   }
 
   Future<void> setThemeMode(ThemeMode mode) async {

--- a/app/lib/src/screens/activity_screen.dart
+++ b/app/lib/src/screens/activity_screen.dart
@@ -102,12 +102,7 @@ class ActivityScreen extends ConsumerWidget {
                   key: ValueKey<String>(download.key),
                   download: download,
                   instanceLabel: labelFor(download.instance),
-                  onTap: () => context.go(
-                    AtriumRoutes.servicePath(
-                      download.instance.kind.name,
-                      download.instance.id,
-                    ),
-                  ),
+                  onTap: () => _openDownload(context, download),
                 ),
             ],
           ],
@@ -138,6 +133,22 @@ class ActivityScreen extends ConsumerWidget {
         body: body,
       ),
     );
+  }
+
+  /// Transfers whose client has a detail screen push it full-screen; the rest
+  /// jump to the source service, same as streams.
+  void _openDownload(BuildContext context, ActivityDownload download) {
+    final Widget Function(BuildContext)? builder = download.onOpenBuilder;
+    if (builder != null) {
+      pushScreen<void>(context, builder(context));
+    } else {
+      context.go(
+        AtriumRoutes.servicePath(
+          download.instance.kind.name,
+          download.instance.id,
+        ),
+      );
+    }
   }
 
   /// Streams with a dedicated screen push it full-screen; the rest (Tautulli)

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -132,11 +132,12 @@ class SonarrCalendarEvent extends CalendarEvent {
 }
 
 /// Aggregated calendar provider for all active Sonarr and Radarr instances.
-final globalCalendarProvider =
-    FutureProvider.autoDispose.family<List<CalendarEvent>, DateTime>((
+final globalCalendarProvider = FutureProvider.autoDispose
+    .family<List<CalendarEvent>, (DateTime, bool)>((
   Ref ref,
-  DateTime month,
+  (DateTime, bool) key,
 ) async {
+  final (DateTime month, bool unmonitored) = key;
   final List<Instance> instances = ref.watch(activeInstancesProvider);
   final List<CalendarEvent> allEvents = [];
   final List<Future<void>> futures = [];
@@ -144,7 +145,7 @@ final globalCalendarProvider =
   for (final Instance instance in instances) {
     if (instance.kind == ServiceKind.radarr) {
       final AsyncValue<List<RadarrMovie>> state =
-          ref.watch(radarrCalendarProvider((instance, month)));
+          ref.watch(radarrCalendarProvider((instance, month, unmonitored)));
       final RadarrApi? api = ref.watch(radarrApiProvider(instance)).value;
 
       RadarrCalendarEvent build(RadarrMovie m) => RadarrCalendarEvent(
@@ -158,7 +159,7 @@ final globalCalendarProvider =
       if (state is AsyncLoading) {
         futures.add(
           ref
-              .read(radarrCalendarProvider((instance, month)).future)
+              .read(radarrCalendarProvider((instance, month, unmonitored)).future)
               .then((List<RadarrMovie> movies) {
             allEvents.addAll(movies.map(build));
           }).catchError((Object e) {
@@ -170,7 +171,7 @@ final globalCalendarProvider =
       }
     } else if (instance.kind == ServiceKind.sonarr) {
       final AsyncValue<List<SonarrEpisode>> state =
-          ref.watch(sonarrCalendarProvider((instance, month)));
+          ref.watch(sonarrCalendarProvider((instance, month, unmonitored)));
       final SonarrApi? api = ref.watch(sonarrApiProvider(instance)).value;
 
       SonarrCalendarEvent build(SonarrEpisode e) => SonarrCalendarEvent(
@@ -185,7 +186,7 @@ final globalCalendarProvider =
       if (state is AsyncLoading) {
         futures.add(
           ref
-              .read(sonarrCalendarProvider((instance, month)).future)
+              .read(sonarrCalendarProvider((instance, month, unmonitored)).future)
               .then((List<SonarrEpisode> episodes) {
             allEvents.addAll(episodes.map(build));
           }).catchError((Object e) {
@@ -219,6 +220,10 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   late DateTime _selectedDay;
   bool _showListView = false;
 
+  /// Whether unmonitored episodes and movies are shown alongside
+  /// monitored ones. Placement is being trialled in two spots.
+  bool _showUnmonitored = false;
+
   @override
   void initState() {
     super.initState();
@@ -232,20 +237,20 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
     final List<Future<void>> futures = [];
     for (final Instance instance in instances) {
       if (instance.kind == ServiceKind.radarr) {
-        ref.invalidate(radarrCalendarProvider((instance, _visibleMonth)));
+        ref.invalidate(radarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)));
         futures.add(
-            ref.read(radarrCalendarProvider((instance, _visibleMonth)).future));
+            ref.read(radarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)).future));
       } else if (instance.kind == ServiceKind.sonarr) {
-        ref.invalidate(sonarrCalendarProvider((instance, _visibleMonth)));
+        ref.invalidate(sonarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)));
         futures.add(
-            ref.read(sonarrCalendarProvider((instance, _visibleMonth)).future));
+            ref.read(sonarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)).future));
       }
     }
     if (futures.isNotEmpty) {
       await Future.wait(futures).catchError((_) => []);
     }
     await ref
-        .read(globalCalendarProvider(_visibleMonth).future)
+        .read(globalCalendarProvider((_visibleMonth, _showUnmonitored)).future)
         .catchError((_) => <CalendarEvent>[]);
   }
 
@@ -404,15 +409,15 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   @override
   Widget build(BuildContext context) {
     final AsyncValue<List<CalendarEvent>> calendar =
-        ref.watch(globalCalendarProvider(_visibleMonth));
+        ref.watch(globalCalendarProvider((_visibleMonth, _showUnmonitored)));
 
     // Prefetch and cache adjacent months to ensure instant navigation transitions
     final DateTime nextMonth =
         DateTime(_visibleMonth.year, _visibleMonth.month + 1);
     final DateTime prevMonth =
         DateTime(_visibleMonth.year, _visibleMonth.month - 1);
-    ref.watch(globalCalendarProvider(nextMonth));
-    ref.watch(globalCalendarProvider(prevMonth));
+    ref.watch(globalCalendarProvider((nextMonth, _showUnmonitored)));
+    ref.watch(globalCalendarProvider((prevMonth, _showUnmonitored)));
 
     final bool hasCalendarServices = ref.watch(activeInstancesProvider).any(
           (Instance i) =>
@@ -470,6 +475,19 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
         ),
         title: const Text('Calendar'),
         actions: <Widget>[
+          IconButton(
+            icon: Icon(
+              _showUnmonitored ? Icons.bookmark_border : Icons.bookmark,
+            ),
+            tooltip: _showUnmonitored
+                ? 'Showing monitored and unmonitored'
+                : 'Showing monitored only',
+            onPressed: () {
+              setState(() {
+                _showUnmonitored = !_showUnmonitored;
+              });
+            },
+          ),
           IconButton(
             icon: Icon(
               _showListView ? Icons.calendar_month : Icons.format_list_bulleted,

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -117,8 +117,13 @@ class SonarrCalendarEvent extends CalendarEvent {
   @override
   bool get hasFile => episode.hasFile;
 
+  /// Sonarr tracks monitoring at two levels and an episode can be monitored
+  /// inside a series that is not. Sonarr will not grab it in that case, so the
+  /// honest answer is the AND of the two rather than the episode's own flag.
+  /// If the series was not embedded there is nothing to narrow it with.
   @override
-  bool get monitored => episode.monitored;
+  bool get monitored =>
+      episode.monitored && (episode.series?.monitored ?? true);
 
   @override
   String get primaryTitle => episode.series?.title ?? 'Unknown Series';

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -4,6 +4,7 @@ import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:go_router/go_router.dart';
 import 'package:core_profile/core_profile.dart';
+import '../preferences.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -225,10 +226,6 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   late DateTime _selectedDay;
   bool _showListView = false;
 
-  /// Whether unmonitored episodes and movies are shown alongside
-  /// monitored ones. Placement is being trialled in two spots.
-  bool _showUnmonitored = false;
-
   @override
   void initState() {
     super.initState();
@@ -238,24 +235,26 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
   }
 
   Future<void> _handleRefresh() async {
+    final bool showUnmonitored =
+        ref.read(preferencesProvider).calendarShowUnmonitored;
     final List<Instance> instances = ref.read(activeInstancesProvider);
     final List<Future<void>> futures = [];
     for (final Instance instance in instances) {
       if (instance.kind == ServiceKind.radarr) {
-        ref.invalidate(radarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)));
+        ref.invalidate(radarrCalendarProvider((instance, _visibleMonth, showUnmonitored)));
         futures.add(
-            ref.read(radarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)).future));
+            ref.read(radarrCalendarProvider((instance, _visibleMonth, showUnmonitored)).future));
       } else if (instance.kind == ServiceKind.sonarr) {
-        ref.invalidate(sonarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)));
+        ref.invalidate(sonarrCalendarProvider((instance, _visibleMonth, showUnmonitored)));
         futures.add(
-            ref.read(sonarrCalendarProvider((instance, _visibleMonth, _showUnmonitored)).future));
+            ref.read(sonarrCalendarProvider((instance, _visibleMonth, showUnmonitored)).future));
       }
     }
     if (futures.isNotEmpty) {
       await Future.wait(futures).catchError((_) => []);
     }
     await ref
-        .read(globalCalendarProvider((_visibleMonth, _showUnmonitored)).future)
+        .read(globalCalendarProvider((_visibleMonth, showUnmonitored)).future)
         .catchError((_) => <CalendarEvent>[]);
   }
 
@@ -413,16 +412,20 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final bool showUnmonitored = ref.watch(
+      preferencesProvider
+          .select((Preferences p) => p.calendarShowUnmonitored),
+    );
     final AsyncValue<List<CalendarEvent>> calendar =
-        ref.watch(globalCalendarProvider((_visibleMonth, _showUnmonitored)));
+        ref.watch(globalCalendarProvider((_visibleMonth, showUnmonitored)));
 
     // Prefetch and cache adjacent months to ensure instant navigation transitions
     final DateTime nextMonth =
         DateTime(_visibleMonth.year, _visibleMonth.month + 1);
     final DateTime prevMonth =
         DateTime(_visibleMonth.year, _visibleMonth.month - 1);
-    ref.watch(globalCalendarProvider((nextMonth, _showUnmonitored)));
-    ref.watch(globalCalendarProvider((prevMonth, _showUnmonitored)));
+    ref.watch(globalCalendarProvider((nextMonth, showUnmonitored)));
+    ref.watch(globalCalendarProvider((prevMonth, showUnmonitored)));
 
     final bool hasCalendarServices = ref.watch(activeInstancesProvider).any(
           (Instance i) =>
@@ -482,16 +485,14 @@ class _CalendarScreenState extends ConsumerState<CalendarScreen> {
         actions: <Widget>[
           IconButton(
             icon: Icon(
-              _showUnmonitored ? Icons.bookmark_border : Icons.bookmark,
+              showUnmonitored ? Icons.bookmark_border : Icons.bookmark,
             ),
-            tooltip: _showUnmonitored
+            tooltip: showUnmonitored
                 ? 'Showing monitored and unmonitored'
                 : 'Showing monitored only',
-            onPressed: () {
-              setState(() {
-                _showUnmonitored = !_showUnmonitored;
-              });
-            },
+            onPressed: () => ref
+                .read(preferencesProvider.notifier)
+                .setCalendarShowUnmonitored(!showUnmonitored),
           ),
           IconButton(
             icon: Icon(

--- a/app/lib/src/screens/changelog/release_notes.dart
+++ b/app/lib/src/screens/changelog/release_notes.dart
@@ -27,6 +27,25 @@ class ReleaseNote {
 /// Newest first. Update alongside appVersion and the pubspec at each release.
 const List<ReleaseNote> releaseNotes = <ReleaseNote>[
   ReleaseNote(
+    version: '1.4.2',
+    date: '2026-08-21',
+    groups: <ChangeGroup>[
+      ChangeGroup(ChangeCategory.added, <String>[
+        'qBittorrent can skip the hash check when you add a torrent whose files are already on disk, instead of rechecking the whole thing.',
+        'qBittorrent torrents can be filtered by tracker, with a count next to each one.',
+        'The calendar can show unmonitored releases as well as monitored ones, and remembers which you chose.',
+      ]),
+      ChangeGroup(ChangeCategory.improved, <String>[
+        'Tapping a transfer in Activity opens that torrent, movie or series directly instead of dropping you on the service to find it again. Works for qBittorrent, Deluge, Transmission, rTorrent, Sonarr and Radarr.',
+        'A tracker message in qBittorrent now wraps instead of being cut off, so you can read why a tracker is not working.',
+      ]),
+      ChangeGroup(ChangeCategory.fixed, <String>[
+        'Cover art is no longer blank when Sonarr or Radarr is served from a subpath with a URL Base configured.',
+        'The calendar no longer labels an episode as monitored when the series it belongs to is not.',
+      ]),
+    ],
+  ),
+  ReleaseNote(
     version: '1.4.1',
     date: '2026-08-15',
     groups: <ChangeGroup>[

--- a/app/lib/src/update_check/app_version.dart
+++ b/app/lib/src/update_check/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Source of truth for the update check and the Settings version line. Bump
 /// this at release time together with pubspec.
-const String appVersion = '1.4.1';
+const String appVersion = '1.4.2';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.4.1+17
+version: 1.4.2+18
 
 environment:
   sdk: ^3.6.0

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -241,7 +241,7 @@ void main() {
       tester,
       <Override>[
         for (final DateTime m in upcomingWindowMonths(DateTime.now()))
-          globalCalendarProvider(m).overrideWith((Ref ref) async => events),
+          globalCalendarProvider((m, false)).overrideWith((Ref ref) async => events),
       ],
       const DashboardUpcomingWidget(),
     );

--- a/app/test/new_services_render_test.dart
+++ b/app/test/new_services_render_test.dart
@@ -256,7 +256,7 @@ void main() {
           (Ref ref) async => RadarrApi(Dio(), apiKey: 'k'),
         ),
         radarrCalendarProvider.overrideWith(
-          (Ref ref, (Instance, DateTime) key) async => <RadarrMovie>[
+          (Ref ref, (Instance, DateTime, bool) key) async => <RadarrMovie>[
             RadarrMovie(
               id: 1,
               title: 'Inception',

--- a/app/test/new_services_render_test.dart
+++ b/app/test/new_services_render_test.dart
@@ -12,6 +12,7 @@ import 'package:service_plex/service_plex.dart';
 import 'package:service_radarr/service_radarr.dart';
 import 'package:service_sabnzbd/service_sabnzbd.dart';
 import 'package:service_tautulli/service_tautulli.dart';
+import 'package:atrium/src/preferences.dart';
 import 'package:atrium/src/screens/calendar_screen.dart';
 
 /// Deterministic render tests for the service modules added in the final pass.
@@ -53,6 +54,12 @@ Future<void> _pump(
   for (int i = 0; i < pumps; i++) {
     await tester.pump();
   }
+}
+
+/// Keeps CalendarScreen from reaching for the real settings box.
+class _FakePreferencesController extends PreferencesController {
+  @override
+  Preferences build() => const Preferences();
 }
 
 void main() {
@@ -249,6 +256,7 @@ void main() {
     await _pump(
       tester,
       <Override>[
+        preferencesProvider.overrideWith(_FakePreferencesController.new),
         activeInstancesProvider.overrideWith(
           (Ref ref) => <Instance>[radarr],
         ),

--- a/fastlane/metadata/android/en-US/changelogs/18.txt
+++ b/fastlane/metadata/android/en-US/changelogs/18.txt
@@ -1,0 +1,13 @@
+qBittorrent can now skip the hash check when you add a torrent whose files are
+already on disk, rather than rechecking the whole thing. Its torrent list can
+also be filtered by tracker, with a count beside each one.
+
+The calendar can show unmonitored releases alongside monitored ones, and
+remembers which you picked.
+
+Tapping a transfer in Activity now opens that torrent, movie or series directly
+instead of dropping you on the service to find it again.
+
+Fixed: cover art was blank when Sonarr or Radarr is served from a subpath, a
+tracker's message was cut off mid sentence, and the calendar could label an
+episode as monitored when its series was not.

--- a/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
+++ b/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
@@ -86,6 +86,7 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
   String? _category;
   bool _paused = false;
   bool _sequential = false;
+  bool _skipHashCheck = false;
   bool _busy = false;
   String? _error;
 
@@ -171,6 +172,7 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
           savePath: savePath,
           paused: _paused,
           sequential: _sequential,
+          skipHashCheck: _skipHashCheck,
         );
       } else {
         // One failure does not abandon the rest of the batch.
@@ -184,6 +186,7 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
               savePath: savePath,
               paused: _paused,
               sequential: _sequential,
+              skipHashCheck: _skipHashCheck,
             );
           } catch (_) {
             failed++;
@@ -290,6 +293,17 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
               title: const Text('Download in sequential order'),
               value: _sequential,
               onChanged: (bool v) => setState(() => _sequential = v),
+            ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Skip hash check'),
+              subtitle: const Text(
+                'Assume the files are already complete and correct. '
+                'qBittorrent rechecks the whole torrent if a piece later '
+                'fails.',
+              ),
+              value: _skipHashCheck,
+              onChanged: (bool v) => setState(() => _skipHashCheck = v),
             ),
             if (_error != null) ...<Widget>[
               const SizedBox(height: Insets.sm),

--- a/services/service_qbittorrent/lib/src/models/qbit_torrent.dart
+++ b/services/service_qbittorrent/lib/src/models/qbit_torrent.dart
@@ -46,6 +46,12 @@ abstract class QbitTorrent with _$QbitTorrent {
     @JsonKey(name: 'completion_on') @Default(0) int completionOn,
     @JsonKey(name: 'downloaded_session') @Default(0) int downloadedSession,
     @JsonKey(name: 'uploaded_session') @Default(0) int uploadedSession,
+
+    /// The first tracker with working status, or empty when none are working.
+    /// That is qBittorrent's own definition, so an empty value means "no
+    /// tracker currently answering" rather than "this torrent has no
+    /// trackers".
+    @Default('') String tracker,
   }) = _QbitTorrent;
 
   factory QbitTorrent.fromJson(Map<String, dynamic> json) =>

--- a/services/service_qbittorrent/lib/src/qbittorrent_client.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_client.dart
@@ -182,15 +182,17 @@ class QbittorrentClient {
   /// Adds one or more torrents from magnet links or http(s) `.torrent` URLs.
   ///
   /// [urlsOrMagnets] may contain multiple entries (qBittorrent accepts them
-  /// newline-separated). Optional [category], [savePath], [paused], and
-  /// [sequential] map to the matching `/torrents/add` form fields. Returns
-  /// nothing - call `getTorrents()` afterwards to refresh.
+  /// newline-separated). Optional [category], [savePath], [paused],
+  /// [sequential] and [skipHashCheck] map to the matching `/torrents/add`
+  /// form fields. Returns nothing - call `getTorrents()` afterwards to
+  /// refresh.
   Future<void> addUrls(
     List<String> urlsOrMagnets, {
     String? category,
     String? savePath,
     bool paused = false,
     bool sequential = false,
+    bool skipHashCheck = false,
   }) =>
       _guarded(() async {
         final FormData form = FormData.fromMap(<String, dynamic>{
@@ -199,6 +201,12 @@ class QbittorrentClient {
           if (savePath != null && savePath.isNotEmpty) 'savepath': savePath,
           'paused': paused ? 'true' : 'false',
           'sequentialDownload': sequential ? 'true' : 'false',
+          // Same feature under two names. Every released qBittorrent up to
+          // 5.2 reads skip_checking; unreleased master renamed it seedMode.
+          // Unknown form fields are ignored, so sending both is correct on
+          // either side of that rename.
+          'skip_checking': skipHashCheck ? 'true' : 'false',
+          'seedMode': skipHashCheck ? 'true' : 'false',
         });
         await _dio.post<dynamic>('api/v2/torrents/add', data: form);
       });
@@ -214,6 +222,7 @@ class QbittorrentClient {
     String? savePath,
     bool paused = false,
     bool sequential = false,
+    bool skipHashCheck = false,
   }) =>
       _guarded(() async {
         final FormData form = FormData.fromMap(<String, dynamic>{
@@ -226,6 +235,12 @@ class QbittorrentClient {
           if (savePath != null && savePath.isNotEmpty) 'savepath': savePath,
           'paused': paused ? 'true' : 'false',
           'sequentialDownload': sequential ? 'true' : 'false',
+          // Same feature under two names. Every released qBittorrent up to
+          // 5.2 reads skip_checking; unreleased master renamed it seedMode.
+          // Unknown form fields are ignored, so sending both is correct on
+          // either side of that rename.
+          'skip_checking': skipHashCheck ? 'true' : 'false',
+          'seedMode': skipHashCheck ? 'true' : 'false',
         });
         await _dio.post<dynamic>('api/v2/torrents/add', data: form);
       });

--- a/services/service_qbittorrent/lib/src/qbittorrent_filter_drawer.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_filter_drawer.dart
@@ -14,6 +14,7 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
     final statusFilter = ref.watch(qbitFilterStatusProvider(instance));
     final categoryFilter = ref.watch(qbitFilterCategoryProvider(instance));
     final tagFilter = ref.watch(qbitFilterTagProvider(instance));
+    final trackerFilter = ref.watch(qbitFilterTrackerProvider(instance));
 
     final AsyncValue<List<String>> categoriesAsync =
         ref.watch(qbitCategoriesProvider(instance));
@@ -37,6 +38,28 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
 
     int getTagCount(String tag, List<QbitTorrent> torrents) {
       return torrents.where((QbitTorrent t) => qbitTagMatches(tag, t)).length;
+    }
+
+    int getTrackerCount(String tracker, List<QbitTorrent> torrents) {
+      return torrents
+          .where((QbitTorrent t) => qbitTrackerMatches(tracker, t))
+          .length;
+    }
+
+    /// Tracker hosts present in the current list, busiest first so the
+    /// trackers holding most of the library stay near the top.
+    List<String> trackerHosts(List<QbitTorrent> torrents) {
+      final Map<String, int> counts = <String, int>{};
+      for (final QbitTorrent t in torrents) {
+        final String host = qbitTrackerHost(t.tracker);
+        if (host.isEmpty) continue;
+        counts[host] = (counts[host] ?? 0) + 1;
+      }
+      return counts.keys.toList()
+        ..sort((String a, String b) {
+          final int byCount = counts[b]!.compareTo(counts[a]!);
+          return byCount != 0 ? byCount : a.compareTo(b);
+        });
     }
 
     return Drawer(
@@ -234,6 +257,53 @@ class QbittorrentFilterDrawer extends ConsumerWidget {
                       ),
                     ),
                     orElse: () => [],
+                  ),
+                ],
+              ),
+              ExpansionTile(
+                initiallyExpanded: true,
+                title: const Padding(
+                  padding: EdgeInsets.symmetric(horizontal: 12.0),
+                  child: Text('Trackers'),
+                ),
+                shape: const Border(),
+                collapsedShape: const Border(),
+                children: [
+                  _FilterTile(
+                    title: 'All Trackers',
+                    count: torrents.length,
+                    icon: Icons.dns,
+                    isSelected: trackerFilter == null,
+                    onTap: () {
+                      ref
+                          .read(qbitFilterTrackerProvider(instance).notifier)
+                          .state = null;
+                    },
+                  ),
+                  if (getTrackerCount('none', torrents) > 0)
+                    _FilterTile(
+                      title: 'No working tracker',
+                      count: getTrackerCount('none', torrents),
+                      icon: Icons.cloud_off,
+                      isSelected: trackerFilter == 'none',
+                      onTap: () {
+                        ref
+                            .read(qbitFilterTrackerProvider(instance).notifier)
+                            .state = 'none';
+                      },
+                    ),
+                  ...trackerHosts(torrents).map(
+                    (String host) => _FilterTile(
+                      title: host,
+                      count: getTrackerCount(host, torrents),
+                      icon: Icons.dns_outlined,
+                      isSelected: trackerFilter == host,
+                      onTap: () {
+                        ref
+                            .read(qbitFilterTrackerProvider(instance).notifier)
+                            .state = host;
+                      },
+                    ),
                   ),
                 ],
               ),

--- a/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
@@ -142,6 +142,8 @@ final qbitFilterCategoryProvider = StateProvider.autoDispose
     .family<String?, Instance>((ref, instance) => null);
 final qbitFilterTagProvider = StateProvider.autoDispose
     .family<String?, Instance>((ref, instance) => null);
+final qbitFilterTrackerProvider = StateProvider.autoDispose
+    .family<String?, Instance>((ref, instance) => null);
 
 /// Whether a torrent belongs to the given status filter bucket.
 ///
@@ -208,6 +210,29 @@ bool qbitTagMatches(String tag, QbitTorrent t) {
   return tags.contains(tag);
 }
 
+/// Host of a tracker announce URL, or '' when there is nothing usable.
+///
+/// Only the host is ever surfaced. Private tracker announce URLs carry a
+/// passkey in the path or query, so rendering the raw URL would put a
+/// credential on screen and into any screenshot of the filter drawer.
+String qbitTrackerHost(String announceUrl) {
+  if (announceUrl.isEmpty) return '';
+  final Uri? uri = Uri.tryParse(announceUrl.trim());
+  return uri?.host.toLowerCase() ?? '';
+}
+
+/// Whether a torrent belongs to the given tracker filter bucket.
+///
+/// 'none' covers torrents qBittorrent reports no working tracker for; any
+/// other value matches that tracker host exactly.
+bool qbitTrackerMatches(String tracker, QbitTorrent t) {
+  final String host = qbitTrackerHost(t.tracker);
+  if (tracker == 'none') {
+    return host.isEmpty;
+  }
+  return host == tracker;
+}
+
 /// All torrents for an instance, sorted by the active [qbitSortProvider].
 /// Polls every [qbitListPollInterval] while watched; stops when the screen
 /// goes away (autoDispose).
@@ -239,6 +264,8 @@ final qbitTorrentsProvider = Provider.autoDispose
   final String? categoryFilter =
       ref.watch(qbitFilterCategoryProvider(instance));
   final String? tagFilter = ref.watch(qbitFilterTagProvider(instance));
+  final String? trackerFilter =
+      ref.watch(qbitFilterTrackerProvider(instance));
 
   return rawAsync.whenData((List<QbitTorrent> raw) {
     final List<QbitTorrent> torrents = List<QbitTorrent>.of(raw);
@@ -265,6 +292,12 @@ final qbitTorrentsProvider = Provider.autoDispose
 
     if (tagFilter != null) {
       torrents.retainWhere((QbitTorrent t) => qbitTagMatches(tagFilter, t));
+    }
+
+    if (trackerFilter != null) {
+      torrents.retainWhere(
+        (QbitTorrent t) => qbitTrackerMatches(trackerFilter, t),
+      );
     }
 
     torrents.sort((QbitTorrent a, QbitTorrent b) {

--- a/services/service_qbittorrent/lib/src/torrent_detail_screen.dart
+++ b/services/service_qbittorrent/lib/src/torrent_detail_screen.dart
@@ -1283,13 +1283,27 @@ class _TrackersTab extends ConsumerWidget {
                               label,
                               if (t.numSeeds >= 0) '${t.numSeeds} seeds',
                               if (t.numPeers >= 0) '${t.numPeers} peers',
-                              if (t.msg.isNotEmpty) t.msg,
                             ].join(' • '),
                             maxLines: 2,
                             overflow: TextOverflow.ellipsis,
                             style: theme.textTheme.bodySmall
                                 ?.copyWith(color: cs.onSurfaceVariant),
                           ),
+                          // The tracker's own message gets its own line and is
+                          // allowed to wrap. It is the only thing here that
+                          // explains *why* a tracker is not working, and
+                          // trackers write long sentences: truncating it after
+                          // the counts left the reason unreadable.
+                          if (t.msg.isNotEmpty) ...<Widget>[
+                            const SizedBox(height: 2),
+                            Text(
+                              t.msg,
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color:
+                                    t.status == 4 ? c : cs.onSurfaceVariant,
+                              ),
+                            ),
+                          ],
                         ],
                       ),
                     ),

--- a/services/service_qbittorrent/pubspec.yaml
+++ b/services/service_qbittorrent/pubspec.yaml
@@ -28,5 +28,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.4.13
+  flutter_test:
+    sdk: flutter
   freezed: ^3.2.5
   json_serializable: ^6.8.0

--- a/services/service_qbittorrent/test/qbit_add_options_test.dart
+++ b/services/service_qbittorrent/test/qbit_add_options_test.dart
@@ -1,0 +1,101 @@
+import 'dart:typed_data';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+
+/// Captures the outgoing request instead of hitting a server.
+class _RecordingAdapter implements HttpClientAdapter {
+  RequestOptions? request;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    request = options;
+    // Drain the multipart body so FormData finalizes exactly as it would live.
+    if (requestStream != null) {
+      await requestStream.drain<void>();
+    }
+    return ResponseBody.fromString('Ok.', 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
+}
+
+Map<String, String> _fields(RequestOptions o) => <String, String>{
+      for (final MapEntry<String, String> e in (o.data as FormData).fields)
+        e.key: e.value,
+    };
+
+void main() {
+  late _RecordingAdapter adapter;
+  late QbittorrentClient client;
+
+  setUp(() {
+    adapter = _RecordingAdapter();
+    // An api key skips the cookie login, so the add call is the only request.
+    client = QbittorrentClient(
+      dio: Dio(BaseOptions(baseUrl: 'https://qbit.example.test/'))
+        ..httpClientAdapter = adapter,
+      cookies: CookieJar(),
+      username: '',
+      password: '',
+      apiKey: 'qbt_placeholder_not_a_secret',
+    );
+  });
+
+  group('skip hash check reaches /torrents/add', () {
+    test('magnet add sends both parameter spellings when enabled', () async {
+      await client.addUrls(
+        <String>['magnet:?xt=urn:btih:0123456789abcdef'],
+        skipHashCheck: true,
+      );
+
+      final Map<String, String> f = _fields(adapter.request!);
+      expect(adapter.request!.path, 'api/v2/torrents/add');
+      // Released qBittorrent up to 5.2 reads skip_checking; master renamed it.
+      expect(f['skip_checking'], 'true');
+      expect(f['seedMode'], 'true');
+    });
+
+    test('magnet add sends false when left off', () async {
+      await client.addUrls(<String>['magnet:?xt=urn:btih:0123456789abcdef']);
+
+      final Map<String, String> f = _fields(adapter.request!);
+      expect(f['skip_checking'], 'false');
+      expect(f['seedMode'], 'false');
+    });
+
+    test('file add carries it too', () async {
+      await client.addTorrentFile(
+        Uint8List.fromList(<int>[1, 2, 3]),
+        filename: 'x.torrent',
+        skipHashCheck: true,
+      );
+
+      final Map<String, String> f = _fields(adapter.request!);
+      expect(adapter.request!.path, 'api/v2/torrents/add');
+      expect(f['skip_checking'], 'true');
+      expect(f['seedMode'], 'true');
+    });
+
+    test('the other add options are untouched by it', () async {
+      await client.addUrls(
+        <String>['magnet:?xt=urn:btih:0123456789abcdef'],
+        paused: true,
+        sequential: true,
+        skipHashCheck: true,
+      );
+
+      final Map<String, String> f = _fields(adapter.request!);
+      expect(f['paused'], 'true');
+      expect(f['sequentialDownload'], 'true');
+      expect(f['skip_checking'], 'true');
+    });
+  });
+}

--- a/services/service_qbittorrent/test/qbit_tracker_filter_test.dart
+++ b/services/service_qbittorrent/test/qbit_tracker_filter_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+
+QbitTorrent _t(String tracker) =>
+    QbitTorrent(hash: 'h', name: 'n', state: 'downloading', tracker: tracker);
+
+void main() {
+  group('qbitTrackerHost', () {
+    test('keeps only the host from an http announce URL', () {
+      expect(
+        qbitTrackerHost('https://tracker.example.org:443/announce'),
+        'tracker.example.org',
+      );
+    });
+
+    test('handles udp trackers', () {
+      expect(
+        qbitTrackerHost('udp://open.demonii.com:1337/announce'),
+        'open.demonii.com',
+      );
+    });
+
+    test('never leaks a private tracker passkey', () {
+      const String url =
+          'https://private.example.org/abcdef0123456789passkey/announce';
+      final String host = qbitTrackerHost(url);
+      expect(host, 'private.example.org');
+      expect(host, isNot(contains('passkey')));
+      expect(host, isNot(contains('abcdef0123456789')));
+    });
+
+    test('strips a passkey carried as a query parameter too', () {
+      final String host = qbitTrackerHost(
+        'https://private.example.org/announce?passkey=SECRETVALUE',
+      );
+      expect(host, 'private.example.org');
+      expect(host, isNot(contains('SECRETVALUE')));
+    });
+
+    test('lowercases the host so one tracker is one bucket', () {
+      expect(
+        qbitTrackerHost('https://Tracker.EXAMPLE.org/announce'),
+        'tracker.example.org',
+      );
+    });
+
+    test('empty and unparseable values collapse to empty', () {
+      expect(qbitTrackerHost(''), '');
+      expect(qbitTrackerHost('   '), '');
+      expect(qbitTrackerHost('not a url at all'), '');
+    });
+  });
+
+  group('qbitTrackerMatches', () {
+    test('matches a torrent to its own host', () {
+      final QbitTorrent t = _t('https://tracker.example.org/announce');
+      expect(qbitTrackerMatches('tracker.example.org', t), isTrue);
+      expect(qbitTrackerMatches('other.example.org', t), isFalse);
+    });
+
+    test('the none bucket holds torrents with no working tracker', () {
+      expect(qbitTrackerMatches('none', _t('')), isTrue);
+      expect(
+        qbitTrackerMatches('none', _t('https://tracker.example.org/announce')),
+        isFalse,
+      );
+    });
+
+    test('a torrent with no working tracker is in no host bucket', () {
+      expect(qbitTrackerMatches('tracker.example.org', _t('')), isFalse);
+    });
+  });
+}

--- a/services/service_radarr/lib/src/radarr_api.dart
+++ b/services/service_radarr/lib/src/radarr_api.dart
@@ -173,9 +173,13 @@ class RadarrApi {
     return upstream;
   }
 
+  /// [unmonitored] mirrors Radarr's own calendar flag. It defaults to false
+  /// there too, so without it the response silently omits unmonitored movies
+  /// rather than returning them for the client to filter.
   Future<List<RadarrMovie>> getCalendar({
     required DateTime start,
     required DateTime end,
+    bool unmonitored = false,
   }) async {
     try {
       final Response<dynamic> resp = await _dio.get<dynamic>(
@@ -183,6 +187,7 @@ class RadarrApi {
         queryParameters: <String, dynamic>{
           'start': start.toUtc().toIso8601String(),
           'end': end.toUtc().toIso8601String(),
+          'unmonitored': unmonitored,
         },
       );
       return (resp.data as List<dynamic>)

--- a/services/service_radarr/lib/src/radarr_api.dart
+++ b/services/service_radarr/lib/src/radarr_api.dart
@@ -156,9 +156,16 @@ class RadarrApi {
         pathOrUrl = '$basePart-$targetWidth$extPart$queryPart';
       }
 
-      if (pathOrUrl.startsWith('/MediaCover/')) {
-        pathOrUrl =
-            '$_base/mediacover${pathOrUrl.substring('/MediaCover'.length)}';
+      // Radarr prefixes its configured URL Base onto images[].url, so this
+      // arrives as either /MediaCover/... or /base/MediaCover/.... Match
+      // the segment wherever it starts and rebuild relative to the API:
+      // the frontend /MediaCover route is served by the web UI, which
+      // ignores the api key and 302s to the login page.
+      final int coverIdx = pathOrUrl.indexOf('/MediaCover/');
+      if (coverIdx != -1) {
+        final String tail =
+            pathOrUrl.substring(coverIdx + '/MediaCover'.length);
+        pathOrUrl = '$_base/mediacover$tail';
       }
       final String separator = pathOrUrl.contains('?') ? '&' : '?';
       return base.resolve('$pathOrUrl${separator}apikey=$apiKey').toString();

--- a/services/service_radarr/lib/src/radarr_providers.dart
+++ b/services/service_radarr/lib/src/radarr_providers.dart
@@ -362,12 +362,15 @@ final radarrWantedCutoffProvider =
 });
 
 /// The calendar entries for an instance for a given month.
-final radarrCalendarProvider =
-    FutureProvider.autoDispose.family<List<RadarrMovie>, (Instance, DateTime)>((
+/// Keyed on the unmonitored flag as well as the month: Radarr decides what to
+/// return server-side, so the two modes are genuinely different responses and
+/// each deserves its own cache entry.
+final radarrCalendarProvider = FutureProvider.autoDispose
+    .family<List<RadarrMovie>, (Instance, DateTime, bool)>((
   Ref ref,
-  (Instance, DateTime) key,
+  (Instance, DateTime, bool) key,
 ) async {
-  final (Instance instance, DateTime month) = key;
+  final (Instance instance, DateTime month, bool unmonitored) = key;
   final RadarrApi api = await ref.watch(radarrApiProvider(instance).future);
 
   // Calculate local month boundaries
@@ -375,7 +378,7 @@ final radarrCalendarProvider =
   final DateTime end = DateTime(month.year, month.month + 1)
       .subtract(const Duration(seconds: 1));
 
-  return api.getCalendar(start: start, end: end);
+  return api.getCalendar(start: start, end: end, unmonitored: unmonitored);
 });
 
 /// Search query for the Wanted tab.

--- a/services/service_radarr/test/radarr_poster_url_test.dart
+++ b/services/service_radarr/test/radarr_poster_url_test.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_radarr/service_radarr.dart';
+
+RadarrApi _apiFor(String baseUrl) =>
+    RadarrApi(Dio(BaseOptions(baseUrl: baseUrl)), apiKey: 'test-key');
+
+void main() {
+  group('posterUrl targets the API route, not the web frontend', () {
+    test('plain Radarr with no URL Base', () {
+      final url = _apiFor('https://example.com/').posterUrl(
+        const RadarrImage(
+          coverType: 'poster',
+          url: '/MediaCover/87/poster.jpg?lastWrite=639',
+        ),
+      );
+      expect(url, contains('/api/v3/mediacover/87/'));
+      expect(url, isNot(contains('/MediaCover/')));
+    });
+
+    test('Radarr with a URL Base configured (issue #64)', () {
+      // With UrlBase set, Radarr prefixes it onto images[].url, so the value
+      // arrives as /radarr/MediaCover/... rather than /MediaCover/...
+      final url = _apiFor('https://example.com/radarr/').posterUrl(
+        const RadarrImage(
+          coverType: 'poster',
+          url: '/radarr/MediaCover/87/poster.jpg?lastWrite=639',
+        ),
+      );
+      // Must hit the API route; the frontend /MediaCover/ route ignores the
+      // api key and 302s to the login page.
+      expect(url, isNot(contains('/MediaCover/')));
+      expect(url, contains('/radarr/api/v3/mediacover/87/'));
+    });
+
+    test('width resizing still applies with a URL Base', () {
+      final url = _apiFor('https://example.com/radarr/').posterUrl(
+        const RadarrImage(
+          coverType: 'poster',
+          url: '/radarr/MediaCover/87/poster.jpg?lastWrite=639',
+        ),
+        width: 500,
+      );
+      expect(url, contains('poster-500.jpg'));
+      expect(url, contains('/radarr/api/v3/mediacover/87/'));
+    });
+  });
+}

--- a/services/service_sonarr/lib/src/sonarr_api.dart
+++ b/services/service_sonarr/lib/src/sonarr_api.dart
@@ -55,10 +55,14 @@ class SonarrApi {
     }
   }
 
+  /// [unmonitored] mirrors Sonarr's own calendar flag. It defaults to false
+  /// there too, so without it the response silently omits unmonitored
+  /// episodes rather than returning them for the client to filter.
   Future<List<SonarrEpisode>> getCalendar({
     required DateTime start,
     required DateTime end,
     bool includeSeries = true,
+    bool unmonitored = false,
   }) async {
     try {
       final Response<dynamic> resp = await _dio.get<dynamic>(
@@ -67,6 +71,7 @@ class SonarrApi {
           'start': start.toUtc().toIso8601String(),
           'end': end.toUtc().toIso8601String(),
           'includeSeries': includeSeries,
+          'unmonitored': unmonitored,
         },
       );
       return (resp.data as List<dynamic>)

--- a/services/service_sonarr/lib/src/sonarr_api.dart
+++ b/services/service_sonarr/lib/src/sonarr_api.dart
@@ -173,9 +173,16 @@ class SonarrApi {
         }
       }
 
-      if (pathOrUrl.startsWith('/MediaCover/')) {
-        pathOrUrl =
-            '$_base/mediacover${pathOrUrl.substring('/MediaCover'.length)}';
+      // Sonarr prefixes its configured URL Base onto images[].url, so this
+      // arrives as either /MediaCover/... or /base/MediaCover/.... Match
+      // the segment wherever it starts and rebuild relative to the API:
+      // the frontend /MediaCover route is served by the web UI, which
+      // ignores the api key and 302s to the login page.
+      final int coverIdx = pathOrUrl.indexOf('/MediaCover/');
+      if (coverIdx != -1) {
+        final String tail =
+            pathOrUrl.substring(coverIdx + '/MediaCover'.length);
+        pathOrUrl = '$_base/mediacover$tail';
       }
       final String separator = pathOrUrl.contains('?') ? '&' : '?';
       return base.resolve('$pathOrUrl${separator}apikey=$apiKey').toString();

--- a/services/service_sonarr/lib/src/sonarr_providers.dart
+++ b/services/service_sonarr/lib/src/sonarr_providers.dart
@@ -493,12 +493,15 @@ final sonarrWantedCutoffProvider =
 });
 
 /// The calendar entries for an instance for a given month.
+/// Keyed on the unmonitored flag as well as the month: Sonarr decides what to
+/// return server-side, so the two modes are genuinely different responses and
+/// each deserves its own cache entry.
 final sonarrCalendarProvider = FutureProvider.autoDispose
-    .family<List<SonarrEpisode>, (Instance, DateTime)>((
+    .family<List<SonarrEpisode>, (Instance, DateTime, bool)>((
   Ref ref,
-  (Instance, DateTime) key,
+  (Instance, DateTime, bool) key,
 ) async {
-  final (Instance instance, DateTime month) = key;
+  final (Instance instance, DateTime month, bool unmonitored) = key;
   final SonarrApi api = await ref.watch(sonarrApiProvider(instance).future);
 
   // Calculate local month boundaries
@@ -509,6 +512,7 @@ final sonarrCalendarProvider = FutureProvider.autoDispose
   final List<SonarrEpisode> episodes = await api.getCalendar(
     start: start,
     end: end,
+    unmonitored: unmonitored,
   );
 
   return episodes;

--- a/services/service_sonarr/test/sonarr_poster_url_test.dart
+++ b/services/service_sonarr/test/sonarr_poster_url_test.dart
@@ -1,0 +1,48 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+SonarrApi _apiFor(String baseUrl) =>
+    SonarrApi(Dio(BaseOptions(baseUrl: baseUrl)), apiKey: 'test-key');
+
+void main() {
+  group('posterUrl targets the API route, not the web frontend', () {
+    test('plain Sonarr with no URL Base', () {
+      final url = _apiFor('https://example.com/').posterUrl(
+        const SonarrImage(
+          coverType: 'poster',
+          url: '/MediaCover/87/poster.jpg?lastWrite=639',
+        ),
+      );
+      expect(url, contains('/api/v3/mediacover/87/'));
+      expect(url, isNot(contains('/MediaCover/')));
+    });
+
+    test('Sonarr with a URL Base configured (issue #64)', () {
+      // With UrlBase set, Sonarr prefixes it onto images[].url, so the value
+      // arrives as /sonarr/MediaCover/... rather than /MediaCover/...
+      final url = _apiFor('https://example.com/sonarr/').posterUrl(
+        const SonarrImage(
+          coverType: 'poster',
+          url: '/sonarr/MediaCover/87/poster.jpg?lastWrite=639',
+        ),
+      );
+      // Must hit the API route; the frontend /MediaCover/ route ignores the
+      // api key and 302s to the login page.
+      expect(url, isNot(contains('/MediaCover/')));
+      expect(url, contains('/sonarr/api/v3/mediacover/87/'));
+    });
+
+    test('width resizing still applies with a URL Base', () {
+      final url = _apiFor('https://example.com/sonarr/').posterUrl(
+        const SonarrImage(
+          coverType: 'poster',
+          url: '/sonarr/MediaCover/87/poster.jpg?lastWrite=639',
+        ),
+        width: 500,
+      );
+      expect(url, contains('poster-500.jpg'));
+      expect(url, contains('/sonarr/api/v3/mediacover/87/'));
+    });
+  });
+}

--- a/site/src/components/hero.html
+++ b/site/src/components/hero.html
@@ -1,7 +1,7 @@
 <section class="hero-section">
   <div class="grid middle-align">
     <div class="s12 m6 hero-text-col center-align-mobile">
-      <div class="chip border round">v1.4.1 Release</div>
+      <div class="chip border round">v1.4.2 Release</div>
       <h1 class="hero-title">Your self-hosted media, unified.</h1>
       <p class="hero-subtitle">One premium Android app that fronts Sonarr, Radarr, Plex, Jellyfin, qBittorrent, and more. Material 3 Expressive, multi-instance, and fully secure.</p>
       <div class="row hero-actions">


### PR DESCRIPTION
Cuts 1.4.2 (build 18). Thirteen commits, six reported issues.

## New

**Skip hash check when adding a torrent** (#120). qBittorrent rechecks a torrent whose files are already on disk, which on a large one is a long wait for a known answer. The add sheet now offers the same switch qBittorrent's own dialog has.

**Filter qBittorrent by tracker** (#115). A Trackers section in the filter drawer, each host with a count, busiest first.

**Show unmonitored releases in the calendar** (#118). A toggle in the app bar that remembers what you chose.

## Improved

**Tapping a transfer in Activity opens it** (#117). Previously it dropped you on the service to find the same item again. Now it opens the torrent, movie or series directly, across qBittorrent, Deluge, Transmission, rTorrent, Sonarr and Radarr.

**A tracker's message wraps** (#114) instead of being clipped mid sentence, so the reason a tracker is not working is readable.

## Fixed

**Cover art was blank behind a subpath** (#64). With a URL Base configured, Sonarr and Radarr prefix it onto image paths, so Atrium requested the web frontend route, which ignores the api key and redirects to a login page.

**The calendar mislabelled monitoring.** An episode can be monitored inside a series that is not, and Sonarr will not grab it in that case.

## Verification

- `flutter analyze` clean across app, service_qbittorrent, service_sonarr, service_radarr, core_models and core_ui
- app 117/117, service_qbittorrent 13/13, service_sonarr 8/8, service_radarr 5/5, core_networking 18/18, core_models 13/13
- Poster fix verified against a live Sonarr 4.0.19 with a URL Base set: the old URL 302s to the login page, the new one returns the image
- Skip hash check verified end to end on an emulator against a recording server: the app posts both `skip_checking` and `seedMode`
- Tracker filter verified rendering host-only, with no announce URL or passkey exposed
- Installed and used on device

## Version bumps

pubspec `1.4.2+18`, `appVersion`, README, bug report template, site version chip, changelog entry, and `fastlane/.../changelogs/18.txt`.

After merge: tag `v1.4.2` on `main`, then sign locally with build-tools 34 per `docs/RELEASING.md`.