### PR TITLE
Release 1.5.0 docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,16 +51,23 @@ body:
         - Settings and profiles
         - Sonarr
         - Radarr
+        - Lidarr
         - Prowlarr
         - Bazarr
         - Seerr (Overseerr or Jellyseerr)
         - Tautulli
+        - Tracearr
         - Jellyfin
         - Emby
         - Plex
         - qBittorrent
+        - Deluge
+        - Transmission
+        - rTorrent
         - SABnzbd
+        - NZBGet
         - Glances
+        - Speedtest Tracker
         - Beszel
         - dashdot
         - Something else

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Atrium
 
 The central courtyard for your self-hosted media stack.
-One Android app that fronts Sonarr, Radarr, Prowlarr, Bazarr,
+One Android app that fronts Sonarr, Radarr, Lidarr, Prowlarr, Bazarr,
 Seerr, Tautulli, Tracearr, Jellyfin, Emby, Plex, qBittorrent, Deluge,
 Transmission, rTorrent, SABnzbd, NZBGet, Glances, Speedtest Tracker, Beszel and dashdot - and routes every request through the right URL
 whether you're on the home Wi-Fi or out in the world.
@@ -55,6 +55,7 @@ each one covers:
 | ---------------------- | --------------------------------------------------------------------- |
 | Sonarr                 | 7 tabs incl. full Settings editor, sort/filter, calendar              |
 | Radarr                 | same depth as Sonarr, movie flavored                                  |
+| Lidarr                 | artists, albums and tracks, wanted, activity, settings, log reader (beta) |
 | Prowlarr               | indexers, search + grab, history, settings, system                    |
 | Bazarr                 | series/movies, wanted, manual subtitle search, system                 |
 | Seerr                  | discover, search, requests management                                 |
@@ -63,7 +64,7 @@ each one covers:
 | Jellyfin               | libraries, detail, seasons, music, sessions with remote control       |
 | Emby                   | same depth as Jellyfin                                                |
 | Plex                   | libraries, detail, seasons, music, genres, now-playing controller     |
-| qBittorrent            | realtime list, add/manage, torrent detail                             |
+| qBittorrent            | realtime list, add/manage, torrent detail, queue reorder, full settings |
 | Deluge                 | torrent list, add/manage, queue moves, speed limits, torrent detail   |
 | Transmission           | torrent list, add/manage, queue moves, turtle mode, torrent detail    |
 | rTorrent               | torrent list, add/manage, priorities, speed limits, torrent detail    |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Atrium - Status
 
-> Snapshot of what genuinely works and what is left, as of 2026-07-31.
+> Snapshot of what genuinely works and what is left, as of 2026-08-23.
 > Atrium is published on F-Droid and on the GitHub releases page. It is
 > still in early development and every module is work in progress; nothing
 > here is a release promise.
@@ -37,8 +37,14 @@ Atrium is a **controller** app. Video playback was removed by design
 - Core foundation: profiles, multi-instance, dual-URL routing, secure
   key storage, import/export, per-service health dots, theming
 - **qBittorrent**: cookie login (qBit 5.x 204 fix), 3s realtime polling,
-  add magnet/file, categories, pause/resume/delete/recheck/queue moves,
-  torrent detail (overview/files/trackers), per-file priority
+  add magnet/file (with skip hash check), categories, tag and tracker
+  filters, pause/resume/delete/recheck, queue moves and reordering
+  (top/up/down/bottom) with sort by queue position, torrent detail
+  (overview/files/trackers), per-file priority, and a settings screen
+  mirroring the web UI across nine tabs. The four settings that would cut
+  Atrium off from the server - web UI address and port, CSRF and
+  clickjacking protection - confirm before applying, because once the
+  address moves the app can no longer reach the server to undo it
 - **Sonarr** (the canonical *arr module): poster/banner grid with
   client-side sort & filter (status, network, airing, added, size on
   disk) and per-series disk sizes, series detail (fanart backdrop,
@@ -46,6 +52,16 @@ Atrium is a **controller** app. Video playback was removed by design
   blocklist/system tabs, and a full Settings editor (17 panels) -
   settings writes live-verified
 - **Radarr**: same depth as Sonarr, movie flavored
+- **Lidarr** (beta, added in 1.5.0): artists and discography with grid and
+  list views and bulk actions, artist detail with release-type filters,
+  album and track detail with a file inspector and single-track search,
+  album studio, track file rename/retag previews and manual import, wanted
+  (missing and cutoff unmet), queue/history/blocklist, the full settings
+  tree (profiles, download clients, indexers, import lists, notifications,
+  metadata, media management, quality definitions), system diagnostics and
+  an in-app log viewer with level filtering and search. Album releases also
+  appear in the shared calendar. Marked beta: it has not been exercised
+  against a live Lidarr for long
 - **Prowlarr**: indexers (add/edit/test from schema), manual search
   across indexers with grab-to-client, history, full settings menu,
   system

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -7,14 +7,14 @@ servers; it does not stream video.
 
 Supported services:
 
-* Sonarr and Radarr - library, queue, wanted, history, blocklist, system status
-  and the full settings tree
+* Sonarr, Radarr and Lidarr - library, queue, wanted, history, blocklist,
+  system status and the full settings tree
 * Prowlarr - indexers, search and grab
 * Bazarr - subtitle status, search and download
 * Seerr (Overseerr and Jellyseerr) - discover, request and manage requests
 * Tautulli - active streams, history, statistics and users
 * Tracearr - who is streaming across Plex, Jellyfin and Emby, watch and
-  library statistics, history and a streaming-location map
+  library statistics, history, a media catalog and policy incidents
 * qBittorrent, Deluge, Transmission and rTorrent - torrent lists, transfers
   and per-torrent files, peers and trackers
 * SABnzbd and NZBGet - usenet queue control and history

--- a/site/src/components/integrations.html
+++ b/site/src/components/integrations.html
@@ -9,6 +9,7 @@
         <h5 class="margin-bottom">The *arr Stack</h5>
         <ul style="list-style-type: none; padding-left: 0; line-height: 1.8;">
           <li><strong>Sonarr & Radarr:</strong> Full settings editor, calendar, advanced sorting, and filtering.</li>
+          <li><strong>Lidarr:</strong> Artists, albums and tracks, wanted, activity, settings, and an in-app log reader.</li>
           <li><strong>Prowlarr:</strong> Add indexers, manual search & grab, history, and system status.</li>
           <li><strong>Bazarr:</strong> Manage wanted subtitles, manual search, and provider details.</li>
         </ul>

--- a/site/src/components/marquee.html
+++ b/site/src/components/marquee.html
@@ -1,13 +1,14 @@
 <section class="padding-top padding-bottom" style="overflow: hidden;">
   <div class="center-align margin-bottom">
     <h2 class="section-title">One App for Everything</h2>
-    <p class="section-subtitle">Fully supporting 18 self-hosted essentials today. Click any service below to explore its tailored interface.</p>
+    <p class="section-subtitle">Fully supporting 21 self-hosted essentials today. Click any service below to explore its tailored interface.</p>
   </div>
   <div class="services-marquee">
     <div class="marquee-track">
       <!-- Set 1 -->
       <div class="chip large marquee-chip" data-service="sonarr"><img src="/assets/service_icons/sonarr.png" class="service-icon" alt="Sonarr">Sonarr</div>
       <div class="chip large marquee-chip" data-service="radarr"><img src="/assets/service_icons/radarr.png" class="service-icon" alt="Radarr">Radarr</div>
+      <div class="chip large marquee-chip" data-service="lidarr"><img src="/assets/service_icons/lidarr.png" class="service-icon" alt="Lidarr">Lidarr</div>
       <div class="chip large marquee-chip" data-service="prowlarr"><img src="/assets/service_icons/prowlarr.png" class="service-icon" alt="Prowlarr">Prowlarr</div>
       <div class="chip large marquee-chip" data-service="bazarr"><img src="/assets/service_icons/bazarr.png" class="service-icon" alt="Bazarr">Bazarr</div>
       <div class="chip large marquee-chip" data-service="seerr"><img src="/assets/service_icons/seerr.png" class="service-icon" alt="Seerr">Seerr</div>
@@ -27,6 +28,7 @@
       <!-- Set 2 -->
       <div class="chip large marquee-chip" data-service="sonarr"><img src="/assets/service_icons/sonarr.png" class="service-icon" alt="Sonarr">Sonarr</div>
       <div class="chip large marquee-chip" data-service="radarr"><img src="/assets/service_icons/radarr.png" class="service-icon" alt="Radarr">Radarr</div>
+      <div class="chip large marquee-chip" data-service="lidarr"><img src="/assets/service_icons/lidarr.png" class="service-icon" alt="Lidarr">Lidarr</div>
       <div class="chip large marquee-chip" data-service="prowlarr"><img src="/assets/service_icons/prowlarr.png" class="service-icon" alt="Prowlarr">Prowlarr</div>
       <div class="chip large marquee-chip" data-service="bazarr"><img src="/assets/service_icons/bazarr.png" class="service-icon" alt="Bazarr">Bazarr</div>
       <div class="chip large marquee-chip" data-service="seerr"><img src="/assets/service_icons/seerr.png" class="service-icon" alt="Seerr">Seerr</div>


### PR DESCRIPTION
Documentation for 1.5.0, which the release PR missed.

The tag `v1.5.0` currently points at a commit where every list of services still says twenty. Nothing is published yet, so the plan is to merge this and move the tag before signing, since F-Droid reads `fastlane/metadata/` from the tag and would otherwise ship a stale store description.

## Lidarr

Added to the README table and intro, to STATUS with what it actually covers, to the store description, and to the site in both the integrations card and the marquee.

## Drift fixed along the way

**The bug report template offered fourteen services.** Tracearr, Deluge, Transmission, rTorrent, NZBGet and Speedtest Tracker were all missing, so anyone reporting a bug against them had to pick "Something else". All are listed now.

**The store description still promised Tracearr had a streaming-location map.** That went when Tracearr was rebuilt on the public API.

**The site marquee claimed eighteen services** while the app shipped twenty. It now says twenty one. Beszel and dashdot are still absent from the marquee itself, because neither has an icon in `site/public/assets/service_icons`.

**qBittorrent was understated** in both the README and STATUS: those entries predate the settings screen, queue reordering, and the tracker and tag filters.

No code changes.