### PR TITLE
test(service_lidarr): cover interactive grab id fallback

### DIFF
--- a/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
@@ -240,6 +240,8 @@ class _LidarrInteractiveSearchScreenState
       final LidarrApi api =
           await ref.read(lidarrApiProvider(widget.instance).future);
       final ReleaseResource payload = release.copyWith(
+        // Search results have no database id, but Lidarr nightly still
+        // deserialises this field as Int32 before it validates the release.
         id: release.id ?? 0,
         albumId: release.albumId ?? widget.albumId,
         artistId: release.artistId ?? widget.artistId,

--- a/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
@@ -240,8 +240,11 @@ class _LidarrInteractiveSearchScreenState
       final LidarrApi api =
           await ref.read(lidarrApiProvider(widget.instance).future);
       final ReleaseResource payload = release.copyWith(
-        // Search results have no database id, but Lidarr nightly still
-        // deserialises this field as Int32 before it validates the release.
+        // A search result carries no id of its own, and Lidarr deserialises
+        // this as a non-nullable int before it validates anything, so a null
+        // fails the request outright. That is true of every branch, not just
+        // nightly. LidarrApi strips nulls as well, but this path is explicit
+        // about it because it is the one that always relies on it.
         id: release.id ?? 0,
         albumId: release.albumId ?? widget.albumId,
         artistId: release.artistId ?? widget.artistId,

--- a/services/service_lidarr/test/features/activity_feature_test.dart
+++ b/services/service_lidarr/test/features/activity_feature_test.dart
@@ -122,6 +122,8 @@ void main() {
       expect(postGrabCalled, isTrue);
       expect(grabbedPayload?['guid'], equals('release-guid-1'));
       expect(grabbedPayload?['indexerId'], equals(1));
+      expect(grabbedPayload?['id'], equals(0));
+      expect(grabbedPayload?['id'], isA<int>());
 
       // Grab rejected release -> should show confirmation dialog
       postGrabCalled = false;
@@ -138,6 +140,8 @@ void main() {
       expect(postGrabCalled, isTrue);
       expect(grabbedPayload?['guid'], equals('release-guid-2'));
       expect(grabbedPayload?['indexerId'], equals(2));
+      expect(grabbedPayload?['id'], equals(0));
+      expect(grabbedPayload?['id'], isA<int>());
     });
 
     testWidgets(


### PR DESCRIPTION
Interactive search results can omit a database id, but Lidarr nightly deserialises ReleaseResource.id as Int32 before validating the release. Assert that normal and force-grab requests send the integer sentinel zero, and document why the fallback must remain.

Refs #134.