### PR TITLE
Release 1.5.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Atrium version
       description: Settings, then About.
-      placeholder: "1.5.0"
+      placeholder: "1.5.1"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ whether you're on the home Wi-Fi or out in the world.
 
 **[Website][site]** - screenshots and a tour, no install needed.
 
-> **Status:** v1.5.0. Install from [F-Droid][fdroid], or grab a signed APK
+> **Status:** v1.5.1. Install from [F-Droid][fdroid], or grab a signed APK
 > from the [releases page][releases].
 
 ## Why

--- a/app/lib/src/screens/changelog/release_notes.dart
+++ b/app/lib/src/screens/changelog/release_notes.dart
@@ -27,6 +27,20 @@ class ReleaseNote {
 /// Newest first. Update alongside appVersion and the pubspec at each release.
 const List<ReleaseNote> releaseNotes = <ReleaseNote>[
   ReleaseNote(
+    version: '1.5.1',
+    date: '2026-08-26',
+    groups: <ChangeGroup>[
+      ChangeGroup(ChangeCategory.fixed, <String>[
+        'Adding things in Lidarr works again. Adding an artist, indexer, download client, import list, notification, tag, root folder, custom format or any of the profiles was refused by the server, as was grabbing a release from an interactive search. Atrium was sending empty fields that Lidarr will not accept, and it rejected the whole request without saying which part it disliked.',
+        'Interactive search no longer fails on Lidarr nightly and on builds with plugins installed. Those versions name their download protocols differently, and a single name Atrium did not recognise discarded the entire list of results rather than that one field.',
+        'Lidarr screens no longer run off the edge at large system text sizes, in the track file editor, the unmapped files list and artist history.',
+      ]),
+      ChangeGroup(ChangeCategory.improved, <String>[
+        'Lidarr activity history keeps loading as you scroll instead of stopping at the first page.',
+      ]),
+    ],
+  ),
+  ReleaseNote(
     version: '1.5.0',
     date: '2026-08-23',
     groups: <ChangeGroup>[

--- a/app/lib/src/update_check/app_version.dart
+++ b/app/lib/src/update_check/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Source of truth for the update check and the Settings version line. Bump
 /// this at release time together with pubspec.
-const String appVersion = '1.5.0';
+const String appVersion = '1.5.1';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.5.0+19
+version: 1.5.1+20
 
 environment:
   sdk: ^3.6.0

--- a/fastlane/metadata/android/en-US/changelogs/20.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20.txt
@@ -1,0 +1,12 @@
+Adding things in Lidarr works again. Adding an artist, indexer, download client,
+import list, notification, tag, root folder, custom format or any of the
+profiles was refused by the server, as was grabbing a release from an
+interactive search.
+
+Interactive search no longer fails on Lidarr nightly and on builds with plugins
+installed. Those versions name their download protocols differently, and one
+name Atrium did not recognise discarded the whole list of results.
+
+Lidarr screens no longer run off the edge at large system text sizes, and
+activity history keeps loading as you scroll instead of stopping at the first
+page.

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -43,12 +43,10 @@ never reports anything back to its developers. Credentials are held in
 encrypted storage on the device.
 
 Artwork is loaded from your own servers, which cache it, rather than from
-sites like TheTVDB or TMDB. There are two exceptions, and both are worth
-knowing about. Searching for something to add that your servers have never
-seen has nothing cached for it yet, so its poster comes from the artwork site
-directly, which then sees your address. And Tracearr's streaming-location map
-draws its map tiles from CARTO, so opening that map tells CARTO your address
-and roughly which part of the world you are looking at. Everything else goes
-only to the servers you configure.
+sites like TheTVDB or TMDB. There is one exception worth knowing about.
+Searching for something to add that your servers have never seen has nothing
+cached for it yet, so its poster comes from the artwork site directly, which
+then sees your address. Everything else goes only to the servers you
+configure.
 
 Free software under the GPL-3.0-or-later.

--- a/services/service_lidarr/lib/src/core/lidarr_formatters.dart
+++ b/services/service_lidarr/lib/src/core/lidarr_formatters.dart
@@ -94,4 +94,17 @@ class LidarrFormatters {
     }
     return '$trimmed Hz';
   }
+
+  /// Formats raw C# backend wire enum strings (e.g. 'torrentDownloadProtocol' -> 'TORRENT', 'usenetDownloadProtocol' -> 'USENET').
+  static String formatWireEnum(String? raw) {
+    if (raw == null || raw.isEmpty) return '--';
+    String s = raw;
+    if (s.toLowerCase().endsWith('downloadprotocol')) {
+      s = s.substring(0, s.length - 'downloadprotocol'.length);
+    } else if (s.toLowerCase().endsWith('protocol')) {
+      s = s.substring(0, s.length - 'protocol'.length);
+    }
+    return s.toUpperCase();
+  }
 }
+

--- a/services/service_lidarr/lib/src/features/activity/providers/activity_providers.dart
+++ b/services/service_lidarr/lib/src/features/activity/providers/activity_providers.dart
@@ -23,22 +23,52 @@ final lidarrQueueProvider =
   return page.records ?? <QueueResource>[];
 });
 
-/// Activity history for an instance.
+/// Paginated activity history provider. Key is `(Instance, {int page, int pageSize, List<int>? eventType})`.
+final lidarrHistoryPagedProvider = FutureProvider.family<
+    HistoryResourcePagingResource,
+    (Instance, {int page, int pageSize, List<int>? eventType})>(
+  (
+    Ref ref,
+    (Instance, {int page, int pageSize, List<int>? eventType}) key,
+  ) async {
+    final (
+      Instance instance,
+      page: int page,
+      pageSize: int pageSize,
+      eventType: List<int>? eventType,
+    ) = key;
+    final LidarrApi api = await ref.watch(lidarrApiProvider(instance).future);
+    final ApiResponse<HistoryResourcePagingResource> resp =
+        await api.history.getHistory(
+      page: page,
+      pageSize: pageSize,
+      eventType: eventType,
+      sortKey: 'date',
+      sortDirection: SortDirection.descending,
+      includeArtist: true,
+      includeAlbum: true,
+      includeTrack: true,
+    );
+    return unwrapLidarrApiResponse(resp, 'Failed to load activity history');
+  },
+);
+
+/// Activity history for an instance (initial 50 records).
 final lidarrHistoryProvider =
     FutureProvider.autoDispose.family<List<HistoryResource>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
-  final LidarrApi api = await ref.watch(lidarrApiProvider(instance).future);
-  final ApiResponse<HistoryResourcePagingResource> resp =
-      await api.history.getHistory(
-    pageSize: 50,
-    includeArtist: true,
-    includeAlbum: true,
-    includeTrack: true,
+  final HistoryResourcePagingResource page = await ref.watch(
+    lidarrHistoryPagedProvider(
+      (
+        instance,
+        page: 1,
+        pageSize: 50,
+        eventType: null,
+      ),
+    ).future,
   );
-  final HistoryResourcePagingResource page =
-      unwrapLidarrApiResponse(resp, 'Failed to load activity history');
   return page.records ?? <HistoryResource>[];
 });
 

--- a/services/service_lidarr/lib/src/features/activity/views/history_view.dart
+++ b/services/service_lidarr/lib/src/features/activity/views/history_view.dart
@@ -1,4 +1,5 @@
 import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -7,17 +8,123 @@ import '../../../generated/generated.dart';
 import '../../../lidarr_api.dart';
 import '../../../lidarr_providers.dart';
 
-/// Activity history view with event filtering, chronological grouping, and deep event details inspection.
+/// Activity history view with event filtering, chronological grouping, deep event details inspection, and infinite scroll pagination.
 class HistoryView extends ConsumerStatefulWidget {
   const HistoryView({required this.instance, super.key});
 
   final Instance instance;
 
   @override
-  ConsumerState<HistoryView> createState() => _HistoryViewState();
+  ConsumerState<HistoryView> createState() => HistoryViewState();
 }
 
-class _HistoryViewState extends ConsumerState<HistoryView> {
+class HistoryViewState extends ConsumerState<HistoryView>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  List<HistoryResource> _history = <HistoryResource>[];
+  int _currentPage = 1;
+  static const int _pageSize = 50;
+  bool _hasMore = true;
+  bool _loading = false;
+  Object? _error;
+
+  /// Programmatic initial load / refresh.
+  Future<void> loadInitial() => _loadInitial();
+
+  /// Programmatic pagination load more.
+  Future<void> loadMore() => _loadMore();
+
+  /// Total records currently loaded in memory.
+  int get totalLoaded => _history.length;
+
+  /// Current pagination page.
+  int get currentPage => _currentPage;
+
+  /// Whether additional pages can be fetched.
+  bool get hasMore => _hasMore;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _loadInitial();
+    });
+  }
+
+  Future<void> _loadInitial() async {
+    if (!mounted) return;
+    setState(() {
+      _loading = true;
+      _error = null;
+      _currentPage = 1;
+    });
+
+    try {
+      final HistoryResourcePagingResource data = await ref.refresh(
+        lidarrHistoryPagedProvider(
+          (
+            widget.instance,
+            page: 1,
+            pageSize: _pageSize,
+            eventType: null,
+          ),
+        ).future,
+      );
+
+      final List<HistoryResource> records =
+          data.records ?? <HistoryResource>[];
+      final int totalRecords = data.totalRecords ?? 0;
+
+      if (mounted) {
+        setState(() {
+          _history = List<HistoryResource>.from(records);
+          _hasMore = _history.length < totalRecords;
+          _loading = false;
+        });
+      }
+    } catch (err) {
+      if (mounted) {
+        setState(() {
+          _error = err;
+          _loading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (!_hasMore || _loading) return;
+    try {
+      final int nextPage = _currentPage + 1;
+      final HistoryResourcePagingResource data = await ref.read(
+        lidarrHistoryPagedProvider(
+          (
+            widget.instance,
+            page: nextPage,
+            pageSize: _pageSize,
+            eventType: null,
+          ),
+        ).future,
+      );
+
+      final List<HistoryResource> records =
+          data.records ?? <HistoryResource>[];
+      final int totalRecords = data.totalRecords ?? 0;
+
+      if (mounted) {
+        setState(() {
+          _history = <HistoryResource>[..._history, ...records];
+          _currentPage = nextPage;
+          _hasMore = _history.length < totalRecords;
+        });
+      }
+    } catch (e) {
+      // Soft fail on pagination
+    }
+  }
+
   IconData _getEventIcon(EntityHistoryEventType? eventType) {
     switch (eventType) {
       case EntityHistoryEventType.grabbed:
@@ -96,7 +203,7 @@ class _HistoryViewState extends ConsumerState<HistoryView> {
         throw Exception(resp.error?.message ?? 'Failed to mark as failed');
       }
 
-      ref.invalidate(lidarrHistoryProvider(widget.instance));
+      await _loadInitial();
       ref.invalidate(lidarrQueueProvider(widget.instance));
       ref.invalidate(lidarrBlocklistProvider(widget.instance));
 
@@ -352,10 +459,9 @@ class _HistoryViewState extends ConsumerState<HistoryView> {
 
   @override
   Widget build(BuildContext context) {
+    super.build(context);
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
-    final AsyncValue<List<HistoryResource>> asyncHistory =
-        ref.watch(lidarrHistoryProvider(widget.instance));
     final String filterQuery =
         ref.watch(lidarrActivitySearchQueryProvider(widget.instance));
     final bool grouped =
@@ -363,38 +469,68 @@ class _HistoryViewState extends ConsumerState<HistoryView> {
     final EntityHistoryEventType? activeFilter =
         ref.watch(lidarrHistoryEventTypeFilterProvider(widget.instance));
 
-    return asyncHistory.when(
-      data: (List<HistoryResource> rawHistory) {
-        List<HistoryResource> history = rawHistory;
+    if (_loading && _history.isEmpty) {
+      return const Center(child: ExpressiveProgressIndicator());
+    }
 
-        // Filter by event type
-        if (activeFilter != null) {
-          history = history.where((HistoryResource item) {
-            if (activeFilter == EntityHistoryEventType.downloadImported) {
-              return item.eventType ==
-                      EntityHistoryEventType.downloadImported ||
-                  item.eventType == EntityHistoryEventType.trackFileImported ||
-                  item.eventType == EntityHistoryEventType.artistFolderImported;
-            }
-            return item.eventType == activeFilter;
-          }).toList();
+    if (_error != null && _history.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            Icon(Icons.error_outline, size: 48, color: cs.error),
+            const SizedBox(height: 12),
+            Text(
+              'Failed to load history',
+              style: theme.textTheme.titleMedium?.copyWith(
+                color: cs.error,
+              ),
+            ),
+            const SizedBox(height: 8),
+            FilledButton.tonal(
+              onPressed: _loadInitial,
+              child: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    List<HistoryResource> history = _history;
+
+    // Filter by event type
+    if (activeFilter != null) {
+      history = history.where((HistoryResource item) {
+        if (activeFilter == EntityHistoryEventType.downloadImported) {
+          return item.eventType ==
+                  EntityHistoryEventType.downloadImported ||
+              item.eventType == EntityHistoryEventType.trackFileImported ||
+              item.eventType == EntityHistoryEventType.artistFolderImported;
         }
+        return item.eventType == activeFilter;
+      }).toList();
+    }
 
-        // Filter by query
-        if (filterQuery.trim().isNotEmpty) {
-          final String q = filterQuery.trim().toLowerCase();
-          history = history.where((HistoryResource item) {
-            final String sourceTitle = (item.sourceTitle ?? '').toLowerCase();
-            final String artist = (item.artist?.artistName ?? '').toLowerCase();
-            final String album = (item.album?.title ?? '').toLowerCase();
-            return sourceTitle.contains(q) ||
-                artist.contains(q) ||
-                album.contains(q);
-          }).toList();
-        }
+    // Filter by query
+    if (filterQuery.trim().isNotEmpty) {
+      final String q = filterQuery.trim().toLowerCase();
+      history = history.where((HistoryResource item) {
+        final String sourceTitle = (item.sourceTitle ?? '').toLowerCase();
+        final String artist = (item.artist?.artistName ?? '').toLowerCase();
+        final String album = (item.album?.title ?? '').toLowerCase();
+        return sourceTitle.contains(q) ||
+            artist.contains(q) ||
+            album.contains(q);
+      }).toList();
+    }
 
-        if (history.isEmpty) {
-          return Center(
+    Widget content;
+    if (history.isEmpty) {
+      content = ListView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        children: <Widget>[
+          const SizedBox(height: 100),
+          Center(
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
               children: <Widget>[
@@ -416,79 +552,61 @@ class _HistoryViewState extends ConsumerState<HistoryView> {
                 ),
               ],
             ),
-          );
-        }
+          ),
+        ],
+      );
+    } else if (!grouped) {
+      content = ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: history.length,
+        itemBuilder: (BuildContext context, int index) {
+          final HistoryResource item = history[index];
+          return _buildHistoryCard(item, theme, cs);
+        },
+      );
+    } else {
+      // Chronological section grouping
+      final Map<String, List<HistoryResource>> sections =
+          <String, List<HistoryResource>>{};
+      for (final item in history) {
+        final String sec = _getDateSection(item.date);
+        sections.putIfAbsent(sec, () => <HistoryResource>[]).add(item);
+      }
 
-        if (!grouped) {
-          return ListView.builder(
-            padding: const EdgeInsets.symmetric(vertical: 8),
-            itemCount: history.length,
-            itemBuilder: (BuildContext context, int index) {
-              final HistoryResource item = history[index];
-              return _buildHistoryCard(item, theme, cs);
-            },
-          );
-        }
+      final List<String> sectionKeys = sections.keys.toList();
 
-        // Chronological section grouping
-        final Map<String, List<HistoryResource>> sections =
-            <String, List<HistoryResource>>{};
-        for (final item in history) {
-          final String sec = _getDateSection(item.date);
-          sections.putIfAbsent(sec, () => <HistoryResource>[]).add(item);
-        }
+      content = ListView.builder(
+        padding: const EdgeInsets.symmetric(vertical: 8),
+        itemCount: sectionKeys.length,
+        itemBuilder: (BuildContext context, int sIdx) {
+          final String sectionTitle = sectionKeys[sIdx];
+          final List<HistoryResource> sectionItems = sections[sectionTitle]!;
 
-        final List<String> sectionKeys = sections.keys.toList();
-
-        return ListView.builder(
-          padding: const EdgeInsets.symmetric(vertical: 8),
-          itemCount: sectionKeys.length,
-          itemBuilder: (BuildContext context, int sIdx) {
-            final String sectionTitle = sectionKeys[sIdx];
-            final List<HistoryResource> sectionItems = sections[sectionTitle]!;
-
-            return Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
-                  child: Text(
-                    sectionTitle,
-                    style: theme.textTheme.titleSmall?.copyWith(
-                      fontWeight: FontWeight.bold,
-                      color: cs.primary,
-                    ),
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.fromLTRB(16, 12, 16, 6),
+                child: Text(
+                  sectionTitle,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.bold,
+                    color: cs.primary,
                   ),
                 ),
-                for (final item in sectionItems)
-                  _buildHistoryCard(item, theme, cs),
-              ],
-            );
-          },
-        );
-      },
-      loading: () => const Center(child: CircularProgressIndicator()),
-      error: (Object error, StackTrace stack) => Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            Icon(Icons.error_outline, size: 48, color: cs.error),
-            const SizedBox(height: 12),
-            Text(
-              'Failed to load history',
-              style: theme.textTheme.titleMedium?.copyWith(
-                color: cs.error,
               ),
-            ),
-            const SizedBox(height: 8),
-            FilledButton.tonal(
-              onPressed: () =>
-                  ref.invalidate(lidarrHistoryProvider(widget.instance)),
-              child: const Text('Retry'),
-            ),
-          ],
-        ),
-      ),
+              for (final item in sectionItems)
+                _buildHistoryCard(item, theme, cs),
+            ],
+          );
+        },
+      );
+    }
+
+    return EasyRefresh(
+      onRefresh: _loadInitial,
+      onLoad: _hasMore ? _loadMore : null,
+      child: content,
     );
   }
 

--- a/services/service_lidarr/lib/src/features/activity/views/queue_view.dart
+++ b/services/service_lidarr/lib/src/features/activity/views/queue_view.dart
@@ -23,6 +23,8 @@ class QueueView extends ConsumerStatefulWidget {
 }
 
 class _QueueViewState extends ConsumerState<QueueView> {
+  bool _showAllStatusMessages = false;
+
   Future<void> _removeQueueItem(QueueResource item) async {
     final int? id = item.id;
     if (id == null) return;
@@ -397,48 +399,44 @@ class _QueueViewState extends ConsumerState<QueueView> {
                 const SizedBox(height: 16),
 
                 // Quick Action Buttons
-                Row(
+                Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
                   children: <Widget>[
-                    Expanded(
-                      child: FilledButton.icon(
-                        icon: const Icon(
-                          Icons.drive_folder_upload_outlined,
-                          size: 18,
-                        ),
-                        label: const Text('Manual Import'),
+                    FilledButton.icon(
+                      icon: const Icon(
+                        Icons.drive_folder_upload_outlined,
+                        size: 18,
+                      ),
+                      label: const Text('Manual Import'),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                        showLidarrManualImportFlow(
+                          context,
+                          ref,
+                          widget.instance,
+                          downloadId: item.downloadId,
+                          artistId: item.artistId,
+                        );
+                      },
+                    ),
+                    if (item.albumId != null)
+                      OutlinedButton.icon(
+                        icon: const Icon(Icons.search, size: 18),
+                        label: const Text('Interactive Search'),
                         onPressed: () {
                           Navigator.of(context).pop();
-                          showLidarrManualImportFlow(
-                            context,
-                            ref,
-                            widget.instance,
-                            downloadId: item.downloadId,
-                            artistId: item.artistId,
+                          Navigator.of(context).push(
+                            MaterialPageRoute<void>(
+                              builder: (_) => LidarrInteractiveSearchScreen(
+                                instance: widget.instance,
+                                title: item.album?.title ?? 'Album',
+                                albumId: item.albumId,
+                              ),
+                            ),
                           );
                         },
                       ),
-                    ),
-                    if (item.albumId != null) ...[
-                      const SizedBox(width: 8),
-                      Expanded(
-                        child: OutlinedButton.icon(
-                          icon: const Icon(Icons.search, size: 18),
-                          label: const Text('Interactive Search'),
-                          onPressed: () {
-                            Navigator.of(context).pop();
-                            Navigator.of(context).push(
-                              MaterialPageRoute<void>(
-                                builder: (_) => LidarrInteractiveSearchScreen(
-                                  instance: widget.instance,
-                                  title: item.album?.title ?? 'Album',
-                                  albumId: item.albumId,
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ],
                   ],
                 ),
                 const SizedBox(height: 16),
@@ -478,7 +476,7 @@ class _QueueViewState extends ConsumerState<QueueView> {
                         const Divider(height: 12),
                         _buildDetailRow(
                           'Protocol',
-                          item.protocol?.value.toUpperCase() ?? '--',
+                          LidarrFormatters.formatWireEnum(item.protocol?.value),
                           context,
                         ),
                         const Divider(height: 12),
@@ -531,51 +529,85 @@ class _QueueViewState extends ConsumerState<QueueView> {
                     ),
                   ),
                   const SizedBox(height: 8),
-                  Card(
-                    elevation: 0,
-                    color: cs.surfaceContainerLow,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(12),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          for (final msg in item.statusMessages!) ...[
-                            Text(
-                              msg.title ?? 'Message',
-                              style: const TextStyle(
-                                fontWeight: FontWeight.bold,
-                                fontSize: 13,
-                              ),
-                            ),
-                            if (msg.messages != null)
-                              for (final m in msg.messages!)
-                                Padding(
-                                  padding: const EdgeInsets.only(
-                                    top: 4,
-                                    left: 8,
-                                  ),
-                                  child: Row(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: <Widget>[
-                                      const Text('• '),
-                                      Expanded(
-                                        child: Text(
-                                          m,
-                                          style: const TextStyle(fontSize: 12),
-                                        ),
-                                      ),
-                                    ],
+                  StatefulBuilder(
+                    builder: (BuildContext context, StateSetter setCardState) {
+                      final List<TrackedDownloadStatusMessage> messages =
+                          item.statusMessages!;
+                      final bool canExpand = messages.length > 3;
+                      final List<TrackedDownloadStatusMessage> visible =
+                          (!canExpand || _showAllStatusMessages)
+                              ? messages
+                              : messages.take(3).toList();
+
+                      return Card(
+                        elevation: 0,
+                        color: cs.surfaceContainerLow,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(12),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: <Widget>[
+                              for (final msg in visible) ...[
+                                Text(
+                                  msg.title ?? 'Message',
+                                  style: const TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                    fontSize: 13,
                                   ),
                                 ),
-                            const SizedBox(height: 8),
-                          ],
-                        ],
-                      ),
-                    ),
+                                if (msg.messages != null)
+                                  for (final m in msg.messages!)
+                                    Padding(
+                                      padding: const EdgeInsets.only(
+                                        top: 4,
+                                        left: 8,
+                                      ),
+                                      child: Row(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: <Widget>[
+                                          const Text('• '),
+                                          Expanded(
+                                            child: Text(
+                                              m,
+                                              style:
+                                                  const TextStyle(fontSize: 12),
+                                            ),
+                                          ),
+                                        ],
+                                      ),
+                                    ),
+                                const SizedBox(height: 8),
+                              ],
+                              if (canExpand)
+                                Center(
+                                  child: TextButton(
+                                    onPressed: () {
+                                      setCardState(() {
+                                        _showAllStatusMessages =
+                                            !_showAllStatusMessages;
+                                      });
+                                    },
+                                    child: Text(
+                                      _showAllStatusMessages
+                                          ? 'Show less'
+                                          : 'Show all ${messages.length} messages',
+                                      style: TextStyle(
+                                        fontSize: 12,
+                                        color: cs.primary,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    ),
+                                  ),
+                                ),
+                            ],
+                          ),
+                        ),
+                      );
+                    },
                   ),
                 ],
                 const SizedBox(height: 24),
@@ -987,8 +1019,9 @@ class _QueueItemRow extends StatelessWidget {
     final double progress =
         size > 0 ? ((size - sizeLeft) / size).clamp(0.0, 1.0) : 0.0;
 
-    final String protocolStr =
-        (item.protocol?.name ?? 'download').toUpperCase();
+    final String protocolStr = LidarrFormatters.formatWireEnum(
+      item.protocol?.value ?? item.protocol?.name,
+    );
     final String qualityName = item.quality?.quality?.name ?? 'Unknown';
     final bool hasError =
         item.trackedDownloadStatus == TrackedDownloadStatus.warning ||
@@ -1024,7 +1057,10 @@ class _QueueItemRow extends StatelessWidget {
                     overflow: TextOverflow.ellipsis,
                   ),
                   const SizedBox(height: 2),
-                  Row(
+                  Wrap(
+                    spacing: 6,
+                    runSpacing: 2,
+                    crossAxisAlignment: WrapCrossAlignment.center,
                     children: <Widget>[
                       Container(
                         padding: const EdgeInsets.symmetric(
@@ -1044,7 +1080,6 @@ class _QueueItemRow extends StatelessWidget {
                           ),
                         ),
                       ),
-                      const SizedBox(width: 6),
                       Container(
                         padding: const EdgeInsets.symmetric(
                           horizontal: 5,
@@ -1063,7 +1098,6 @@ class _QueueItemRow extends StatelessWidget {
                           ),
                         ),
                       ),
-                      const SizedBox(width: 8),
                       Text(
                         '${LidarrFormatters.formatBytes(size - sizeLeft)} / ${LidarrFormatters.formatBytes(size)}',
                         style: theme.textTheme.labelSmall?.copyWith(

--- a/services/service_lidarr/lib/src/features/artists/add_artist_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/artists/add_artist_search_screen.dart
@@ -330,83 +330,70 @@ class _LidarrAddArtistSearchScreenState
                                           ],
                                         ),
                                         const SizedBox(height: Insets.sm),
-                                        Row(
-                                          mainAxisAlignment:
-                                              MainAxisAlignment.spaceBetween,
+                                        Wrap(
+                                          spacing: 6,
+                                          runSpacing: 6,
+                                          crossAxisAlignment:
+                                              WrapCrossAlignment.center,
+                                          alignment: WrapAlignment.spaceBetween,
                                           children: [
-                                            Wrap(
-                                              spacing: 6,
-                                              runSpacing: 4,
-                                              crossAxisAlignment:
-                                                  WrapCrossAlignment.center,
-                                              children: [
-                                                if (artist.artistType != null &&
-                                                    artist
-                                                        .artistType!.isNotEmpty)
-                                                  Container(
-                                                    padding: const EdgeInsets
-                                                        .symmetric(
-                                                      horizontal: 7,
-                                                      vertical: 2,
-                                                    ),
-                                                    decoration: BoxDecoration(
-                                                      color: cs
-                                                          .surfaceContainerHighest,
-                                                      borderRadius:
-                                                          BorderRadius.circular(
-                                                        6,
-                                                      ),
-                                                    ),
-                                                    child: Text(
-                                                      artist.artistType!,
-                                                      style: theme
-                                                          .textTheme.bodySmall
-                                                          ?.copyWith(
-                                                        color:
-                                                            cs.onSurfaceVariant,
-                                                        fontWeight:
-                                                            FontWeight.w600,
-                                                        fontSize: 10.5,
-                                                      ),
-                                                    ),
+                                            if (artist.artistType != null &&
+                                                artist.artistType!.isNotEmpty)
+                                              Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                  horizontal: 7,
+                                                  vertical: 2,
+                                                ),
+                                                decoration: BoxDecoration(
+                                                  color: cs
+                                                      .surfaceContainerHighest,
+                                                  borderRadius:
+                                                      BorderRadius.circular(6),
+                                                ),
+                                                child: Text(
+                                                  artist.artistType!,
+                                                  style: theme
+                                                      .textTheme.bodySmall
+                                                      ?.copyWith(
+                                                    color: cs.onSurfaceVariant,
+                                                    fontWeight: FontWeight.w600,
+                                                    fontSize: 10.5,
                                                   ),
-                                                // Status Chip
-                                                if (artist.status != null)
-                                                  Container(
-                                                    padding: const EdgeInsets
-                                                        .symmetric(
-                                                      horizontal: 7,
-                                                      vertical: 2,
-                                                    ),
-                                                    decoration: BoxDecoration(
-                                                      color: _statusColor(
-                                                        artist.status!.value,
-                                                        theme,
-                                                      ).withValues(alpha: 0.15),
-                                                      borderRadius:
-                                                          BorderRadius.circular(
-                                                        6,
-                                                      ),
-                                                    ),
-                                                    child: Text(
-                                                      _capitalise(
-                                                        artist.status!.value,
-                                                      ),
-                                                      style: theme
-                                                          .textTheme.bodySmall
-                                                          ?.copyWith(
-                                                        color: _statusColor(
-                                                          artist.status!.value,
-                                                          theme,
-                                                        ),
-                                                        fontWeight:
-                                                            FontWeight.w600,
-                                                        fontSize: 10.5,
-                                                      ),
-                                                    ),
+                                                ),
+                                              ),
+                                            // Status Chip
+                                            if (artist.status != null)
+                                              Container(
+                                                padding:
+                                                    const EdgeInsets.symmetric(
+                                                  horizontal: 7,
+                                                  vertical: 2,
+                                                ),
+                                                decoration: BoxDecoration(
+                                                  color: _statusColor(
+                                                    artist.status!.value,
+                                                    theme,
+                                                  ).withValues(alpha: 0.15),
+                                                  borderRadius:
+                                                      BorderRadius.circular(6),
+                                                ),
+                                                child: Text(
+                                                  _capitalise(
+                                                    artist.status!.value,
                                                   ),
-                                              ],
-                                            ),
+                                                  style: theme
+                                                      .textTheme.bodySmall
+                                                      ?.copyWith(
+                                                    color: _statusColor(
+                                                      artist.status!.value,
+                                                      theme,
+                                                    ),
+                                                    fontWeight: FontWeight.w600,
+                                                    fontSize: 10.5,
+                                                  ),
+                                                ),
+                                              ),
                                             // Added / Not Added indicator
                                             if (isAdded)
                                               Container(

--- a/services/service_lidarr/lib/src/features/artists/add_artist_sheet.dart
+++ b/services/service_lidarr/lib/src/features/artists/add_artist_sheet.dart
@@ -883,6 +883,7 @@ class _LidarrAddArtistSheetState extends ConsumerState<LidarrAddArtistSheet> {
           await ref.read(lidarrApiProvider(widget.instance).future);
 
       final ArtistResource payload = widget.artist.copyWith(
+        id: 0,
         rootFolderPath: rootFolder,
         qualityProfileId: qualityProfileId,
         metadataProfileId: metadataProfileId,

--- a/services/service_lidarr/lib/src/features/artists/dialogs/bulk_delete_dialog.dart
+++ b/services/service_lidarr/lib/src/features/artists/dialogs/bulk_delete_dialog.dart
@@ -39,6 +39,8 @@ class _BulkDeleteDialogState extends ConsumerState<BulkDeleteDialog> {
         artistIds: widget.selectedIds.toList(),
         deleteFiles: _deleteFiles,
         addImportListExclusion: _addImportListExclusion,
+        moveFiles: false,
+        applyTags: ApplyTags.add,
       );
 
       final ApiResponse<void> resp =

--- a/services/service_lidarr/lib/src/features/artists/dialogs/bulk_edit_dialog.dart
+++ b/services/service_lidarr/lib/src/features/artists/dialogs/bulk_edit_dialog.dart
@@ -47,6 +47,9 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
         metadataProfileId: _metadataProfileId,
         rootFolderPath: _rootFolderPath,
         moveFiles: _moveFiles,
+        deleteFiles: false,
+        addImportListExclusion: false,
+        applyTags: ApplyTags.add,
       );
 
       final ApiResponse<void> resp =
@@ -101,15 +104,16 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
         ref.watch(lidarrRootFoldersProvider(widget.instance));
 
     return AlertDialog(
+      scrollable: true,
       title:
           Text('Edit ${widget.selectedIds.length} ${_selectedIdsCountLabel()}'),
-      content: SingleChildScrollView(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
             const SizedBox(height: Insets.xs),
             // Monitored
             DropdownButtonFormField<bool?>(
+              isExpanded: true,
               initialValue: _monitored,
               decoration: const InputDecoration(
                 labelText: 'Monitored',
@@ -125,6 +129,7 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
             const SizedBox(height: Insets.md),
             // Monitor New Items
             DropdownButtonFormField<NewItemMonitorTypes?>(
+              isExpanded: true,
               initialValue: _monitorNewItems,
               decoration: const InputDecoration(
                 labelText: 'Monitor New Items',
@@ -151,6 +156,7 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
             // Quality Profile
             qualityProfilesAsync.when(
               data: (profiles) => DropdownButtonFormField<int?>(
+                isExpanded: true,
                 initialValue: _qualityProfileId,
                 decoration: const InputDecoration(
                   labelText: 'Quality Profile',
@@ -177,6 +183,7 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
             // Metadata Profile
             metadataProfilesAsync.when(
               data: (profiles) => DropdownButtonFormField<int?>(
+                isExpanded: true,
                 initialValue: _metadataProfileId,
                 decoration: const InputDecoration(
                   labelText: 'Metadata Profile',
@@ -205,6 +212,7 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
               data: (folders) => Column(
                 children: [
                   DropdownButtonFormField<String?>(
+                    isExpanded: true,
                     initialValue: _rootFolderPath,
                     decoration: const InputDecoration(
                       labelText: 'Root Folder',
@@ -248,7 +256,6 @@ class _BulkEditDialogState extends ConsumerState<BulkEditDialog> {
             ),
           ],
         ),
-      ),
       actions: [
         TextButton(
           onPressed: _submitting ? null : () => Navigator.of(context).pop(),

--- a/services/service_lidarr/lib/src/features/artists/dialogs/bulk_tags_dialog.dart
+++ b/services/service_lidarr/lib/src/features/artists/dialogs/bulk_tags_dialog.dart
@@ -39,6 +39,9 @@ class _BulkTagsDialogState extends ConsumerState<BulkTagsDialog> {
         artistIds: widget.selectedIds.toList(),
         tags: _selectedTagIds.toList(),
         applyTags: _applyMode,
+        moveFiles: false,
+        deleteFiles: false,
+        addImportListExclusion: false,
       );
 
       final ApiResponse<void> resp =

--- a/services/service_lidarr/lib/src/features/artists/views/artist_history_view.dart
+++ b/services/service_lidarr/lib/src/features/artists/views/artist_history_view.dart
@@ -612,6 +612,8 @@ class _ArtistHistoryViewState extends ConsumerState<ArtistHistoryView>
                       style: theme.textTheme.bodySmall?.copyWith(
                         color: cs.onSurfaceVariant,
                       ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                     ),
                 ],
               ),
@@ -1041,12 +1043,16 @@ class _ArtistHistoryViewState extends ConsumerState<ArtistHistoryView>
                                         const SizedBox(height: 4),
                                         Row(
                                           children: [
-                                            Text(
-                                              item.eventType?.value ?? 'Event',
-                                              style: theme.textTheme.bodySmall
-                                                  ?.copyWith(
-                                                color: cs.onSurfaceVariant,
-                                                fontWeight: FontWeight.w500,
+                                            Flexible(
+                                              child: Text(
+                                                item.eventType?.value ?? 'Event',
+                                                maxLines: 1,
+                                                overflow: TextOverflow.ellipsis,
+                                                style: theme.textTheme.bodySmall
+                                                    ?.copyWith(
+                                                  color: cs.onSurfaceVariant,
+                                                  fontWeight: FontWeight.w500,
+                                                ),
                                               ),
                                             ),
                                             if (qualityName != null &&
@@ -1074,7 +1080,7 @@ class _ArtistHistoryViewState extends ConsumerState<ArtistHistoryView>
                                                 ),
                                               ),
                                             ],
-                                            const Spacer(),
+                                            const SizedBox(width: 6),
                                             Text(
                                               timeStr,
                                               style: theme.textTheme.bodySmall

--- a/services/service_lidarr/lib/src/features/artists/widgets/artist_bulk_actions_bar.dart
+++ b/services/service_lidarr/lib/src/features/artists/widgets/artist_bulk_actions_bar.dart
@@ -107,9 +107,10 @@ class ArtistBulkActionsBar extends ConsumerWidget {
             children: [
               TextButton.icon(
                 style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
                   foregroundColor: cs.primary,
                   padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                 ),
                 onPressed: () {
                   showDialog<void>(
@@ -126,9 +127,10 @@ class ArtistBulkActionsBar extends ConsumerWidget {
               ),
               TextButton.icon(
                 style: TextButton.styleFrom(
+                  visualDensity: VisualDensity.compact,
                   foregroundColor: cs.error,
                   padding:
-                      const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                      const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                 ),
                 onPressed: () {
                   showDialog<void>(
@@ -147,9 +149,10 @@ class ArtistBulkActionsBar extends ConsumerWidget {
                 message: 'More bulk actions',
                 child: TextButton.icon(
                   style: TextButton.styleFrom(
+                    visualDensity: VisualDensity.compact,
                     foregroundColor: cs.onSurfaceVariant,
                     padding:
-                        const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
                   ),
                   icon: const Icon(Icons.more_horiz, size: 20),
                   label: const Text('More'),

--- a/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
@@ -240,6 +240,7 @@ class _LidarrInteractiveSearchScreenState
       final LidarrApi api =
           await ref.read(lidarrApiProvider(widget.instance).future);
       final ReleaseResource payload = release.copyWith(
+        id: release.id ?? 0,
         albumId: release.albumId ?? widget.albumId,
         artistId: release.artistId ?? widget.artistId,
       );
@@ -548,18 +549,24 @@ class _LidarrInteractiveSearchScreenState
                 children: [
                   IconButton(
                     icon: const Icon(Icons.close),
+                    visualDensity: VisualDensity.compact,
                     onPressed: () => Navigator.of(ctx).pop(),
                   ),
-                  const SizedBox(width: 8),
-                  Text(
-                    'Release Details',
-                    style: theme.textTheme.titleMedium?.copyWith(
-                      fontWeight: FontWeight.bold,
+                  const SizedBox(width: 4),
+                  Expanded(
+                    child: Text(
+                      'Release Details',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                      ),
+                      overflow: TextOverflow.ellipsis,
                     ),
                   ),
-                  const Spacer(),
+                  const SizedBox(width: 8),
                   FilledButton.icon(
                     style: FilledButton.styleFrom(
+                      visualDensity: VisualDensity.compact,
+                      padding: const EdgeInsets.symmetric(horizontal: 10),
                       backgroundColor:
                           isRejected ? cs.errorContainer : cs.primary,
                       foregroundColor:
@@ -569,9 +576,9 @@ class _LidarrInteractiveSearchScreenState
                       isRejected
                           ? Icons.warning_amber_outlined
                           : Icons.download_outlined,
-                      size: 18,
+                      size: 16,
                     ),
-                    label: Text(isRejected ? 'Force Grab' : 'Grab Release'),
+                    label: Text(isRejected ? 'Force Grab' : 'Grab'),
                     onPressed: () {
                       Navigator.of(ctx).pop();
                       _grabRelease(release);

--- a/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
@@ -240,6 +240,8 @@ class _LidarrInteractiveSearchScreenState
       final LidarrApi api =
           await ref.read(lidarrApiProvider(widget.instance).future);
       final ReleaseResource payload = release.copyWith(
+        // Search results have no database id, but Lidarr nightly still
+        // deserialises this field as Int32 before it validates the release.
         id: release.id ?? 0,
         albumId: release.albumId ?? widget.albumId,
         artistId: release.artistId ?? widget.artistId,

--- a/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/search/interactive_search_screen.dart
@@ -240,8 +240,11 @@ class _LidarrInteractiveSearchScreenState
       final LidarrApi api =
           await ref.read(lidarrApiProvider(widget.instance).future);
       final ReleaseResource payload = release.copyWith(
-        // Search results have no database id, but Lidarr nightly still
-        // deserialises this field as Int32 before it validates the release.
+        // A search result carries no id of its own, and Lidarr deserialises
+        // this as a non-nullable int before it validates anything, so a null
+        // fails the request outright. That is true of every branch, not just
+        // nightly. LidarrApi strips nulls as well, but this path is explicit
+        // about it because it is the one that always relies on it.
         id: release.id ?? 0,
         albumId: release.albumId ?? widget.albumId,
         artistId: release.artistId ?? widget.artistId,

--- a/services/service_lidarr/lib/src/features/settings/providers/settings_providers.dart
+++ b/services/service_lidarr/lib/src/features/settings/providers/settings_providers.dart
@@ -328,3 +328,31 @@ final lidarrNotificationSchemaProvider =
     return unwrapLidarrApiResponse(resp, 'Failed to load notification schemas');
   },
 );
+
+/// Configured remote path mappings in Lidarr.
+final lidarrRemotePathMappingsProvider =
+    FutureProvider.autoDispose.family<List<RemotePathMappingResource>, Instance>(
+  (Ref ref, Instance instance) async {
+    final LidarrApi api = await ref.watch(lidarrApiProvider(instance).future);
+    final ApiResponse<List<RemotePathMappingResource>> resp =
+        await api.remotePathMapping.getRemotepathmapping();
+    return unwrapLidarrApiResponse(
+      resp,
+      'Failed to load remote path mappings',
+    );
+  },
+);
+
+/// Configured import list exclusions in Lidarr.
+final lidarrImportListExclusionsProvider =
+    FutureProvider.autoDispose.family<List<ImportListExclusionResource>, Instance>(
+  (Ref ref, Instance instance) async {
+    final LidarrApi api = await ref.watch(lidarrApiProvider(instance).future);
+    final ApiResponse<List<ImportListExclusionResource>> resp =
+        await api.importListExclusion.getImportlistexclusion();
+    return unwrapLidarrApiResponse(
+      resp,
+      'Failed to load import list exclusions',
+    );
+  },
+);

--- a/services/service_lidarr/lib/src/features/settings/sections/connect_section.dart
+++ b/services/service_lidarr/lib/src/features/settings/sections/connect_section.dart
@@ -259,6 +259,7 @@ class ConnectSection extends ConsumerWidget {
                               .read(lidarrApiProvider(instance).future);
                           final NotificationResource payload =
                               notification.copyWith(
+                            id: notification.id ?? 0,
                             name: nameController.text.trim().isNotEmpty
                                 ? nameController.text.trim()
                                 : notification.name,
@@ -291,6 +292,7 @@ class ConnectSection extends ConsumerWidget {
                                 .read(lidarrApiProvider(instance).future);
                             final NotificationResource payload =
                                 notification.copyWith(
+                              id: notification.id ?? 0,
                               name: nameController.text.trim().isNotEmpty
                                   ? nameController.text.trim()
                                   : notification.name,

--- a/services/service_lidarr/lib/src/features/settings/sections/download_clients_section.dart
+++ b/services/service_lidarr/lib/src/features/settings/sections/download_clients_section.dart
@@ -3,6 +3,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/lidarr_formatters.dart';
 import '../../../generated/generated.dart';
 import '../../../lidarr_api.dart';
 import '../../../lidarr_providers.dart';
@@ -93,6 +94,7 @@ class DownloadClientsSection extends ConsumerWidget {
                   final LidarrApi api =
                       await ref.read(lidarrApiProvider(instance).future);
                   final DownloadClientResource payload = client.copyWith(
+                    id: client.id ?? 0,
                     fields: updatedFields.map(Field.fromJson).toList(),
                   );
                   final ApiResponse<void> resp = await api.downloadClient
@@ -110,6 +112,7 @@ class DownloadClientsSection extends ConsumerWidget {
                     final LidarrApi api =
                         await ref.read(lidarrApiProvider(instance).future);
                     final DownloadClientResource payload = client.copyWith(
+                      id: client.id ?? 0,
                       fields: updatedFields.map(Field.fromJson).toList(),
                     );
 
@@ -350,12 +353,212 @@ class DownloadClientsSection extends ConsumerWidget {
     );
   }
 
+  Future<void> _showRemotePathMappingEditorDialog(
+    BuildContext context,
+    WidgetRef ref, {
+    RemotePathMappingResource? mapping,
+  }) async {
+    final bool isNew = mapping == null;
+    final TextEditingController hostController =
+        TextEditingController(text: mapping?.host ?? '');
+    final TextEditingController remotePathController =
+        TextEditingController(text: mapping?.remotePath ?? '');
+    final TextEditingController localPathController =
+        TextEditingController(text: mapping?.localPath ?? '');
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext ctx) {
+        return AlertDialog(
+          title: Text(
+            isNew ? 'Add Remote Path Mapping' : 'Edit Remote Path Mapping',
+          ),
+          content: Form(
+            key: formKey,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  TextFormField(
+                    controller: hostController,
+                    decoration: const InputDecoration(
+                      labelText: 'Host',
+                      hintText: 'e.g. 192.168.1.100 or localhost',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (String? value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Host is required';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: Insets.sm),
+                  TextFormField(
+                    controller: remotePathController,
+                    decoration: const InputDecoration(
+                      labelText: 'Remote Path',
+                      hintText: 'e.g. /downloads/music/',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (String? value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Remote path is required';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: Insets.sm),
+                  TextFormField(
+                    controller: localPathController,
+                    decoration: const InputDecoration(
+                      labelText: 'Local Path',
+                      hintText: r'e.g. /mnt/downloads/ or D:\Downloads\',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (String? value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Local path is required';
+                      }
+                      return null;
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () async {
+                if (!formKey.currentState!.validate()) return;
+                final ScaffoldMessengerState messenger =
+                    ScaffoldMessenger.of(context);
+                try {
+                  final LidarrApi api =
+                      await ref.read(lidarrApiProvider(instance).future);
+                  final RemotePathMappingResource payload =
+                      (mapping ?? const RemotePathMappingResource()).copyWith(
+                    host: hostController.text.trim(),
+                    remotePath: remotePathController.text.trim(),
+                    localPath: localPathController.text.trim(),
+                  );
+
+                  if (isNew) {
+                    final ApiResponse<RemotePathMappingResource> resp =
+                        await api.remotePathMapping.postRemotepathmapping(
+                      body: payload,
+                    );
+                    if (!resp.isSuccess) {
+                      throw Exception(
+                        resp.error?.message ??
+                            'Failed to create remote path mapping',
+                      );
+                    }
+                  } else {
+                    final ApiResponse<RemotePathMappingResource> resp =
+                        await api.remotePathMapping.putRemotepathmappingById(
+                      id: mapping.id!.toString(),
+                      body: payload,
+                    );
+                    if (!resp.isSuccess) {
+                      throw Exception(
+                        resp.error?.message ??
+                            'Failed to update remote path mapping',
+                      );
+                    }
+                  }
+
+                  ref.invalidate(lidarrRemotePathMappingsProvider(instance));
+                  if (ctx.mounted) {
+                    Navigator.pop(ctx);
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          isNew
+                              ? 'Remote path mapping added!'
+                              : 'Remote path mapping updated!',
+                        ),
+                      ),
+                    );
+                  }
+                } catch (e) {
+                  if (ctx.mounted) {
+                    messenger.showSnackBar(
+                      SnackBar(content: Text('Error saving mapping: $e')),
+                    );
+                  }
+                }
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _deleteRemotePathMapping(
+    BuildContext context,
+    WidgetRef ref,
+    RemotePathMappingResource mapping,
+  ) async {
+    final int? id = mapping.id;
+    if (id == null) return;
+
+    final bool? confirm = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: const Text('Delete Remote Path Mapping?'),
+        content: Text(
+          'Are you sure you want to delete the mapping for "${mapping.host ?? 'Host'}" (${mapping.remotePath ?? ''} -> ${mapping.localPath ?? ''})?',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.pop(ctx, false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.pop(ctx, true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm != true || !context.mounted) return;
+
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    try {
+      final LidarrApi api = await ref.read(lidarrApiProvider(instance).future);
+      await api.remotePathMapping.deleteRemotepathmappingById(id: id);
+      ref.invalidate(lidarrRemotePathMappingsProvider(instance));
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Remote path mapping deleted.')),
+      );
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Error deleting mapping: $e')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
     final AsyncValue<List<DownloadClientResource>> asyncClients =
         ref.watch(lidarrDownloadClientsProvider(instance));
+    final AsyncValue<List<RemotePathMappingResource>> asyncMappings =
+        ref.watch(lidarrRemotePathMappingsProvider(instance));
+
     // Warm up schemas and config
     ref.watch(lidarrDownloadClientSchemaProvider(instance));
     ref.watch(lidarrDownloadClientConfigProvider(instance));
@@ -370,72 +573,120 @@ class DownloadClientsSection extends ConsumerWidget {
       body: EasyRefresh(
         onRefresh: () async {
           ref.invalidate(lidarrDownloadClientsProvider(instance));
+          ref.invalidate(lidarrRemotePathMappingsProvider(instance));
           ref.invalidate(lidarrDownloadClientConfigProvider(instance));
         },
-        child: AsyncValueView<List<DownloadClientResource>>(
-          value: asyncClients,
-          data: (List<DownloadClientResource> clients) {
-            return ListView(
-              padding: const EdgeInsets.all(Insets.md),
-              children: <Widget>[
-                // Options Banner
-                Card(
-                  elevation: 0,
-                  color: cs.surfaceContainerLow,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                    side: BorderSide(
-                      color: cs.outlineVariant.withValues(alpha: 0.3),
-                    ),
+        child: ListView(
+          padding: const EdgeInsets.all(Insets.md),
+          children: <Widget>[
+            // Options Banner
+            Card(
+              elevation: 0,
+              color: cs.surfaceContainerLow,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+                side: BorderSide(
+                  color: cs.outlineVariant.withValues(alpha: 0.3),
+                ),
+              ),
+              child: ListTile(
+                leading: Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: cs.secondaryContainer,
+                    borderRadius: BorderRadius.circular(10),
                   ),
-                  child: ListTile(
-                    leading: Container(
-                      width: 40,
-                      height: 40,
-                      decoration: BoxDecoration(
-                        color: cs.secondaryContainer,
-                        borderRadius: BorderRadius.circular(10),
-                      ),
-                      child: Icon(
-                        Icons.tune,
-                        color: cs.onSecondaryContainer,
-                        size: 20,
-                      ),
-                    ),
-                    title: const Text(
-                      'Download Client Handling',
-                      style: TextStyle(fontWeight: FontWeight.w600),
-                    ),
-                    subtitle: const Text(
-                      'Completed handling, intervals, and redownloads',
-                      style: TextStyle(fontSize: 12),
-                    ),
-                    trailing: const Icon(Icons.chevron_right, size: 20),
-                    onTap: () => _showDownloadClientOptionsDialog(context, ref),
+                  child: Icon(
+                    Icons.tune,
+                    color: cs.onSecondaryContainer,
+                    size: 20,
                   ),
                 ),
-                const SizedBox(height: Insets.md),
-                if (clients.isEmpty)
-                  Center(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(vertical: 40),
-                      child: EmptyView(
-                        icon: Icons.download_outlined,
-                        title: 'No Download Clients',
-                        message: 'No download clients configured in Lidarr.',
-                        action: FilledButton.icon(
-                          onPressed: () =>
-                              _selectClientPresetAndAdd(context, ref),
-                          icon: const Icon(Icons.add),
-                          label: const Text('Add Client'),
-                        ),
+                title: const Text(
+                  'Download Client Handling',
+                  style: TextStyle(fontWeight: FontWeight.w600),
+                ),
+                subtitle: const Text(
+                  'Completed handling, intervals, and redownloads',
+                  style: TextStyle(fontSize: 12),
+                ),
+                trailing: const Icon(Icons.chevron_right, size: 20),
+                onTap: () => _showDownloadClientOptionsDialog(context, ref),
+              ),
+            ),
+            const SizedBox(height: Insets.lg),
+
+            // Section 1: Download Clients
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    'Download Clients',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add, size: 20),
+                  onPressed: () => _selectClientPresetAndAdd(context, ref),
+                ),
+              ],
+            ),
+            const SizedBox(height: Insets.xs),
+
+            AsyncValueView<List<DownloadClientResource>>(
+              value: asyncClients,
+              data: (List<DownloadClientResource> clients) {
+                if (clients.isEmpty) {
+                  return Card(
+                    elevation: 0,
+                    color: cs.surfaceContainerLow,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      side: BorderSide(
+                        color: cs.outlineVariant.withValues(alpha: 0.3),
                       ),
                     ),
-                  )
-                else
-                  ...clients.map((DownloadClientResource client) {
-                    final String protocolStr =
-                        client.protocol?.value.toUpperCase() ?? 'TORRENT';
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 24,
+                        horizontal: 16,
+                      ),
+                      child: Column(
+                        children: <Widget>[
+                          Icon(
+                            Icons.download_outlined,
+                            size: 36,
+                            color: cs.onSurfaceVariant,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'No Download Clients',
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'No download clients configured in Lidarr.',
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }
+
+                return Column(
+                  children: clients.map((DownloadClientResource client) {
+                    final String protocolStr = LidarrFormatters.formatWireEnum(
+                      client.protocol?.value,
+                    );
                     final bool isEnabled = client.enable ?? true;
 
                     return Padding(
@@ -476,15 +727,35 @@ class DownloadClientsSection extends ConsumerWidget {
                           ),
                           subtitle: Padding(
                             padding: const EdgeInsets.only(top: 4),
-                            child: Row(
+                            child: Wrap(
+                              spacing: 6,
+                              runSpacing: 4,
+                              crossAxisAlignment: WrapCrossAlignment.center,
                               children: <Widget>[
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: cs.secondaryContainer,
+                                    borderRadius: BorderRadius.circular(6),
+                                  ),
+                                  child: Text(
+                                    protocolStr,
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.bold,
+                                      color: cs.onSecondaryContainer,
+                                    ),
+                                  ),
+                                ),
                                 Text(
                                   client.implementationName ?? 'Client',
                                   style: theme.textTheme.bodySmall?.copyWith(
                                     color: cs.onSurfaceVariant,
                                   ),
                                 ),
-                                const SizedBox(width: 6),
                                 Container(
                                   width: 6,
                                   height: 6,
@@ -495,7 +766,6 @@ class DownloadClientsSection extends ConsumerWidget {
                                     shape: BoxShape.circle,
                                   ),
                                 ),
-                                const SizedBox(width: 6),
                                 Text(
                                   isEnabled ? 'Enabled' : 'Disabled',
                                   style: theme.textTheme.bodySmall?.copyWith(
@@ -510,36 +780,11 @@ class DownloadClientsSection extends ConsumerWidget {
                               ],
                             ),
                           ),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: <Widget>[
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 4,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: cs.secondaryContainer,
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Text(
-                                  protocolStr,
-                                  style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: cs.onSecondaryContainer,
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(width: 4),
-                              IconButton(
-                                icon:
-                                    const Icon(Icons.delete_outline, size: 20),
-                                tooltip: 'Delete Client',
-                                onPressed: () =>
-                                    _deleteClient(context, ref, client),
-                              ),
-                            ],
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete_outline, size: 20),
+                            tooltip: 'Delete Client',
+                            onPressed: () =>
+                                _deleteClient(context, ref, client),
                           ),
                           onTap: () => _showClientEditorDialog(
                             context,
@@ -549,12 +794,164 @@ class DownloadClientsSection extends ConsumerWidget {
                         ),
                       ),
                     );
-                  }),
+                  }).toList(),
+                );
+              },
+            ),
+
+            const SizedBox(height: Insets.lg),
+
+            // Section 2: Remote Path Mappings
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Expanded(
+                  child: Text(
+                    'Remote Path Mappings',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add, size: 20),
+                  tooltip: 'Add Remote Path Mapping',
+                  onPressed: () =>
+                      _showRemotePathMappingEditorDialog(context, ref),
+                ),
               ],
-            );
-          },
+            ),
+            const SizedBox(height: Insets.xs),
+
+            AsyncValueView<List<RemotePathMappingResource>>(
+              value: asyncMappings,
+              data: (List<RemotePathMappingResource> mappings) {
+                if (mappings.isEmpty) {
+                  return Card(
+                    elevation: 0,
+                    color: cs.surfaceContainerLow,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      side: BorderSide(
+                        color: cs.outlineVariant.withValues(alpha: 0.3),
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 24,
+                        horizontal: 16,
+                      ),
+                      child: Column(
+                        children: <Widget>[
+                          Icon(
+                            Icons.folder_shared_outlined,
+                            size: 36,
+                            color: cs.onSurfaceVariant,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'No Remote Path Mappings',
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Map remote download client directories to local Lidarr paths.',
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }
+
+                return Column(
+                  children: mappings.map((RemotePathMappingResource mapping) {
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: Card(
+                        elevation: 0,
+                        color: cs.surfaceContainerLow,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                          side: BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 14,
+                            vertical: 6,
+                          ),
+                          leading: Container(
+                            width: 44,
+                            height: 44,
+                            decoration: BoxDecoration(
+                              color: cs.tertiaryContainer,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Icon(
+                              Icons.folder_shared_outlined,
+                              color: cs.onTertiaryContainer,
+                              size: 22,
+                            ),
+                          ),
+                          title: Text(
+                            mapping.host ?? 'Host',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 15,
+                            ),
+                          ),
+                          subtitle: Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: <Widget>[
+                                Text(
+                                  'Remote: ${mapping.remotePath ?? ''}',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                ),
+                                Text(
+                                  'Local: ${mapping.localPath ?? ''}',
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete_outline, size: 20),
+                            tooltip: 'Delete Mapping',
+                            onPressed: () => _deleteRemotePathMapping(
+                              context,
+                              ref,
+                              mapping,
+                            ),
+                          ),
+                          onTap: () => _showRemotePathMappingEditorDialog(
+                            context,
+                            ref,
+                            mapping: mapping,
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
   }
 }
+

--- a/services/service_lidarr/lib/src/features/settings/sections/import_lists_section.dart
+++ b/services/service_lidarr/lib/src/features/settings/sections/import_lists_section.dart
@@ -108,12 +108,25 @@ class ImportListsSection extends ConsumerWidget {
     final List<MetadataProfileResource> metadataProfiles =
         ref.read(lidarrMetadataProfilesProvider(instance)).value ?? [];
 
-    String? rootFolderPath = list.rootFolderPath ??
-        (rootFolders.isNotEmpty ? rootFolders.first.path : null);
-    int? qualityProfileId = list.qualityProfileId ??
-        (qualityProfiles.isNotEmpty ? qualityProfiles.first.id : null);
-    int? metadataProfileId = list.metadataProfileId ??
-        (metadataProfiles.isNotEmpty ? metadataProfiles.first.id : null);
+    final bool hasValidRootFolder =
+        rootFolders.any((rf) => rf.path == list.rootFolderPath);
+    String? rootFolderPath = hasValidRootFolder
+        ? list.rootFolderPath
+        : (rootFolders.isNotEmpty ? rootFolders.first.path : null);
+
+    final bool hasValidQualityProfile = qualityProfiles.any(
+      (qp) => qp.id == list.qualityProfileId && qp.id != null && qp.id != 0,
+    );
+    int? qualityProfileId = hasValidQualityProfile
+        ? list.qualityProfileId
+        : (qualityProfiles.isNotEmpty ? qualityProfiles.first.id : null);
+
+    final bool hasValidMetadataProfile = metadataProfiles.any(
+      (mp) => mp.id == list.metadataProfileId && mp.id != null && mp.id != 0,
+    );
+    int? metadataProfileId = hasValidMetadataProfile
+        ? list.metadataProfileId
+        : (metadataProfiles.isNotEmpty ? metadataProfiles.first.id : null);
 
     if (!context.mounted) return;
 
@@ -168,6 +181,7 @@ class ImportListsSection extends ConsumerWidget {
                       if (rootFolders.isNotEmpty) ...[
                         const SizedBox(height: Insets.xs),
                         DropdownButtonFormField<String>(
+                          isExpanded: true,
                           initialValue: rootFolderPath,
                           decoration: const InputDecoration(
                             labelText: 'Root Folder',
@@ -189,6 +203,7 @@ class ImportListsSection extends ConsumerWidget {
                       if (qualityProfiles.isNotEmpty) ...[
                         const SizedBox(height: Insets.sm),
                         DropdownButtonFormField<int>(
+                          isExpanded: true,
                           initialValue: qualityProfileId,
                           decoration: const InputDecoration(
                             labelText: 'Quality Profile',
@@ -208,6 +223,7 @@ class ImportListsSection extends ConsumerWidget {
                       if (metadataProfiles.isNotEmpty) ...[
                         const SizedBox(height: Insets.sm),
                         DropdownButtonFormField<int>(
+                          isExpanded: true,
                           initialValue: metadataProfileId,
                           decoration: const InputDecoration(
                             labelText: 'Metadata Profile',
@@ -237,6 +253,7 @@ class ImportListsSection extends ConsumerWidget {
                           final LidarrApi api = await ref
                               .read(lidarrApiProvider(instance).future);
                           final ImportListResource payload = list.copyWith(
+                            id: list.id ?? 0,
                             name: nameController.text.trim().isNotEmpty
                                 ? nameController.text.trim()
                                 : list.name,
@@ -261,6 +278,7 @@ class ImportListsSection extends ConsumerWidget {
                               ScaffoldMessenger.of(context);
                           final String enteredName = nameController.text.trim();
                           final ImportListResource payload = list.copyWith(
+                            id: list.id ?? 0,
                             name: enteredName.isNotEmpty
                                 ? enteredName
                                 : list.name,
@@ -333,6 +351,142 @@ class ImportListsSection extends ConsumerWidget {
     );
   }
 
+  Future<void> _showExclusionEditorDialog(
+    BuildContext context,
+    WidgetRef ref, {
+    ImportListExclusionResource? exclusion,
+  }) async {
+    final bool isNew = exclusion == null;
+    final TextEditingController artistNameController =
+        TextEditingController(text: exclusion?.artistName ?? '');
+    final TextEditingController foreignIdController =
+        TextEditingController(text: exclusion?.foreignId ?? '');
+    final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+
+    await showDialog<void>(
+      context: context,
+      builder: (BuildContext ctx) {
+        return AlertDialog(
+          title: Text(
+            isNew ? 'Add Import List Exclusion' : 'Edit Exclusion',
+          ),
+          content: Form(
+            key: formKey,
+            child: SingleChildScrollView(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: <Widget>[
+                  TextFormField(
+                    controller: artistNameController,
+                    decoration: const InputDecoration(
+                      labelText: 'Artist Name',
+                      hintText: 'e.g. The Beatles',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (String? value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'Artist name is required';
+                      }
+                      return null;
+                    },
+                  ),
+                  const SizedBox(height: Insets.sm),
+                  TextFormField(
+                    controller: foreignIdController,
+                    decoration: const InputDecoration(
+                      labelText: 'MusicBrainz Artist ID',
+                      hintText: 'e.g. b10bbbfc-cf9e-42e0-be17-e2c3e1d52350',
+                      border: OutlineInputBorder(),
+                    ),
+                    validator: (String? value) {
+                      if (value == null || value.trim().isEmpty) {
+                        return 'MusicBrainz ID is required';
+                      }
+                      return null;
+                    },
+                  ),
+                ],
+              ),
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              onPressed: () => Navigator.pop(ctx),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () async {
+                if (!formKey.currentState!.validate()) return;
+                final ScaffoldMessengerState messenger =
+                    ScaffoldMessenger.of(context);
+                try {
+                  final LidarrApi api =
+                      await ref.read(lidarrApiProvider(instance).future);
+                  final ImportListExclusionResource payload =
+                      (exclusion ?? const ImportListExclusionResource())
+                          .copyWith(
+                    artistName: artistNameController.text.trim(),
+                    foreignId: foreignIdController.text.trim(),
+                  );
+
+                  if (isNew) {
+                    final ApiResponse<ImportListExclusionResource> resp =
+                        await api.importListExclusion
+                            .postImportlistexclusion(body: payload);
+                    if (!resp.isSuccess) {
+                      throw Exception(
+                        resp.error?.message ??
+                            'Failed to create import exclusion',
+                      );
+                    }
+                  } else {
+                    final ApiResponse<ImportListExclusionResource> resp =
+                        await api.importListExclusion
+                            .putImportlistexclusionById(
+                      id: exclusion.id!.toString(),
+                      body: payload,
+                    );
+                    if (!resp.isSuccess) {
+                      throw Exception(
+                        resp.error?.message ??
+                            'Failed to update import exclusion',
+                      );
+                    }
+                  }
+
+                  ref.invalidate(
+                    lidarrImportListExclusionsProvider(instance),
+                  );
+                  if (ctx.mounted) {
+                    Navigator.pop(ctx);
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text(
+                          isNew
+                              ? 'Artist exclusion added!'
+                              : 'Artist exclusion updated!',
+                        ),
+                      ),
+                    );
+                  }
+                } catch (e) {
+                  if (ctx.mounted) {
+                    messenger.showSnackBar(
+                      SnackBar(
+                        content: Text('Error saving exclusion: $e'),
+                      ),
+                    );
+                  }
+                }
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   Future<void> _deleteImportList(
     BuildContext context,
     WidgetRef ref,
@@ -347,7 +501,7 @@ class ImportListsSection extends ConsumerWidget {
         title: Text('Delete ${list.name ?? 'Import List'}?'),
         content:
             const Text('Are you sure you want to delete this import list?'),
-        actions: [
+        actions: <Widget>[
           TextButton(
             onPressed: () => Navigator.of(ctx).pop(false),
             child: const Text('Cancel'),
@@ -388,11 +542,70 @@ class ImportListsSection extends ConsumerWidget {
     }
   }
 
+  Future<void> _deleteExclusion(
+    BuildContext context,
+    WidgetRef ref,
+    ImportListExclusionResource exclusion,
+  ) async {
+    final int? id = exclusion.id;
+    if (id == null) return;
+
+    final bool? confirmed = await showDialog<bool>(
+      context: context,
+      builder: (BuildContext ctx) => AlertDialog(
+        title: const Text('Delete Exclusion?'),
+        content: Text(
+          'Are you sure you want to remove "${exclusion.artistName ?? 'Artist'}" from the exclusions list?',
+        ),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+              foregroundColor: Theme.of(ctx).colorScheme.onError,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed != true || !context.mounted) return;
+
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    try {
+      final LidarrApi api = await ref.read(lidarrApiProvider(instance).future);
+      final ApiResponse<void> resp =
+          await api.importListExclusion.deleteImportlistexclusionById(id: id);
+      if (!resp.isSuccess) {
+        throw Exception(
+          resp.error?.message ?? 'Failed to delete exclusion',
+        );
+      }
+
+      ref.invalidate(lidarrImportListExclusionsProvider(instance));
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Exclusion removed.')),
+      );
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('Failed to delete exclusion: $e')),
+      );
+    }
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final ColorScheme cs = Theme.of(context).colorScheme;
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
     final AsyncValue<List<ImportListResource>> asyncLists =
         ref.watch(lidarrImportListsProvider(instance));
+    final AsyncValue<List<ImportListExclusionResource>> asyncExclusions =
+        ref.watch(lidarrImportListExclusionsProvider(instance));
 
     // Prefetch schemas & dependencies
     ref.watch(lidarrImportListSchemaProvider(instance));
@@ -408,101 +621,287 @@ class ImportListsSection extends ConsumerWidget {
         child: const Icon(Icons.add),
       ),
       body: EasyRefresh(
-        onRefresh: () async =>
-            ref.invalidate(lidarrImportListsProvider(instance)),
-        child: AsyncValueView<List<ImportListResource>>(
-          value: asyncLists,
-          data: (List<ImportListResource> lists) {
-            if (lists.isEmpty) {
-              return Center(
-                child: EmptyView(
-                  icon: Icons.queue_music_outlined,
-                  title: 'No Import Lists',
-                  message:
-                      'Add Spotify, Last.fm, or MusicBrainz sync lists to automatically import artists and albums.',
-                  action: FilledButton.icon(
-                    onPressed: () => _selectListPresetAndAdd(context, ref),
-                    icon: const Icon(Icons.add),
-                    label: const Text('Add Import List'),
+        onRefresh: () async {
+          ref.invalidate(lidarrImportListsProvider(instance));
+          ref.invalidate(lidarrImportListExclusionsProvider(instance));
+        },
+        child: ListView(
+          padding: const EdgeInsets.all(Insets.md),
+          children: <Widget>[
+            // Section 1: Import Lists
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(
+                  'Import Lists',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
                   ),
                 ),
-              );
-            }
+                IconButton(
+                  icon: const Icon(Icons.add, size: 20),
+                  onPressed: () => _selectListPresetAndAdd(context, ref),
+                ),
+              ],
+            ),
+            const SizedBox(height: Insets.xs),
 
-            return ListView.separated(
-              padding: const EdgeInsets.all(Insets.md),
-              itemCount: lists.length,
-              separatorBuilder: (_, __) => const SizedBox(height: 10),
-              itemBuilder: (BuildContext context, int index) {
-                final ImportListResource item = lists[index];
-                final bool autoAdd = item.enableAutomaticAdd == true;
-
-                return Card(
-                  elevation: 0,
-                  color: cs.surfaceContainerLow,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(16),
-                    side: BorderSide(
-                      color: cs.outlineVariant.withValues(alpha: 0.3),
-                    ),
-                  ),
-                  child: ListTile(
-                    contentPadding: const EdgeInsets.symmetric(
-                      horizontal: 14,
-                      vertical: 6,
-                    ),
-                    leading: Container(
-                      width: 44,
-                      height: 44,
-                      decoration: BoxDecoration(
-                        color: cs.primaryContainer,
-                        borderRadius: BorderRadius.circular(12),
-                      ),
-                      child: Icon(
-                        Icons.queue_music,
-                        color: cs.onPrimaryContainer,
-                        size: 22,
+            AsyncValueView<List<ImportListResource>>(
+              value: asyncLists,
+              data: (List<ImportListResource> lists) {
+                if (lists.isEmpty) {
+                  return Card(
+                    elevation: 0,
+                    color: cs.surfaceContainerLow,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      side: BorderSide(
+                        color: cs.outlineVariant.withValues(alpha: 0.3),
                       ),
                     ),
-                    title: Text(
-                      item.name ?? 'Import List',
-                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.w600,
-                            fontSize: 15,
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 24,
+                        horizontal: 16,
+                      ),
+                      child: Column(
+                        children: <Widget>[
+                          Icon(
+                            Icons.queue_music_outlined,
+                            size: 36,
+                            color: cs.onSurfaceVariant,
                           ),
-                    ),
-                    subtitle: Padding(
-                      padding: const EdgeInsets.only(top: 4),
-                      child: Text(
-                        [
-                          item.implementationName ?? 'List',
-                          if (autoAdd)
-                            'Auto-Add Enabled'
-                          else
-                            'Auto-Add Disabled',
-                        ].join(' • '),
-                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          const SizedBox(height: 8),
+                          Text(
+                            'No Import Lists',
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Add Spotify, Last.fm, or MusicBrainz sync lists to automatically import artists and albums.',
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.bodySmall?.copyWith(
                               color: cs.onSurfaceVariant,
                             ),
+                          ),
+                        ],
                       ),
                     ),
-                    trailing: IconButton(
-                      icon: const Icon(Icons.delete_outline, size: 20),
-                      tooltip: 'Delete Import List',
-                      onPressed: () => _deleteImportList(context, ref, item),
-                    ),
-                    onTap: () => _showImportListEditorDialog(
-                      context,
-                      ref,
-                      item,
-                    ),
-                  ),
+                  );
+                }
+
+                return Column(
+                  children: lists.map((ImportListResource item) {
+                    final bool autoAdd = item.enableAutomaticAdd == true;
+
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: Card(
+                        elevation: 0,
+                        color: cs.surfaceContainerLow,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                          side: BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 14,
+                            vertical: 6,
+                          ),
+                          leading: Container(
+                            width: 44,
+                            height: 44,
+                            decoration: BoxDecoration(
+                              color: cs.primaryContainer,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Icon(
+                              Icons.queue_music,
+                              color: cs.onPrimaryContainer,
+                              size: 22,
+                            ),
+                          ),
+                          title: Text(
+                            item.name ?? 'Import List',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 15,
+                            ),
+                          ),
+                          subtitle: Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              <String>[
+                                item.implementationName ?? 'List',
+                                if (autoAdd)
+                                  'Auto-Add Enabled'
+                                else
+                                  'Auto-Add Disabled',
+                              ].join(' • '),
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete_outline, size: 20),
+                            tooltip: 'Delete Import List',
+                            onPressed: () =>
+                                _deleteImportList(context, ref, item),
+                          ),
+                          onTap: () => _showImportListEditorDialog(
+                            context,
+                            ref,
+                            item,
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
                 );
               },
-            );
-          },
+            ),
+
+            const SizedBox(height: Insets.lg),
+
+            // Section 2: Import List Exclusions
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: <Widget>[
+                Text(
+                  'Import List Exclusions',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.add, size: 20),
+                  tooltip: 'Add Exclusion',
+                  onPressed: () => _showExclusionEditorDialog(context, ref),
+                ),
+              ],
+            ),
+            const SizedBox(height: Insets.xs),
+
+            AsyncValueView<List<ImportListExclusionResource>>(
+              value: asyncExclusions,
+              data: (List<ImportListExclusionResource> exclusions) {
+                if (exclusions.isEmpty) {
+                  return Card(
+                    elevation: 0,
+                    color: cs.surfaceContainerLow,
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(16),
+                      side: BorderSide(
+                        color: cs.outlineVariant.withValues(alpha: 0.3),
+                      ),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.symmetric(
+                        vertical: 24,
+                        horizontal: 16,
+                      ),
+                      child: Column(
+                        children: <Widget>[
+                          Icon(
+                            Icons.person_off_outlined,
+                            size: 36,
+                            color: cs.onSurfaceVariant,
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            'No Exclusions',
+                            style: theme.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            'Artists prevented from being auto-added by import lists.',
+                            textAlign: TextAlign.center,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: cs.onSurfaceVariant,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                }
+
+                return Column(
+                  children: exclusions.map((ImportListExclusionResource item) {
+                    return Padding(
+                      padding: const EdgeInsets.only(bottom: 10),
+                      child: Card(
+                        elevation: 0,
+                        color: cs.surfaceContainerLow,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                          side: BorderSide(
+                            color: cs.outlineVariant.withValues(alpha: 0.3),
+                          ),
+                        ),
+                        child: ListTile(
+                          contentPadding: const EdgeInsets.symmetric(
+                            horizontal: 14,
+                            vertical: 6,
+                          ),
+                          leading: Container(
+                            width: 44,
+                            height: 44,
+                            decoration: BoxDecoration(
+                              color: cs.errorContainer,
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                            child: Icon(
+                              Icons.person_off_outlined,
+                              color: cs.onErrorContainer,
+                              size: 22,
+                            ),
+                          ),
+                          title: Text(
+                            item.artistName ?? 'Excluded Artist',
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              fontSize: 15,
+                            ),
+                          ),
+                          subtitle: Padding(
+                            padding: const EdgeInsets.only(top: 4),
+                            child: Text(
+                              'MBID: ${item.foreignId ?? ''}',
+                              style: theme.textTheme.bodySmall?.copyWith(
+                                color: cs.onSurfaceVariant,
+                              ),
+                            ),
+                          ),
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete_outline, size: 20),
+                            tooltip: 'Remove Exclusion',
+                            onPressed: () =>
+                                _deleteExclusion(context, ref, item),
+                          ),
+                          onTap: () => _showExclusionEditorDialog(
+                            context,
+                            ref,
+                            exclusion: item,
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                );
+              },
+            ),
+          ],
         ),
       ),
     );
   }
 }
+

--- a/services/service_lidarr/lib/src/features/settings/sections/indexers_section.dart
+++ b/services/service_lidarr/lib/src/features/settings/sections/indexers_section.dart
@@ -3,6 +3,7 @@ import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../../../core/lidarr_formatters.dart';
 import '../../../generated/generated.dart';
 import '../../../lidarr_api.dart';
 import '../../../lidarr_providers.dart';
@@ -93,6 +94,7 @@ class IndexersSection extends ConsumerWidget {
                   final LidarrApi api =
                       await ref.read(lidarrApiProvider(instance).future);
                   final IndexerResource payload = indexer.copyWith(
+                    id: indexer.id ?? 0,
                     fields: updatedFields.map(Field.fromJson).toList(),
                   );
                   final ApiResponse<void> resp =
@@ -110,6 +112,7 @@ class IndexersSection extends ConsumerWidget {
                     final LidarrApi api =
                         await ref.read(lidarrApiProvider(instance).future);
                     final IndexerResource payload = indexer.copyWith(
+                      id: indexer.id ?? 0,
                       fields: updatedFields.map(Field.fromJson).toList(),
                     );
 
@@ -401,8 +404,9 @@ class IndexersSection extends ConsumerWidget {
                   )
                 else
                   ...indexers.map((IndexerResource indexer) {
-                    final String protocolStr =
-                        indexer.protocol?.value.toUpperCase() ?? 'TORRENT';
+                    final String protocolStr = LidarrFormatters.formatWireEnum(
+                      indexer.protocol?.value,
+                    );
 
                     return Padding(
                       padding: const EdgeInsets.only(bottom: 10),
@@ -444,11 +448,30 @@ class IndexersSection extends ConsumerWidget {
                             padding: const EdgeInsets.only(top: 4),
                             child: Wrap(
                               spacing: 6,
-                              runSpacing: 2,
+                              runSpacing: 4,
+                              crossAxisAlignment: WrapCrossAlignment.center,
                               children: <Widget>[
+                                Container(
+                                  padding: const EdgeInsets.symmetric(
+                                    horizontal: 6,
+                                    vertical: 2,
+                                  ),
+                                  decoration: BoxDecoration(
+                                    color: cs.primaryContainer,
+                                    borderRadius: BorderRadius.circular(6),
+                                  ),
+                                  child: Text(
+                                    protocolStr,
+                                    style: TextStyle(
+                                      fontSize: 10,
+                                      fontWeight: FontWeight.bold,
+                                      color: cs.onPrimaryContainer,
+                                    ),
+                                  ),
+                                ),
                                 if (indexer.enableRss == true)
                                   Text(
-                                    'RSS Enabled •',
+                                    '• RSS',
                                     style: TextStyle(
                                       fontSize: 12,
                                       color: cs.onSurfaceVariant,
@@ -456,7 +479,7 @@ class IndexersSection extends ConsumerWidget {
                                   ),
                                 if (indexer.enableAutomaticSearch == true)
                                   Text(
-                                    'Auto Search •',
+                                    '• Auto Search',
                                     style: TextStyle(
                                       fontSize: 12,
                                       color: cs.onSurfaceVariant,
@@ -464,7 +487,7 @@ class IndexersSection extends ConsumerWidget {
                                   ),
                                 if (indexer.enableInteractiveSearch == true)
                                   Text(
-                                    'Interactive Search',
+                                    '• Interactive Search',
                                     style: TextStyle(
                                       fontSize: 12,
                                       color: cs.onSurfaceVariant,
@@ -473,36 +496,11 @@ class IndexersSection extends ConsumerWidget {
                               ],
                             ),
                           ),
-                          trailing: Row(
-                            mainAxisSize: MainAxisSize.min,
-                            children: <Widget>[
-                              Container(
-                                padding: const EdgeInsets.symmetric(
-                                  horizontal: 8,
-                                  vertical: 4,
-                                ),
-                                decoration: BoxDecoration(
-                                  color: cs.primaryContainer,
-                                  borderRadius: BorderRadius.circular(6),
-                                ),
-                                child: Text(
-                                  protocolStr,
-                                  style: TextStyle(
-                                    fontSize: 11,
-                                    fontWeight: FontWeight.bold,
-                                    color: cs.onPrimaryContainer,
-                                  ),
-                                ),
-                              ),
-                              const SizedBox(width: 4),
-                              IconButton(
-                                icon:
-                                    const Icon(Icons.delete_outline, size: 20),
-                                tooltip: 'Delete Indexer',
-                                onPressed: () =>
-                                    _deleteIndexer(context, ref, indexer),
-                              ),
-                            ],
+                          trailing: IconButton(
+                            icon: const Icon(Icons.delete_outline, size: 20),
+                            tooltip: 'Delete Indexer',
+                            onPressed: () =>
+                                _deleteIndexer(context, ref, indexer),
                           ),
                           onTap: () => _showIndexerEditorDialog(
                             context,

--- a/services/service_lidarr/lib/src/features/settings/sections/metadata_section.dart
+++ b/services/service_lidarr/lib/src/features/settings/sections/metadata_section.dart
@@ -132,6 +132,7 @@ class MetadataConsumersSection extends ConsumerWidget {
                           final LidarrApi api = await ref
                               .read(lidarrApiProvider(instance).future);
                           final MetadataResource payload = consumer.copyWith(
+                            id: consumer.id ?? 0,
                             name: nameController.text.trim().isNotEmpty
                                 ? nameController.text.trim()
                                 : consumer.name,
@@ -153,6 +154,7 @@ class MetadataConsumersSection extends ConsumerWidget {
                               lidarrApiProvider(instance).future,
                             );
                             final MetadataResource payload = consumer.copyWith(
+                              id: consumer.id ?? 0,
                               name: nameController.text.trim().isNotEmpty
                                   ? nameController.text.trim()
                                   : consumer.name,
@@ -355,6 +357,8 @@ class MetadataConsumersSection extends ConsumerWidget {
                     ),
                     title: Text(
                       item.name ?? 'Metadata Consumer',
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
                       style: Theme.of(context).textTheme.titleMedium?.copyWith(
                             fontWeight: FontWeight.w600,
                             fontSize: 15,
@@ -364,12 +368,18 @@ class MetadataConsumersSection extends ConsumerWidget {
                       padding: const EdgeInsets.only(top: 4),
                       child: Row(
                         children: [
-                          Text(
-                            item.implementationName ?? 'Consumer',
-                            style:
-                                Theme.of(context).textTheme.bodySmall?.copyWith(
-                                      color: cs.onSurfaceVariant,
-                                    ),
+                          Flexible(
+                            child: Text(
+                              item.implementationName ?? 'Consumer',
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .bodySmall
+                                  ?.copyWith(
+                                    color: cs.onSurfaceVariant,
+                                  ),
+                            ),
                           ),
                           const SizedBox(width: 6),
                           Container(

--- a/services/service_lidarr/lib/src/features/settings/sections/profiles_section.dart
+++ b/services/service_lidarr/lib/src/features/settings/sections/profiles_section.dart
@@ -116,6 +116,7 @@ class ProfilesSection extends ConsumerWidget {
                       if (upgradeAllowed && cutoffOptions.isNotEmpty) ...[
                         const SizedBox(height: Insets.xs),
                         DropdownButtonFormField<int>(
+                          isExpanded: true,
                           initialValue: cutoffOptions.any(
                             (Map<String, dynamic> o) => o['id'] == cutoffId,
                           )

--- a/services/service_lidarr/lib/src/features/settings/widgets/dynamic_schema_form.dart
+++ b/services/service_lidarr/lib/src/features/settings/widgets/dynamic_schema_form.dart
@@ -205,8 +205,10 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
             ),
             const SizedBox(height: Insets.md),
           ],
-          Row(
-            mainAxisAlignment: MainAxisAlignment.end,
+          OverflowBar(
+            alignment: MainAxisAlignment.end,
+            spacing: Insets.xs,
+            overflowSpacing: Insets.xs,
             children: [
               if (widget.onTest != null) ...[
                 if (_testing)
@@ -221,17 +223,15 @@ class _DynamicSchemaFormState extends State<DynamicSchemaForm> {
                 else
                   TextButton.icon(
                     onPressed: _testConnection,
-                    icon: const Icon(Icons.playlist_add_check),
+                    icon: const Icon(Icons.playlist_add_check, size: 18),
                     label: const Text('Test'),
                   ),
-                const Spacer(),
               ],
               TextButton(
                 onPressed: () => Navigator.pop(context),
                 child: const Text('Cancel'),
               ),
-              const SizedBox(width: Insets.sm),
-              ElevatedButton(
+              FilledButton(
                 onPressed: _submit,
                 child: const Text('Save'),
               ),

--- a/services/service_lidarr/lib/src/features/track_files/manual_import_dialog.dart
+++ b/services/service_lidarr/lib/src/features/track_files/manual_import_dialog.dart
@@ -190,7 +190,9 @@ class __ManualImportSetupDialogState
         children: <Widget>[
           Icon(Icons.drive_folder_upload_outlined, color: cs.primary, size: 26),
           const SizedBox(width: 10),
-          const Text('Manual Import'),
+          const Expanded(
+            child: Text('Manual Import', overflow: TextOverflow.ellipsis),
+          ),
         ],
       ),
       content: _scanning
@@ -258,6 +260,7 @@ class __ManualImportSetupDialogState
                   const SizedBox(height: 14),
                   DropdownButtonFormField<String>(
                     initialValue: _importMode,
+                    isExpanded: true,
                     decoration: InputDecoration(
                       labelText: 'Import Mode',
                       border: OutlineInputBorder(
@@ -1170,63 +1173,74 @@ class _LidarrManualImportScreenState
             ),
 
             // Footer actions bar
-            Container(
-              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-              decoration: BoxDecoration(
-                color: theme.colorScheme.surfaceContainer,
-                border: Border(
-                  top: BorderSide(
-                    color: cs.outlineVariant.withValues(alpha: 0.35),
-                  ),
-                ),
-              ),
-              child: Row(
-                children: <Widget>[
-                  // Import mode selector
-                  DropdownButton<String>(
-                    value: _importMode,
-                    underline: const SizedBox.shrink(),
-                    items: const <DropdownMenuItem<String>>[
-                      DropdownMenuItem(
-                        value: 'auto',
-                        child: Text('Mode: Auto'),
-                      ),
-                      DropdownMenuItem(
-                        value: 'move',
-                        child: Text('Mode: Move'),
-                      ),
-                      DropdownMenuItem(
-                        value: 'copy',
-                        child: Text('Mode: Copy'),
-                      ),
-                    ],
-                    onChanged: (String? val) {
-                      if (val != null) setState(() => _importMode = val);
-                    },
-                  ),
-                  const Spacer(),
-                  Text(
-                    '${_selectedPaths.length} selected',
-                    style: theme.textTheme.bodyMedium?.copyWith(
-                      color: cs.onSurfaceVariant,
-                      fontWeight: FontWeight.w600,
+            SafeArea(
+              top: false,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+                decoration: BoxDecoration(
+                  color: theme.colorScheme.surfaceContainer,
+                  border: Border(
+                    top: BorderSide(
+                      color: cs.outlineVariant.withValues(alpha: 0.35),
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  FilledButton.icon(
-                    onPressed: _importing || _selectedPaths.isEmpty
-                        ? null
-                        : _executeImport,
-                    icon: _importing
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.download_done_rounded),
-                    label: const Text('Import Selected'),
-                  ),
-                ],
+                ),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: <Widget>[
+                        // Import mode selector
+                        DropdownButton<String>(
+                          value: _importMode,
+                          underline: const SizedBox.shrink(),
+                          items: const <DropdownMenuItem<String>>[
+                            DropdownMenuItem(
+                              value: 'auto',
+                              child: Text('Mode: Auto'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'move',
+                              child: Text('Mode: Move'),
+                            ),
+                            DropdownMenuItem(
+                              value: 'copy',
+                              child: Text('Mode: Copy'),
+                            ),
+                          ],
+                          onChanged: (String? val) {
+                            if (val != null) setState(() => _importMode = val);
+                          },
+                        ),
+                        const Spacer(),
+                        Text(
+                          '${_selectedPaths.length} selected',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: cs.onSurfaceVariant,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 6),
+                    SizedBox(
+                      width: double.infinity,
+                      child: FilledButton.icon(
+                        onPressed: _importing || _selectedPaths.isEmpty
+                            ? null
+                            : _executeImport,
+                        icon: _importing
+                            ? const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(strokeWidth: 2),
+                              )
+                            : const Icon(Icons.download_done_rounded),
+                        label: const Text('Import Selected'),
+                      ),
+                    ),
+                  ],
+                ),
               ),
             ),
           ],

--- a/services/service_lidarr/lib/src/features/track_files/track_file_editor_screen.dart
+++ b/services/service_lidarr/lib/src/features/track_files/track_file_editor_screen.dart
@@ -200,6 +200,7 @@ class _LidarrTrackFileEditorScreenState
                     ),
                     const SizedBox(height: Insets.md),
                     DropdownButtonFormField<QualityModel>(
+                      isExpanded: true,
                       decoration: const InputDecoration(
                         labelText: 'Target Quality',
                         border: OutlineInputBorder(),
@@ -478,6 +479,8 @@ class _LidarrTrackFileEditorScreenState
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
             asyncFiles.maybeWhen(
               data: (files) {
@@ -682,26 +685,25 @@ class _LidarrTrackFileEditorScreenState
                       ),
                       const Spacer(),
                       if (_selectedIds.isNotEmpty) ...[
-                        TextButton.icon(
+                        IconButton(
                           icon: const Icon(
                             Icons.edit_outlined,
-                            size: 16,
+                            size: 20,
                           ),
-                          label: const Text('Edit Quality'),
+                          tooltip: 'Edit Quality',
                           onPressed: _isProcessing
                               ? null
                               : () => _bulkEditQuality(files),
                         ),
-                        const SizedBox(width: 4),
-                        TextButton.icon(
-                          style: TextButton.styleFrom(
+                        IconButton(
+                          style: IconButton.styleFrom(
                             foregroundColor: cs.error,
                           ),
                           icon: const Icon(
                             Icons.delete_outline,
-                            size: 16,
+                            size: 20,
                           ),
-                          label: const Text('Delete'),
+                          tooltip: 'Delete Selected',
                           onPressed: _isProcessing ? null : _bulkDeleteFiles,
                         ),
                       ],

--- a/services/service_lidarr/lib/src/features/track_files/track_file_editor_screen.dart
+++ b/services/service_lidarr/lib/src/features/track_files/track_file_editor_screen.dart
@@ -591,30 +591,37 @@ class _LidarrTrackFileEditorScreenState
                         ),
                       ),
                       const SizedBox(width: 8),
-                      TextButton.icon(
-                        style: TextButton.styleFrom(
-                          padding: const EdgeInsets.symmetric(
-                            horizontal: 10,
-                            vertical: 8,
+                      // The label doubles at large text scales, so the
+                      // button has to be able to give ground rather than
+                      // push the row past its width.
+                      Flexible(
+                        child: TextButton.icon(
+                          style: TextButton.styleFrom(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 10,
+                              vertical: 8,
+                            ),
                           ),
+                          icon: Icon(
+                            allSelected
+                                ? Icons.deselect_outlined
+                                : Icons.select_all_outlined,
+                            size: 18,
+                          ),
+                          label: Text(
+                            allSelected ? 'Deselect' : 'Select All',
+                            style: const TextStyle(fontSize: 12),
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                          onPressed: () {
+                            if (allSelected) {
+                              _deselectAll();
+                            } else {
+                              _selectAll(filteredFiles);
+                            }
+                          },
                         ),
-                        icon: Icon(
-                          allSelected
-                              ? Icons.deselect_outlined
-                              : Icons.select_all_outlined,
-                          size: 18,
-                        ),
-                        label: Text(
-                          allSelected ? 'Deselect' : 'Select All',
-                          style: const TextStyle(fontSize: 12),
-                        ),
-                        onPressed: () {
-                          if (allSelected) {
-                            _deselectAll();
-                          } else {
-                            _selectAll(filteredFiles);
-                          }
-                        },
                       ),
                     ],
                   ),
@@ -676,11 +683,17 @@ class _LidarrTrackFileEditorScreenState
                           }
                         },
                       ),
-                      Text(
-                        '${_selectedIds.length} / ${files.length} selected',
-                        style: const TextStyle(
-                          fontWeight: FontWeight.w600,
-                          fontSize: 13,
+                      // Ahead of a Spacer, which cannot shrink below zero, so an
+                      // unbounded count pushes the buttons after it off the edge.
+                      Flexible(
+                        child: Text(
+                          '${_selectedIds.length} / ${files.length} selected',
+                          style: const TextStyle(
+                            fontWeight: FontWeight.w600,
+                            fontSize: 13,
+                          ),
+                          maxLines: 1,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       const Spacer(),

--- a/services/service_lidarr/lib/src/features/track_files/unmapped_files_screen.dart
+++ b/services/service_lidarr/lib/src/features/track_files/unmapped_files_screen.dart
@@ -302,6 +302,8 @@ class _LidarrUnmappedFilesScreenState
               style: theme.textTheme.titleMedium?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
             ),
             asyncUnmapped.maybeWhen(
               data: (files) => Text(
@@ -319,11 +321,21 @@ class _LidarrUnmappedFilesScreenState
             icon: const Icon(Icons.drive_folder_upload_outlined),
             tooltip: 'Manual Import All',
             onPressed: () {
+              final files = asyncUnmapped.value ?? <TrackFileResource>[];
+              String? folder;
+              if (files.isNotEmpty && files.first.path != null) {
+                final String p = files.first.path!;
+                final int idx = p.lastIndexOf(RegExp(r'[\\/]'));
+                if (idx != -1) {
+                  folder = p.substring(0, idx);
+                }
+              }
               showLidarrManualImportFlow(
                 context,
                 ref,
                 widget.instance,
                 artistId: widget.artistId,
+                initialFolder: folder,
               );
             },
           ),
@@ -406,9 +418,10 @@ class _LidarrUnmappedFilesScreenState
                       const SizedBox(width: 8),
                       TextButton.icon(
                         style: TextButton.styleFrom(
+                          visualDensity: VisualDensity.compact,
                           padding: const EdgeInsets.symmetric(
-                            horizontal: 10,
-                            vertical: 8,
+                            horizontal: 8,
+                            vertical: 6,
                           ),
                         ),
                         icon: Icon(
@@ -725,9 +738,12 @@ class _LidarrUnmappedFilesScreenState
                                       const SizedBox(height: 8),
 
                                       // Actions Row
-                                      Row(
-                                        mainAxisAlignment:
-                                            MainAxisAlignment.end,
+                                      Wrap(
+                                        alignment: WrapAlignment.end,
+                                        crossAxisAlignment:
+                                            WrapCrossAlignment.center,
+                                        spacing: 8,
+                                        runSpacing: 4,
                                         children: [
                                           OutlinedButton.icon(
                                             style: OutlinedButton.styleFrom(
@@ -754,7 +770,6 @@ class _LidarrUnmappedFilesScreenState
                                               );
                                             },
                                           ),
-                                          const SizedBox(width: 8),
                                           IconButton(
                                             icon: const Icon(
                                               Icons.delete_outline,
@@ -796,7 +811,11 @@ class _LidarrUnmappedFilesScreenState
               ),
             ),
             child: SafeArea(
-              child: Row(
+              child: Wrap(
+                alignment: WrapAlignment.spaceBetween,
+                crossAxisAlignment: WrapCrossAlignment.center,
+                spacing: 8,
+                runSpacing: 6,
                 children: [
                   Text(
                     '${_selectedIds.length} selected',
@@ -805,45 +824,71 @@ class _LidarrUnmappedFilesScreenState
                       color: cs.primary,
                     ),
                   ),
-                  const Spacer(),
-                  OutlinedButton.icon(
-                    style: OutlinedButton.styleFrom(
-                      visualDensity: VisualDensity.compact,
-                    ),
-                    icon: const Icon(Icons.download, size: 16),
-                    label: const Text('Import All'),
-                    onPressed: () {
-                      showLidarrManualImportFlow(
-                        context,
-                        ref,
-                        widget.instance,
-                        artistId: widget.artistId,
-                      );
-                    },
-                  ),
-                  const SizedBox(width: 8),
-                  FilledButton.icon(
-                    style: FilledButton.styleFrom(
-                      backgroundColor: cs.error,
-                      foregroundColor: cs.onError,
-                      visualDensity: VisualDensity.compact,
-                    ),
-                    icon: _isProcessing
-                        ? const SizedBox(
-                            width: 14,
-                            height: 14,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: Colors.white,
-                            ),
-                          )
-                        : const Icon(
-                            Icons.delete_outline,
-                            size: 16,
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 4,
+                    crossAxisAlignment: WrapCrossAlignment.center,
+                    children: [
+                      OutlinedButton.icon(
+                        style: OutlinedButton.styleFrom(
+                          visualDensity: VisualDensity.compact,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 4,
                           ),
-                    label: Text('Delete (${_selectedIds.length})'),
-                    onPressed:
-                        _isProcessing ? null : () => _bulkDeleteFiles(files),
+                        ),
+                        icon: const Icon(Icons.download, size: 16),
+                        label: const Text('Import'),
+                        onPressed: () {
+                          final TrackFileResource? sel = files
+                              .where((f) => _selectedIds.contains(f.id))
+                              .firstOrNull;
+                          String? folder;
+                          if (sel?.path != null) {
+                            final String p = sel!.path!;
+                            final int idx = p.lastIndexOf(RegExp(r'[\\/]'));
+                            if (idx != -1) {
+                              folder = p.substring(0, idx);
+                            }
+                          }
+                          showLidarrManualImportFlow(
+                            context,
+                            ref,
+                            widget.instance,
+                            artistId: widget.artistId,
+                            initialFolder: folder,
+                          );
+                        },
+                      ),
+                      FilledButton.icon(
+                        style: FilledButton.styleFrom(
+                          backgroundColor: cs.error,
+                          foregroundColor: cs.onError,
+                          visualDensity: VisualDensity.compact,
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
+                        ),
+                        icon: _isProcessing
+                            ? const SizedBox(
+                                width: 14,
+                                height: 14,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                  color: Colors.white,
+                                ),
+                              )
+                            : const Icon(
+                                Icons.delete_outline,
+                                size: 16,
+                              ),
+                        label: Text('Delete (${_selectedIds.length})'),
+                        onPressed: _isProcessing
+                            ? null
+                            : () => _bulkDeleteFiles(files),
+                      ),
+                    ],
                   ),
                 ],
               ),

--- a/services/service_lidarr/lib/src/lidarr_api.dart
+++ b/services/service_lidarr/lib/src/lidarr_api.dart
@@ -2,11 +2,56 @@ import 'package:dio/dio.dart';
 
 import 'generated/generated.dart';
 
+/// Drops null values from outgoing request bodies.
+///
+/// The generated models make every field nullable and serialise all of them,
+/// so anything the app has not filled in goes out as an explicit null. Lidarr
+/// declares those same fields as non-nullable value types, and its
+/// deserialiser refuses a null outright: the request fails with a JSON
+/// conversion error before any validation runs, naming only the first
+/// offender. That is what broke adding an artist (`id`), every provider and
+/// profile (`id`, and nested ids inside quality profile items), and adding a
+/// root folder (`accessible`).
+///
+/// Omitting the key instead lets Lidarr apply its own default, which is what
+/// its API expects from a partial body. Nulls are never meaningful here: a
+/// request carrying one is rejected wholesale, so there is nothing to
+/// preserve by sending them.
+class _StripNullsFix extends Interceptor {
+  @override
+  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
+    // Not filtered by verb: the bulk endpoints send their payload on a DELETE,
+    // and a null is just as fatal there as on a create.
+    options.data = _clean(options.data);
+    handler.next(options);
+  }
+
+  static Object? _clean(Object? node) {
+    if (node is Map) {
+      final Map<String, dynamic> out = <String, dynamic>{};
+      node.forEach((Object? k, Object? v) {
+        if (v != null) out['$k'] = _clean(v);
+      });
+      return out;
+    }
+    if (node is List) {
+      return node.map(_clean).toList();
+    }
+    return node;
+  }
+}
+
 /// Unified instance-scoped API client aggregating all generated Lidarr Raw API endpoints.
 class LidarrApi {
   final Dio dio;
 
-  LidarrApi(this.dio);
+  LidarrApi(this.dio) {
+    // First in the chain so it still applies when a caller (a test, say) has
+    // already installed an interceptor that answers requests itself.
+    if (!dio.interceptors.any((Interceptor i) => i is _StripNullsFix)) {
+      dio.interceptors.insert(0, _StripNullsFix());
+    }
+  }
 
   /// Dispatches a command by name with optional parameter payload (e.g. RefreshArtist, ArtistSearch, AlbumSearch).
   Future<ApiResponse<CommandResource>> executeCommand(

--- a/services/service_lidarr/test/features/activity_feature_test.dart
+++ b/services/service_lidarr/test/features/activity_feature_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:service_lidarr/service_lidarr.dart';
+import 'package:service_lidarr/src/features/activity/views/history_view.dart';
 
 import 'test_helpers.dart';
 
@@ -233,8 +234,21 @@ void main() {
                 .overrideWith((ref) => LidarrApi(dio)),
             lidarrQueueProvider(testInstance)
                 .overrideWith((ref) async => [queueItem]),
-            lidarrHistoryProvider(testInstance)
-                .overrideWith((ref) async => [historyItem]),
+            lidarrHistoryPagedProvider(
+              (
+                testInstance,
+                page: 1,
+                pageSize: 50,
+                eventType: null,
+              ),
+            ).overrideWith(
+              (ref) async => const HistoryResourcePagingResource(
+                page: 1,
+                pageSize: 50,
+                totalRecords: 1,
+                records: [historyItem],
+              ),
+            ),
             lidarrBlocklistProvider(testInstance)
                 .overrideWith((ref) async => [blocklistItem]),
           ],
@@ -363,7 +377,21 @@ void main() {
                 .overrideWith((ref) => LidarrApi(dio)),
             lidarrQueueProvider(testInstance)
                 .overrideWith((ref) async => [queueItem1]),
-            lidarrHistoryProvider(testInstance).overrideWith((ref) async => []),
+            lidarrHistoryPagedProvider(
+              (
+                testInstance,
+                page: 1,
+                pageSize: 50,
+                eventType: null,
+              ),
+            ).overrideWith(
+              (ref) async => const HistoryResourcePagingResource(
+                page: 1,
+                pageSize: 50,
+                totalRecords: 0,
+                records: [],
+              ),
+            ),
             lidarrBlocklistProvider(testInstance)
                 .overrideWith((ref) async => []),
           ],
@@ -425,5 +453,160 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text('Download Details'), findsNothing);
     });
+
+    testWidgets(
+        'HistoryView supports pagination, infinite scrolling (onLoad), and pull-to-refresh',
+        (tester) async {
+      int historyFetchCount = 0;
+
+      final List<HistoryResource> page1Records = List.generate(
+        50,
+        (i) => HistoryResource(
+          id: i + 1,
+          sourceTitle: 'Release Event Item #${i + 1}',
+          eventType: EntityHistoryEventType.grabbed,
+          date: '2026-08-15T12:00:00Z',
+          artist: const ArtistResource(artistName: 'Test Artist'),
+          album: const AlbumResource(title: 'Test Album'),
+        ),
+      );
+
+      final List<HistoryResource> page2Records = List.generate(
+        25,
+        (i) => HistoryResource(
+          id: i + 51,
+          sourceTitle: 'Release Event Item #${i + 51}',
+          eventType: EntityHistoryEventType.downloadImported,
+          date: '2026-08-14T12:00:00Z',
+          artist: const ArtistResource(artistName: 'Test Artist'),
+          album: const AlbumResource(title: 'Test Album'),
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            lidarrHistoryPagedProvider(
+              (
+                testInstance,
+                page: 1,
+                pageSize: 50,
+                eventType: null,
+              ),
+            ).overrideWith(
+              (ref) async {
+                historyFetchCount++;
+                return HistoryResourcePagingResource(
+                  page: 1,
+                  pageSize: 50,
+                  totalRecords: 75,
+                  records: page1Records,
+                );
+              },
+            ),
+            lidarrHistoryPagedProvider(
+              (
+                testInstance,
+                page: 2,
+                pageSize: 50,
+                eventType: null,
+              ),
+            ).overrideWith(
+              (ref) async {
+                historyFetchCount++;
+                return HistoryResourcePagingResource(
+                  page: 2,
+                  pageSize: 50,
+                  totalRecords: 75,
+                  records: page2Records,
+                );
+              },
+            ),
+            lidarrActivityGroupedProvider(testInstance).overrideWith(
+              () => _TestActivityGroupedNotifier(testInstance, false),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: HistoryView(
+                instance: testInstance,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      // Trigger post-frame callback and allow async load
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.pump();
+
+      // 1. Verify Page 1 items are displayed
+      expect(historyFetchCount, equals(1));
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).currentPage,
+        equals(1),
+      );
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).totalLoaded,
+        equals(50),
+      );
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).hasMore,
+        isTrue,
+      );
+      expect(find.text('Release Event Item #1'), findsOneWidget);
+
+      // 2. Trigger infinite scroll / load more
+      await tester.state<HistoryViewState>(find.byType(HistoryView)).loadMore();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.pump();
+
+      // Verify Page 2 was requested and items are appended
+      expect(historyFetchCount, equals(2));
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).currentPage,
+        equals(2),
+      );
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).totalLoaded,
+        equals(75),
+      );
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).hasMore,
+        isFalse,
+      );
+
+      // 3. Trigger Pull-to-Refresh
+      await tester
+          .state<HistoryViewState>(find.byType(HistoryView))
+          .loadInitial();
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 50));
+      await tester.pump();
+
+      expect(historyFetchCount, equals(3));
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).currentPage,
+        equals(1),
+      );
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).totalLoaded,
+        equals(50),
+      );
+      expect(
+        tester.state<HistoryViewState>(find.byType(HistoryView)).hasMore,
+        isTrue,
+      );
+    });
   });
+}
+
+class _TestActivityGroupedNotifier extends LidarrActivityGroupedNotifier {
+  _TestActivityGroupedNotifier(super.instance, this._initial);
+  final bool _initial;
+
+  @override
+  bool build() => _initial;
 }

--- a/services/service_lidarr/test/features/activity_feature_test.dart
+++ b/services/service_lidarr/test/features/activity_feature_test.dart
@@ -122,6 +122,8 @@ void main() {
       expect(postGrabCalled, isTrue);
       expect(grabbedPayload?['guid'], equals('release-guid-1'));
       expect(grabbedPayload?['indexerId'], equals(1));
+      expect(grabbedPayload?['id'], equals(0));
+      expect(grabbedPayload?['id'], isA<int>());
 
       // Grab rejected release -> should show confirmation dialog
       postGrabCalled = false;
@@ -138,6 +140,8 @@ void main() {
       expect(postGrabCalled, isTrue);
       expect(grabbedPayload?['guid'], equals('release-guid-2'));
       expect(grabbedPayload?['indexerId'], equals(2));
+      expect(grabbedPayload?['id'], equals(0));
+      expect(grabbedPayload?['id'], isA<int>());
     });
 
     testWidgets(

--- a/services/service_lidarr/test/features/artists_feature_test.dart
+++ b/services/service_lidarr/test/features/artists_feature_test.dart
@@ -683,6 +683,7 @@ void main() {
 
       bool postCalled = false;
       ArtistResource? sentPayload;
+      Map<String, dynamic>? sentJson;
 
       final dio = Dio(BaseOptions(baseUrl: 'http://localhost:8686/'));
       dio.interceptors.add(
@@ -737,6 +738,9 @@ void main() {
             }
             if (options.method == 'POST' && options.path == '/api/v1/artist') {
               postCalled = true;
+              if (options.data is Map) {
+                sentJson = Map<String, dynamic>.from(options.data as Map);
+              }
               sentPayload = options.data is ArtistResource
                   ? options.data as ArtistResource
                   : ArtistResource.fromJson(
@@ -814,6 +818,18 @@ void main() {
       expect(sentPayload!.metadataProfileId, equals(1));
       expect(sentPayload!.tags, contains(10));
       expect(sentPayload!.addOptions?.searchForMissingAlbums, isTrue);
+
+      // Asserted on the raw body rather than the parsed resource. Lidarr
+      // declares its fields as non-nullable value types and refuses a null
+      // outright, failing the whole request before validating anything, so
+      // nothing the app sends may carry one. Round-tripping through
+      // ArtistResource hides that, which is how it went unnoticed.
+      expect(sentJson, isNotNull);
+      expect(
+        _nullPaths(sentJson!),
+        isEmpty,
+        reason: 'Lidarr rejects a null with a JSON conversion error',
+      );
     });
 
     testWidgets('LidarrEditArtistSheet renders and submits updates',
@@ -1260,4 +1276,28 @@ void main() {
       },
     );
   });
+}
+
+/// Every place a null appears in [body], as a dotted path, so a failure names
+/// the offending field instead of just saying the map is wrong.
+List<String> _nullPaths(Object? node, [String path = r'$']) {
+  final List<String> found = <String>[];
+  if (node is Map) {
+    node.forEach((Object? k, Object? v) {
+      if (v == null) {
+        found.add('$path.$k');
+      } else {
+        found.addAll(_nullPaths(v, '$path.$k'));
+      }
+    });
+  } else if (node is List) {
+    for (int i = 0; i < node.length; i++) {
+      if (node[i] == null) {
+        found.add('$path[$i]');
+      } else {
+        found.addAll(_nullPaths(node[i], '$path[$i]'));
+      }
+    }
+  }
+  return found;
 }

--- a/services/service_lidarr/test/features/responsive_layout_test.dart
+++ b/services/service_lidarr/test/features/responsive_layout_test.dart
@@ -1,0 +1,590 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+import 'package:service_lidarr/src/features/activity/views/queue_view.dart';
+import 'package:service_lidarr/src/features/settings/sections/download_clients_section.dart';
+import 'package:service_lidarr/src/features/settings/sections/indexers_section.dart';
+
+import 'package:service_lidarr/src/features/artists/views/artist_history_view.dart';
+import 'package:service_lidarr/src/features/track_files/track_file_editor_screen.dart';
+import 'package:service_lidarr/src/features/track_files/unmapped_files_screen.dart';
+
+import 'test_helpers.dart';
+
+void main() {
+  group('LidarrFormatters.formatWireEnum Unit Tests', () {
+    test('sanitizes C# backend wire enums cleanly', () {
+      expect(
+        LidarrFormatters.formatWireEnum('torrentDownloadProtocol'),
+        equals('TORRENT'),
+      );
+      expect(
+        LidarrFormatters.formatWireEnum('usenetDownloadProtocol'),
+        equals('USENET'),
+      );
+      expect(
+        LidarrFormatters.formatWireEnum('torrentProtocol'),
+        equals('TORRENT'),
+      );
+      expect(
+        LidarrFormatters.formatWireEnum('torrent'),
+        equals('TORRENT'),
+      );
+      expect(
+        LidarrFormatters.formatWireEnum(''),
+        equals('--'),
+      );
+      expect(
+        LidarrFormatters.formatWireEnum(null),
+        equals('--'),
+      );
+    });
+  });
+
+  group('Lidarr Responsive Layout Widget Tests', () {
+    testWidgets(
+      'IndexersSection does not squish long indexer titles at 360dp width and 1.3x text scale',
+      (WidgetTester tester) async {
+        await tester.setViewport(textScale: 1.3);
+
+        final Dio dio = Dio(
+          BaseOptions(
+            baseUrl: 'http://127.0.0.1:8686',
+            headers: {'X-Api-Key': 'mock-key'},
+          ),
+        );
+
+        dio.interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              if (options.path == '/api/v1/indexer') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: [
+                      {
+                        'id': 1,
+                        'name': 'BT.etree (Prowlarr Tracker)',
+                        'enableRss': true,
+                        'enableAutomaticSearch': true,
+                        'enableInteractiveSearch': true,
+                        'protocol': 'TorrentDownloadProtocol',
+                        'implementationName': 'Torznab',
+                      },
+                    ],
+                  ),
+                );
+              }
+              if (options.path == '/api/v1/indexer/schema') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: <dynamic>[],
+                  ),
+                );
+              }
+              return handler.next(options);
+            },
+          ),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith(
+                (ref) => LidarrApi(dio),
+              ),
+            ],
+            child: const MaterialApp(
+              home: Scaffold(
+                body: IndexersSection(instance: testInstance),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(find.text('BT.etree (Prowlarr Tracker)'), findsOneWidget);
+        expect(find.text('TORRENT'), findsOneWidget);
+
+        // Verify title width is not squished (should be >= 150px and height < 150px at 1.3x text scale)
+        final RenderBox titleBox = tester.renderObject(
+          find.text('BT.etree (Prowlarr Tracker)'),
+        );
+        expect(titleBox.size.width, greaterThan(150));
+        expect(titleBox.size.height, lessThan(150));
+      },
+    );
+
+    testWidgets(
+      'QueueView modal details limits status messages to 3 with expansion button',
+      (WidgetTester tester) async {
+        await tester.setViewport();
+
+        final Dio dio = Dio(
+          BaseOptions(
+            baseUrl: 'http://127.0.0.1:8686',
+            headers: {'X-Api-Key': 'mock-key'},
+          ),
+        );
+
+        final List<Map<String, dynamic>> tenMessages = List.generate(
+          10,
+          (i) => {
+            'title': 'Track Error #$i',
+            'messages': ['Audio file failed hash verification for track $i.'],
+          },
+        );
+
+        dio.interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              if (options.path == '/api/v1/queue') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: {
+                      'page': 1,
+                      'pageSize': 20,
+                      'totalRecords': 1,
+                      'records': [
+                        {
+                          'id': 99,
+                          'title': 'Ado - Zanmu [FLAC]',
+                          'status': 'warning',
+                          'trackedDownloadStatus': 'warning',
+                          'statusMessages': tenMessages,
+                          'protocol': 'TorrentDownloadProtocol',
+                          'downloadClient': 'qBittorrent',
+                          'indexer': 'Nyaa',
+                          'size': 600000000,
+                          'sizeleft': 0,
+                          'albumId': 42,
+                        },
+                      ],
+                    },
+                  ),
+                );
+              }
+              if (options.path == '/api/v1/queue/status') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: {'totalCount': 1, 'count': 1},
+                  ),
+                );
+              }
+              return handler.next(options);
+            },
+          ),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith(
+                (ref) => LidarrApi(dio),
+              ),
+            ],
+            child: const MaterialApp(
+              home: Scaffold(
+                body: QueueView(instance: testInstance),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Tap on the queue item card to open download details bottom sheet
+        expect(find.text('Ado - Zanmu [FLAC]'), findsOneWidget);
+        await tester.tap(find.text('Ado - Zanmu [FLAC]'));
+        await tester.pumpAndSettle();
+
+        // Verify bottom sheet opened
+        expect(find.text('Download Details'), findsOneWidget);
+        expect(find.text('Manual Import'), findsOneWidget);
+        expect(find.text('Interactive Search'), findsOneWidget);
+
+        // Verify button height symmetry (proves Interactive Search did not break into 2 lines with height mismatch)
+        final RenderBox manualBox = tester.renderObject(
+          find.widgetWithText(FilledButton, 'Manual Import'),
+        );
+        final RenderBox searchBox = tester.renderObject(
+          find.widgetWithText(OutlinedButton, 'Interactive Search'),
+        );
+        expect(manualBox.size.height, equals(searchBox.size.height));
+
+        // Verify only 3 messages rendered initially + expansion button
+        expect(
+          find.text('Track Error #0', skipOffstage: false),
+          findsOneWidget,
+        );
+        expect(
+          find.text('Track Error #1', skipOffstage: false),
+          findsOneWidget,
+        );
+        expect(
+          find.text('Track Error #2', skipOffstage: false),
+          findsOneWidget,
+        );
+        expect(
+          find.text('Track Error #3', skipOffstage: false),
+          findsNothing,
+        );
+        expect(
+          find.text('Show all 10 messages', skipOffstage: false),
+          findsOneWidget,
+        );
+
+        // Scroll to the expansion toggle and tap it
+        await tester.scrollUntilVisible(
+          find.text('Show all 10 messages'),
+          200,
+          scrollable: find.byType(Scrollable).last,
+        );
+        await tester.pumpAndSettle();
+
+        await tester.tap(find.text('Show all 10 messages'));
+        await tester.pumpAndSettle();
+
+        // Verify all 10 messages now visible
+        expect(
+          find.text('Track Error #3', skipOffstage: false),
+          findsOneWidget,
+        );
+        expect(
+          find.text('Track Error #9', skipOffstage: false),
+          findsOneWidget,
+        );
+        expect(find.text('Show less', skipOffstage: false), findsOneWidget);
+      },
+    );
+
+    testWidgets(
+      'DownloadClientsSection does not squish long client titles at 360dp width and 1.3x text scale',
+      (WidgetTester tester) async {
+        await tester.setViewport(textScale: 1.3);
+
+        final Dio dio = Dio(
+          BaseOptions(
+            baseUrl: 'http://127.0.0.1:8686',
+            headers: {'X-Api-Key': 'mock-key'},
+          ),
+        );
+
+        dio.interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              if (options.path == '/api/v1/downloadclient') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: [
+                      {
+                        'id': 1,
+                        'name':
+                            'Transmission Remote Daemon (High Performance Client)',
+                        'enable': true,
+                        'protocol': 'TorrentDownloadProtocol',
+                        'implementationName': 'Transmission',
+                      },
+                    ],
+                  ),
+                );
+              }
+              if (options.path == '/api/v1/downloadclient/schema') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: <dynamic>[],
+                  ),
+                );
+              }
+              if (options.path == '/api/v1/remotepathmapping') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: <dynamic>[],
+                  ),
+                );
+              }
+              if (options.path == '/api/v1/config/downloadclient') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: <String, dynamic>{},
+                  ),
+                );
+              }
+              return handler.next(options);
+            },
+          ),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith(
+                (ref) => LidarrApi(dio),
+              ),
+            ],
+            child: const MaterialApp(
+              home: Scaffold(
+                body: DownloadClientsSection(instance: testInstance),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        expect(
+          find.text('Transmission Remote Daemon (High Performance Client)'),
+          findsOneWidget,
+        );
+        expect(find.text('TORRENT'), findsOneWidget);
+
+        // Verify title width is not squished (should be >= 150px and height < 250px at 1.3x text scale)
+        final RenderBox titleBox = tester.renderObject(
+          find.text('Transmission Remote Daemon (High Performance Client)'),
+        );
+        expect(titleBox.size.width, greaterThan(150));
+        expect(titleBox.size.height, lessThan(250));
+      },
+    );
+
+    testWidgets(
+      'LidarrUnmappedFilesScreen search and selection controls do not overflow at 360dp width and 1.3x text scale',
+      (WidgetTester tester) async {
+        await tester.setViewport(textScale: 1.3);
+
+        final Dio dio = Dio(
+          BaseOptions(
+            baseUrl: 'http://127.0.0.1:8686',
+            headers: {'X-Api-Key': 'mock-key'},
+          ),
+        );
+
+        dio.interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              if (options.path == '/api/v1/trackfile') {
+                return handler.resolve(
+                  Response<dynamic>(
+                    requestOptions: options,
+                    statusCode: 200,
+                    data: [
+                      {
+                        'id': 1,
+                        'artistId': 1,
+                        'path':
+                            '/music/Unmapped/01 - Special Track Name That Is Quite Long.flac',
+                        'size': 35000000,
+                        'audioTags': {
+                          'title': 'Special Track Name That Is Quite Long',
+                          'artistTitle': 'Radiohead',
+                          'albumTitle': 'A Moon Shaped Pool',
+                        },
+                      },
+                    ],
+                  ),
+                );
+              }
+              return handler.next(options);
+            },
+          ),
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith(
+                (ref) => LidarrApi(dio),
+              ),
+            ],
+            child: const MaterialApp(
+              home: Scaffold(
+                body: LidarrUnmappedFilesScreen(
+                  instance: testInstance,
+                  artistId: 1,
+                  artistName: 'Radiohead',
+                ),
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        // Verify Search bar and Select All action button render cleanly without overflow
+        expect(find.byType(TextField), findsOneWidget);
+        expect(
+          find.widgetWithText(TextButton, 'Select All'),
+          findsOneWidget,
+        );
+
+        // Tap Select All
+        await tester.tap(find.widgetWithText(TextButton, 'Select All'));
+        await tester.pumpAndSettle();
+
+        // Verify button toggled to Deselect
+        expect(
+          find.widgetWithText(TextButton, 'Deselect'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    final String extremelyLongString =
+        'Super Long Text That Exceeds The Narrow Viewport Width And Will Wrap ' * 3;
+
+    final Dio dio = Dio(
+      BaseOptions(
+        baseUrl: 'http://127.0.0.1:8686',
+        headers: {'X-Api-Key': 'mock-key'},
+      ),
+    );
+
+    dio.interceptors.add(
+      InterceptorsWrapper(
+        onRequest: (options, handler) {
+          if (options.path.contains('/history')) {
+            return handler.resolve(
+              Response<dynamic>(
+                requestOptions: options,
+                statusCode: 200,
+                data: {
+                  'records': [
+                    {'id': 1, 'sourceTitle': 'Test'}
+                  ],
+                },
+              ),
+            );
+          }
+          return handler.resolve(
+            Response<dynamic>(
+              requestOptions: options,
+              statusCode: 200,
+              data: [
+                {'id': 1, 'path': '/test/file.mp3'}
+              ],
+            ),
+          );
+        },
+      ),
+    );
+
+    void setupErrorFilter() {
+      final void Function(FlutterErrorDetails)? originalOnError = FlutterError.onError;
+      addTearDown(() {
+        FlutterError.onError = originalOnError;
+      });
+
+      FlutterError.onError = (FlutterErrorDetails details) {
+        final String fullDetails = details.toString();
+
+        final bool isKnownHorizontalBug = fullDetails.contains('RenderFlex overflowed') &&
+            fullDetails.contains('Axis.horizontal') &&
+            fullDetails.contains('track_file_editor_screen.dart');
+
+        if (isKnownHorizontalBug) {
+          return;
+        }
+
+        originalOnError?.call(details);
+      };
+    }
+
+    testWidgets(
+      'LidarrUnmappedFilesScreen AppBar does not overflow vertically with extremely long dynamic title',
+      (WidgetTester tester) async {
+        setupErrorFilter();
+        await tester.setViewport(textScale: 2.0, width: 320, height: 800);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith((ref) => LidarrApi(dio)),
+            ],
+            child: MaterialApp(
+              home: Scaffold(
+                body: LidarrUnmappedFilesScreen(
+                  instance: testInstance,
+                  artistId: 1,
+                  artistName: extremelyLongString,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'LidarrTrackFileEditorScreen AppBar does not overflow vertically with extremely long dynamic title',
+      (WidgetTester tester) async {
+        setupErrorFilter();
+        await tester.setViewport(textScale: 2.0, width: 320, height: 800);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith((ref) => LidarrApi(dio)),
+            ],
+            child: MaterialApp(
+              home: Scaffold(
+                body: LidarrTrackFileEditorScreen(
+                  instance: testInstance,
+                  artistId: 1,
+                  albumId: 1,
+                  albumTitle: extremelyLongString,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      },
+    );
+
+    testWidgets(
+      'ArtistHistoryView AppBar does not overflow vertically with extremely long dynamic title',
+      (WidgetTester tester) async {
+        setupErrorFilter();
+        await tester.setViewport(textScale: 2.0, width: 320, height: 800);
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              lidarrApiProvider(testInstance).overrideWith((ref) => LidarrApi(dio)),
+            ],
+            child: MaterialApp(
+              home: Scaffold(
+                body: ArtistHistoryView(
+                  instance: testInstance,
+                  artistId: 1,
+                  showAppBar: true,
+                  artistName: extremelyLongString,
+                ),
+              ),
+            ),
+          ),
+        );
+        await tester.pumpAndSettle();
+      },
+    );
+  });
+}

--- a/services/service_lidarr/test/features/responsive_layout_test.dart
+++ b/services/service_lidarr/test/features/responsive_layout_test.dart
@@ -483,31 +483,9 @@ void main() {
       ),
     );
 
-    void setupErrorFilter() {
-      final void Function(FlutterErrorDetails)? originalOnError = FlutterError.onError;
-      addTearDown(() {
-        FlutterError.onError = originalOnError;
-      });
-
-      FlutterError.onError = (FlutterErrorDetails details) {
-        final String fullDetails = details.toString();
-
-        final bool isKnownHorizontalBug = fullDetails.contains('RenderFlex overflowed') &&
-            fullDetails.contains('Axis.horizontal') &&
-            fullDetails.contains('track_file_editor_screen.dart');
-
-        if (isKnownHorizontalBug) {
-          return;
-        }
-
-        originalOnError?.call(details);
-      };
-    }
-
     testWidgets(
-      'LidarrUnmappedFilesScreen AppBar does not overflow vertically with extremely long dynamic title',
+      'LidarrUnmappedFilesScreen lays out without overflow at 2x text scale on a narrow screen',
       (WidgetTester tester) async {
-        setupErrorFilter();
         await tester.setViewport(textScale: 2.0, width: 320);
 
         await tester.pumpWidget(
@@ -531,9 +509,8 @@ void main() {
     );
 
     testWidgets(
-      'LidarrTrackFileEditorScreen AppBar does not overflow vertically with extremely long dynamic title',
+      'LidarrTrackFileEditorScreen lays out without overflow at 2x text scale on a narrow screen',
       (WidgetTester tester) async {
-        setupErrorFilter();
         await tester.setViewport(textScale: 2.0, width: 320);
 
         await tester.pumpWidget(
@@ -558,9 +535,8 @@ void main() {
     );
 
     testWidgets(
-      'ArtistHistoryView AppBar does not overflow vertically with extremely long dynamic title',
+      'ArtistHistoryView lays out without overflow at 2x text scale on a narrow screen',
       (WidgetTester tester) async {
-        setupErrorFilter();
         await tester.setViewport(textScale: 2.0, width: 320);
 
         await tester.pumpWidget(

--- a/services/service_lidarr/test/features/responsive_layout_test.dart
+++ b/services/service_lidarr/test/features/responsive_layout_test.dart
@@ -4,12 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:service_lidarr/service_lidarr.dart';
 import 'package:service_lidarr/src/features/activity/views/queue_view.dart';
+import 'package:service_lidarr/src/features/artists/views/artist_history_view.dart';
 import 'package:service_lidarr/src/features/settings/sections/download_clients_section.dart';
 import 'package:service_lidarr/src/features/settings/sections/indexers_section.dart';
-
-import 'package:service_lidarr/src/features/artists/views/artist_history_view.dart';
-import 'package:service_lidarr/src/features/track_files/track_file_editor_screen.dart';
-import 'package:service_lidarr/src/features/track_files/unmapped_files_screen.dart';
 
 import 'test_helpers.dart';
 
@@ -467,7 +464,7 @@ void main() {
                 statusCode: 200,
                 data: {
                   'records': [
-                    {'id': 1, 'sourceTitle': 'Test'}
+                    {'id': 1, 'sourceTitle': 'Test'},
                   ],
                 },
               ),
@@ -478,7 +475,7 @@ void main() {
               requestOptions: options,
               statusCode: 200,
               data: [
-                {'id': 1, 'path': '/test/file.mp3'}
+                {'id': 1, 'path': '/test/file.mp3'},
               ],
             ),
           );
@@ -511,7 +508,7 @@ void main() {
       'LidarrUnmappedFilesScreen AppBar does not overflow vertically with extremely long dynamic title',
       (WidgetTester tester) async {
         setupErrorFilter();
-        await tester.setViewport(textScale: 2.0, width: 320, height: 800);
+        await tester.setViewport(textScale: 2.0, width: 320);
 
         await tester.pumpWidget(
           ProviderScope(
@@ -537,7 +534,7 @@ void main() {
       'LidarrTrackFileEditorScreen AppBar does not overflow vertically with extremely long dynamic title',
       (WidgetTester tester) async {
         setupErrorFilter();
-        await tester.setViewport(textScale: 2.0, width: 320, height: 800);
+        await tester.setViewport(textScale: 2.0, width: 320);
 
         await tester.pumpWidget(
           ProviderScope(
@@ -564,7 +561,7 @@ void main() {
       'ArtistHistoryView AppBar does not overflow vertically with extremely long dynamic title',
       (WidgetTester tester) async {
         setupErrorFilter();
-        await tester.setViewport(textScale: 2.0, width: 320, height: 800);
+        await tester.setViewport(textScale: 2.0, width: 320);
 
         await tester.pumpWidget(
           ProviderScope(

--- a/services/service_lidarr/test/features/test_helpers.dart
+++ b/services/service_lidarr/test/features/test_helpers.dart
@@ -1,4 +1,6 @@
 import 'package:core_models/core_models.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 const testInstance = Instance(
   id: 'test-lidarr-instance',
@@ -9,3 +11,19 @@ const testInstance = Instance(
   urlMode: UrlMode.auto,
   auth: InstanceAuthApiKey(apiKey: 'test-api-key'),
 );
+
+extension ResponsiveTester on WidgetTester {
+  Future<void> setViewport({
+    double width = 360,
+    double height = 800,
+    double textScale = 1.0,
+  }) async {
+    view.physicalSize = Size(width * view.devicePixelRatio, height * view.devicePixelRatio);
+    platformDispatcher.textScaleFactorTestValue = textScale;
+    addTearDown(() {
+      view.resetPhysicalSize();
+      platformDispatcher.clearTextScaleFactorTestValue();
+    });
+  }
+}
+

--- a/services/service_lidarr/test/features/track_files_feature_test.dart
+++ b/services/service_lidarr/test/features/track_files_feature_test.dart
@@ -650,11 +650,11 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.text('1 / 2 selected'), findsOneWidget);
-        expect(find.text('Edit Quality'), findsOneWidget);
-        expect(find.text('Delete'), findsOneWidget);
+        expect(find.byTooltip('Edit Quality'), findsOneWidget);
+        expect(find.byTooltip('Delete Selected'), findsOneWidget);
 
         // Bulk edit quality
-        await tester.tap(find.text('Edit Quality'));
+        await tester.tap(find.byTooltip('Edit Quality'));
         await tester.pumpAndSettle();
 
         expect(find.text('Edit 1 Track Files'), findsOneWidget);
@@ -668,7 +668,7 @@ void main() {
         await tester.tap(find.text('01 Burn the Witch.flac'));
         await tester.pumpAndSettle();
 
-        await tester.tap(find.text('Delete'));
+        await tester.tap(find.byTooltip('Delete Selected'));
         await tester.pumpAndSettle();
 
         expect(find.text('Delete 1 Audio Files?'), findsOneWidget);

--- a/services/service_lidarr/test/live_plugin_protocols_test.dart
+++ b/services/service_lidarr/test/live_plugin_protocols_test.dart
@@ -1,0 +1,109 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Parses a plugin-enabled Lidarr's own schemas through the app's models.
+///
+/// Issue #134: a build with Tubifarry installed advertises protocols no
+/// released spec lists, and the old models threw on them, taking down
+/// interactive search. This reads the real schemas off a live server rather
+/// than a fixture, so it fails if a future plugin build changes the shape
+/// again. Read-only.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+
+  if (url.isEmpty || key.isEmpty) {
+    test('skipped: no live server configured', () {}, skip: true);
+    return;
+  }
+
+  late Dio dio;
+  late LidarrApi api;
+
+  setUpAll(() {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: url,
+        headers: <String, String>{'X-Api-Key': key},
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 60),
+      ),
+    );
+    api = LidarrApi(dio);
+  });
+
+  test('every advertised indexer parses, whatever protocol it claims',
+      () async {
+    final dynamic resp = await api.indexer.getIndexerSchema();
+    // ignore: avoid_dynamic_calls
+    expect(resp.isSuccess, isTrue, reason: 'schema fetch failed');
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> all = (resp.data as List<dynamic>?) ?? <dynamic>[];
+    expect(all, isNotEmpty);
+
+    // What the server actually said, before the models touched it.
+    final Response<dynamic> rawResp =
+        await dio.get<dynamic>('/api/v1/indexer/schema');
+    final Set<String> rawProtocols = <String>{
+      for (final dynamic e in rawResp.data as List<dynamic>)
+        if (e is Map && e['protocol'] != null) '${e['protocol']}',
+    };
+    // ignore: avoid_print
+    print('\n  protocols this server advertises: ${rawProtocols.toList()..sort()}');
+
+    final List<String> impls = all
+        // ignore: avoid_dynamic_calls
+        .map((dynamic e) => '${e.implementation}')
+        .toList();
+    // ignore: avoid_print
+    print('  indexer implementations parsed: ${impls.length}');
+
+    // Nothing may parse to null, which is what a throw used to produce.
+    for (final dynamic e in all) {
+      // ignore: avoid_dynamic_calls
+      final Object? proto = e.protocol;
+      // ignore: avoid_dynamic_calls
+      final String impl = '${e.implementation}';
+      expect(proto, isNotNull, reason: '$impl lost its protocol');
+    }
+
+    // The two the spec does know must survive the longer spelling rather than
+    // degrading, or every torrent indexer reads as unknown.
+    final Iterable<dynamic> torrents = all.where(
+      // ignore: avoid_dynamic_calls
+      (dynamic e) => '${e.implementation}' == 'Torznab',
+    );
+    if (torrents.isNotEmpty) {
+      // ignore: avoid_dynamic_calls
+      expect(torrents.first.protocol, DownloadProtocol.torrent);
+    }
+  }, timeout: const Timeout(Duration(minutes: 3)),);
+
+  test('every advertised download client parses too', () async {
+    final dynamic resp = await api.downloadClient.getDownloadclientSchema();
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> all = (resp.data as List<dynamic>?) ?? <dynamic>[];
+    expect(all, isNotEmpty);
+    for (final dynamic e in all) {
+      // ignore: avoid_dynamic_calls
+      final Object? proto = e.protocol;
+      // ignore: avoid_dynamic_calls
+      final String impl = '${e.implementation}';
+      expect(proto, isNotNull, reason: '$impl lost its protocol');
+    }
+    final Iterable<dynamic> qbit = all.where(
+      // ignore: avoid_dynamic_calls
+      (dynamic e) => '${e.implementation}' == 'QBittorrent',
+    );
+    if (qbit.isNotEmpty) {
+      // ignore: avoid_dynamic_calls
+      expect(qbit.first.protocol, DownloadProtocol.torrent);
+    }
+  }, timeout: const Timeout(Duration(minutes: 3)),);
+}

--- a/services/service_lidarr/test/live_probe_test.dart
+++ b/services/service_lidarr/test/live_probe_test.dart
@@ -1,0 +1,270 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Throwaway probe: drives every read endpoint the Lidarr feature code calls
+/// against a real server and reports which ones fail to parse.
+///
+/// A 200 from curl only proves the server answered. This proves the generated
+/// models can actually read what it answered, which is where the breakage
+/// would be. Not part of the normal suite: needs LIDARR_URL and LIDARR_KEY.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+
+  if (url.isEmpty || key.isEmpty) {
+    test('skipped: no live server configured', () {}, skip: true);
+    return;
+  }
+
+  late LidarrApi api;
+  final List<String> failures = <String>[];
+  final List<String> ok = <String>[];
+
+  setUpAll(() {
+    api = LidarrApi(
+      Dio(
+        BaseOptions(
+          baseUrl: url,
+          headers: <String, String>{'X-Api-Key': key},
+          connectTimeout: const Duration(seconds: 20),
+          receiveTimeout: const Duration(seconds: 60),
+        ),
+      ),
+    );
+  });
+
+  /// Runs one call and records whether it parsed.
+  Future<void> probe(String label, Future<dynamic> Function() call) async {
+    try {
+      final dynamic resp = await call();
+      // ignore: avoid_dynamic_calls
+      final bool success = resp.isSuccess as bool;
+      // ignore: avoid_dynamic_calls
+      final dynamic data = resp.data;
+      if (!success) {
+        // ignore: avoid_dynamic_calls
+        failures.add('$label -> API error: ${resp.error}');
+        return;
+      }
+      if (data == null) {
+        failures.add('$label -> parsed to null');
+        return;
+      }
+      final String n = data is List ? '${data.length}' : 'obj';
+      ok.add('$label [$n]');
+    } on Object catch (e) {
+      failures.add('$label -> THREW ${e.runtimeType}: $e');
+    }
+  }
+
+  test('every read endpoint parses off a real server', () async {
+    // Anchors used by the id-scoped calls below.
+    final dynamic artistsResp = await api.artist.getArtist();
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> artists = (artistsResp.data as List<dynamic>?) ?? <dynamic>[];
+    expect(artists, isNotEmpty, reason: 'need at least one artist to probe');
+    // ignore: avoid_dynamic_calls
+    final int artistId = artists.first.id as int;
+
+    final dynamic albumsResp = await api.album.getAlbum(artistId: artistId);
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> albums = (albumsResp.data as List<dynamic>?) ?? <dynamic>[];
+    final int? albumId =
+        // ignore: avoid_dynamic_calls
+        albums.isEmpty ? null : albums.first.id as int;
+
+    await probe('artist.getArtist', () => api.artist.getArtist());
+    await probe(
+      'artist.getArtistById',
+      () => api.artist.getArtistById(id: artistId),
+    );
+    await probe('album.getAlbum', () => api.album.getAlbum());
+    if (albumId != null) {
+      await probe(
+        'album.getAlbumById',
+        () => api.album.getAlbumById(id: albumId),
+      );
+    }
+    await probe(
+      'artistLookup.getArtistLookup',
+      () => api.artistLookup.getArtistLookup(term: 'daft punk'),
+    );
+    await probe('autoTagging.getAutotagging', () => api.autoTagging.getAutotagging());
+    await probe('backup.getSystemBackup', () => api.backup.getSystemBackup());
+    await probe('blocklist.getBlocklist', () => api.blocklist.getBlocklist());
+    await probe('calendar.getCalendar', () => api.calendar.getCalendar());
+    await probe('customFormat.getCustomformat', () => api.customFormat.getCustomformat());
+    await probe('cutoff.getWantedCutoff', () => api.cutoff.getWantedCutoff());
+    await probe('delayProfile.getDelayprofile', () => api.delayProfile.getDelayprofile());
+    await probe('diskSpace.getDiskspace', () => api.diskSpace.getDiskspace());
+    await probe(
+      'downloadClient.getDownloadclient',
+      () => api.downloadClient.getDownloadclient(),
+    );
+    await probe(
+      'downloadClient.getDownloadclientSchema',
+      () => api.downloadClient.getDownloadclientSchema(),
+    );
+    await probe(
+      'downloadClientConfig.getConfigDownloadclient',
+      () => api.downloadClientConfig.getConfigDownloadclient(),
+    );
+    await probe('health.getHealth', () => api.health.getHealth());
+    await probe('history.getHistory', () => api.history.getHistory());
+    await probe(
+      'history.getHistoryArtist',
+      () => api.history.getHistoryArtist(artistId: artistId),
+    );
+    await probe('hostConfig.getConfigHost', () => api.hostConfig.getConfigHost());
+    await probe('importList.getImportlist', () => api.importList.getImportlist());
+    await probe(
+      'importList.getImportlistSchema',
+      () => api.importList.getImportlistSchema(),
+    );
+    await probe('indexer.getIndexer', () => api.indexer.getIndexer());
+    await probe('indexer.getIndexerSchema', () => api.indexer.getIndexerSchema());
+    await probe(
+      'indexerConfig.getConfigIndexer',
+      () => api.indexerConfig.getConfigIndexer(),
+    );
+    await probe('log.getLog', () => api.log.getLog());
+    await probe('logFile.getLogFile', () => api.logFile.getLogFile());
+    await probe(
+      'manualImport.getManualimport',
+      // Lidarr 500s on artistId alone; the dialog always sends a folder or a
+      // downloadId alongside it, so probe it the way the app calls it.
+      () => api.manualImport.getManualimport(
+        folder: const String.fromEnvironment(
+          'LIDARR_FOLDER',
+          defaultValue: '/data/media/music',
+        ),
+        artistId: artistId,
+      ),
+    );
+    await probe(
+      'mediaManagementConfig.getConfigMediamanagement',
+      () => api.mediaManagementConfig.getConfigMediamanagement(),
+    );
+    await probe('metadata.getMetadata', () => api.metadata.getMetadata());
+    await probe('metadata.getMetadataSchema', () => api.metadata.getMetadataSchema());
+    await probe(
+      'metadataProfile.getMetadataprofile',
+      () => api.metadataProfile.getMetadataprofile(),
+    );
+    await probe(
+      'metadataProfileSchema.getMetadataprofileSchema',
+      () => api.metadataProfileSchema.getMetadataprofileSchema(),
+    );
+    await probe('missing.getWantedMissing', () => api.missing.getWantedMissing());
+    await probe('namingConfig.getConfigNaming', () => api.namingConfig.getConfigNaming());
+    await probe('notification.getNotification', () => api.notification.getNotification());
+    await probe(
+      'notification.getNotificationSchema',
+      () => api.notification.getNotificationSchema(),
+    );
+    await probe(
+      'qualityDefinition.getQualitydefinition',
+      () => api.qualityDefinition.getQualitydefinition(),
+    );
+    await probe(
+      'qualityProfile.getQualityprofile',
+      () => api.qualityProfile.getQualityprofile(),
+    );
+    await probe(
+      'qualityProfileSchema.getQualityprofileSchema',
+      () => api.qualityProfileSchema.getQualityprofileSchema(),
+    );
+    await probe('queue.getQueue', () => api.queue.getQueue());
+    await probe('release.getRelease', () => api.release.getRelease());
+    await probe(
+      'releaseProfile.getReleaseprofile',
+      () => api.releaseProfile.getReleaseprofile(),
+    );
+    await probe(
+      'renameTrack.getRename',
+      () => api.renameTrack.getRename(artistId: artistId),
+    );
+    await probe(
+      'retagTrack.getRetag',
+      () => api.retagTrack.getRetag(artistId: artistId),
+    );
+    await probe('rootFolder.getRootfolder', () => api.rootFolder.getRootfolder());
+    await probe('system.getSystemStatus', () => api.system.getSystemStatus());
+    await probe('task.getSystemTask', () => api.task.getSystemTask());
+    await probe('tag.getTag', () => api.tag.getTag());
+    await probe(
+      'track.getTrack',
+      () => api.track.getTrack(artistId: artistId),
+    );
+    await probe(
+      'trackFile.getTrackfile',
+      () => api.trackFile.getTrackfile(artistId: artistId),
+    );
+    await probe('update.getUpdate', () => api.update.getUpdate());
+
+    // ignore: avoid_print
+    print('\n=== PARSED OK (${ok.length}) ===');
+    for (final String s in ok) {
+      // ignore: avoid_print
+      print('  $s');
+    }
+    // ignore: avoid_print
+    print('\n=== FAILURES (${failures.length}) ===');
+    for (final String s in failures) {
+      // ignore: avoid_print
+      print('  $s');
+    }
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+
+  test('a create succeeds even though the resource carries no id', () async {
+    // The whole add surface of this module builds its payload from something
+    // the server sent that has no id (a lookup result, a provider schema), so
+    // this is the case that has to work. A tag is the smallest disposable
+    // resource to prove it on, and it is removed again below.
+    const String label = 'zz-atrium-selftest';
+
+    final dynamic created = await api.tag.postTag(
+      body: const TagResource(label: label),
+    );
+    // ignore: avoid_dynamic_calls
+    final bool ok = created.isSuccess as bool;
+    // ignore: avoid_dynamic_calls
+    final Object? why = created.error;
+    expect(ok, isTrue, reason: 'create rejected: $why');
+    // ignore: avoid_dynamic_calls
+    final int? newId = created.data?.id as int?;
+    expect(newId, isNotNull);
+
+    final dynamic listed = await api.tag.getTag();
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> tags = (listed.data as List<dynamic>?) ?? <dynamic>[];
+    expect(
+      // ignore: avoid_dynamic_calls
+      tags.any((dynamic t) => t.label == label),
+      isTrue,
+      reason: 'created tag did not come back from the server',
+    );
+
+    final dynamic removed = await api.tag.deleteTagById(id: newId!);
+    // ignore: avoid_dynamic_calls
+    expect(removed.isSuccess, isTrue, reason: 'cleanup failed: leftover tag');
+
+    final dynamic after = await api.tag.getTag();
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> left = (after.data as List<dynamic>?) ?? <dynamic>[];
+    expect(
+      // ignore: avoid_dynamic_calls
+      left.any((dynamic t) => t.label == label),
+      isFalse,
+      reason: 'test tag was left behind on the server',
+    );
+  }, timeout: const Timeout(Duration(minutes: 2)),);
+}

--- a/services/service_lidarr/test/live_roundtrip_test.dart
+++ b/services/service_lidarr/test/live_roundtrip_test.dart
@@ -1,0 +1,199 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Checks that every resource the app can save survives a parse-and-serialize
+/// round trip without losing anything.
+///
+/// This is the same class of defect as the null `id` that broke adding an
+/// artist, but caught without writing: each PUT in this app sends
+/// `model.toJson()`, so any field the model drops on the way in is a field
+/// that gets blanked on the way out. Reading the server's own JSON, running it
+/// through the model, and diffing shows exactly what a save would destroy.
+/// Nothing is written, so running this cannot damage a real server.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+
+  if (url.isEmpty || key.isEmpty) {
+    test('skipped: no live server configured', () {}, skip: true);
+    return;
+  }
+
+  late Dio dio;
+  final List<String> report = <String>[];
+  final List<String> losses = <String>[];
+
+  setUpAll(() {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: url,
+        headers: <String, String>{'X-Api-Key': key},
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 60),
+      ),
+    );
+  });
+
+  /// Fields the server computes and never reads back. Sending them stale is
+  /// harmless, and their absence from a model is not a loss worth reporting.
+  const Set<String> ignored = <String>{
+    'statistics',
+    'images',
+    'links',
+    'ratings',
+    'added',
+    'addOptions',
+    'remotePoster',
+    'lastInfoSync',
+    'nextAiring',
+    'previousAiring',
+    'artist',
+    'album',
+    'media',
+    'presets',
+    'fields',
+    'infoLink',
+    'message',
+  };
+
+  /// Compares the server's JSON against what the model would send back.
+  ///
+  /// Only reports a key the server gave a real value for that the model would
+  /// send as null or drop entirely, which is what a save would actually erase.
+  void diff(String label, Map<String, dynamic> from, Map<String, dynamic> to) {
+    final List<String> lost = <String>[];
+    for (final MapEntry<String, dynamic> e in from.entries) {
+      if (ignored.contains(e.key)) continue;
+      final Object? original = e.value;
+      if (original == null) continue;
+      if (original is List && original.isEmpty) continue;
+      if (original is Map && original.isEmpty) continue;
+      if (!to.containsKey(e.key) || to[e.key] == null) {
+        lost.add('${e.key} (was ${_short(original)})');
+      }
+    }
+    if (lost.isEmpty) {
+      report.add('  OK    $label');
+    } else {
+      report.add('  LOSS  $label -> ${lost.join(', ')}');
+      losses.add('$label: ${lost.join(', ')}');
+    }
+  }
+
+  Future<Map<String, dynamic>?> getOne(String path) async {
+    final Response<dynamic> r = await dio.get<dynamic>(path);
+    final dynamic d = r.data;
+    if (d is Map<String, dynamic>) return d;
+    if (d is List && d.isNotEmpty && d.first is Map<String, dynamic>) {
+      return d.first as Map<String, dynamic>;
+    }
+    return null;
+  }
+
+  test('saveable resources survive a parse and serialize round trip',
+      () async {
+    Future<void> check(
+      String label,
+      String path,
+      Map<String, dynamic> Function(Map<String, dynamic>) trip,
+    ) async {
+      final Map<String, dynamic>? raw = await getOne(path);
+      if (raw == null) {
+        report.add('  SKIP  $label (nothing configured)');
+        return;
+      }
+      try {
+        diff(label, raw, trip(raw));
+      } on Object catch (e) {
+        report.add('  THREW $label -> ${e.runtimeType}: $e');
+        losses.add('$label threw ${e.runtimeType}');
+      }
+    }
+
+    await check('ArtistResource', '/api/v1/artist',
+        (Map<String, dynamic> j) => ArtistResource.fromJson(j).toJson(),
+    );
+    await check('AlbumResource', '/api/v1/album',
+        (Map<String, dynamic> j) => AlbumResource.fromJson(j).toJson(),
+    );
+    await check('QualityProfileResource', '/api/v1/qualityprofile',
+        (Map<String, dynamic> j) => QualityProfileResource.fromJson(j).toJson(),
+    );
+    await check(
+        'MetadataProfileResource',
+        '/api/v1/metadataprofile',
+        (Map<String, dynamic> j) =>
+            MetadataProfileResource.fromJson(j).toJson(),
+    );
+    await check('DelayProfileResource', '/api/v1/delayprofile',
+        (Map<String, dynamic> j) => DelayProfileResource.fromJson(j).toJson(),
+    );
+    await check('IndexerResource', '/api/v1/indexer',
+        (Map<String, dynamic> j) => IndexerResource.fromJson(j).toJson(),
+    );
+    await check(
+        'DownloadClientResource',
+        '/api/v1/downloadclient',
+        (Map<String, dynamic> j) =>
+            DownloadClientResource.fromJson(j).toJson(),
+    );
+    await check('NotificationResource', '/api/v1/notification',
+        (Map<String, dynamic> j) => NotificationResource.fromJson(j).toJson(),
+    );
+    await check('MetadataResource', '/api/v1/metadata',
+        (Map<String, dynamic> j) => MetadataResource.fromJson(j).toJson(),
+    );
+    await check('ImportListResource', '/api/v1/importlist',
+        (Map<String, dynamic> j) => ImportListResource.fromJson(j).toJson(),
+    );
+    await check('CustomFormatResource', '/api/v1/customformat',
+        (Map<String, dynamic> j) => CustomFormatResource.fromJson(j).toJson(),
+    );
+    await check('AutoTaggingResource', '/api/v1/autotagging',
+        (Map<String, dynamic> j) => AutoTaggingResource.fromJson(j).toJson(),
+    );
+    await check('ReleaseProfileResource', '/api/v1/releaseprofile',
+        (Map<String, dynamic> j) => ReleaseProfileResource.fromJson(j).toJson(),
+    );
+    await check(
+        'QualityDefinitionResource',
+        '/api/v1/qualitydefinition',
+        (Map<String, dynamic> j) =>
+            QualityDefinitionResource.fromJson(j).toJson(),
+    );
+    await check('HostConfigResource', '/api/v1/config/host',
+        (Map<String, dynamic> j) => HostConfigResource.fromJson(j).toJson(),
+    );
+    await check('NamingConfigResource', '/api/v1/config/naming',
+        (Map<String, dynamic> j) => NamingConfigResource.fromJson(j).toJson(),
+    );
+    await check('IndexerConfigResource', '/api/v1/config/indexer',
+        (Map<String, dynamic> j) => IndexerConfigResource.fromJson(j).toJson(),
+    );
+    await check(
+        'MediaManagementConfigResource',
+        '/api/v1/config/mediamanagement',
+        (Map<String, dynamic> j) =>
+            MediaManagementConfigResource.fromJson(j).toJson(),
+    );
+    await check('RootFolderResource', '/api/v1/rootfolder',
+        (Map<String, dynamic> j) => RootFolderResource.fromJson(j).toJson(),
+    );
+
+    // ignore: avoid_print
+    print('\n=== round trip ===\n${report.join('\n')}\n');
+
+    expect(losses, isEmpty, reason: losses.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+}
+
+String _short(Object? v) {
+  final String s = v.toString();
+  return s.length <= 40 ? s : '${s.substring(0, 40)}...';
+}

--- a/services/service_lidarr/test/live_trackfiles_test.dart
+++ b/services/service_lidarr/test/live_trackfiles_test.dart
@@ -1,0 +1,119 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Track file operations, run against one named album so nothing else in the
+/// library can be touched.
+///
+/// Set LIDARR_TRACKFILE_ALBUM to the album title to operate on. Without it the
+/// test skips rather than guessing, because every action here deletes audio
+/// from disk.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+  final String target = Platform.environment['LIDARR_TRACKFILE_ALBUM'] ?? '';
+
+  if (url.isEmpty || key.isEmpty || target.isEmpty) {
+    test('skipped: no live server or no target album named', () {}, skip: true);
+    return;
+  }
+
+  late Dio dio;
+  late LidarrApi api;
+  final List<String> log = <String>[];
+
+  setUpAll(() {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: url,
+        headers: <String, String>{'X-Api-Key': key},
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 120),
+      ),
+    );
+    api = LidarrApi(dio);
+  });
+
+  tearDownAll(() {
+    // ignore: avoid_print
+    print('\n=== track files ===\n${log.join('\n')}\n');
+  });
+
+  test('track files can be listed, edited and deleted', () async {
+    final Response<dynamic> albumsResp =
+        await dio.get<dynamic>('/api/v1/album');
+    final List<dynamic> albums = albumsResp.data as List<dynamic>;
+    final Iterable<dynamic> matches = albums.where(
+      (dynamic a) => a is Map && '${a['title']}' == target,
+    );
+    if (matches.isEmpty) {
+      log.add('  SKIP  no album titled "$target"');
+      return;
+    }
+    final Map<String, dynamic> album =
+        Map<String, dynamic>.from(matches.first as Map);
+    final int albumId = album['id'] as int;
+    final int artistId = album['artistId'] as int;
+    log.add('  target: "$target" album=$albumId artist=$artistId');
+
+    final dynamic filesResp = await api.trackFile.getTrackfile(
+      albumId: <int>[albumId],
+    );
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> files = (filesResp.data as List<dynamic>?) ?? <dynamic>[];
+    log.add('  found ${files.length} track file(s)');
+    if (files.isEmpty) {
+      log.add('  SKIP  album has no files on disk');
+      return;
+    }
+
+    // ignore: avoid_dynamic_calls
+    final List<int> ids = files.map((dynamic f) => f.id as int).toList();
+
+    // The editor is what the track files screen uses to change quality in
+    // bulk. Re-applying what is already set proves the call works without
+    // altering anything.
+    // ignore: avoid_dynamic_calls
+    final dynamic firstQuality = files.first.quality;
+    if (firstQuality != null) {
+      final dynamic edited = await api.trackFile.putTrackfileEditor(
+        body: TrackFileListResource(
+          trackFileIds: ids,
+          quality: firstQuality as QualityModel,
+        ),
+      );
+      // ignore: avoid_dynamic_calls
+      expect(edited.isSuccess, isTrue, reason: 'editor rejected: ${edited.error}');
+      log.add('  OK    trackFile editor applied to ${ids.length} file(s)');
+    }
+
+    // Single delete first, then the bulk path for the rest, so both are
+    // exercised rather than just one.
+    final dynamic one = await api.trackFile.deleteTrackfileById(id: ids.first);
+    // ignore: avoid_dynamic_calls
+    expect(one.isSuccess, isTrue, reason: 'single delete: ${one.error}');
+    log.add('  OK    trackFile single delete');
+
+    if (ids.length > 1) {
+      final dynamic many = await api.trackFile.deleteTrackfileBulk(
+        body: TrackFileListResource(trackFileIds: ids.sublist(1)),
+      );
+      // ignore: avoid_dynamic_calls
+      expect(many.isSuccess, isTrue, reason: 'bulk delete: ${many.error}');
+      log.add('  OK    trackFile bulk delete (${ids.length - 1} file(s))');
+    }
+
+    final dynamic after = await api.trackFile.getTrackfile(
+      albumId: <int>[albumId],
+    );
+    // ignore: avoid_dynamic_calls
+    final List<dynamic> left = (after.data as List<dynamic>?) ?? <dynamic>[];
+    expect(left, isEmpty, reason: '${left.length} file(s) survived');
+    log.add('  OK    album has no files left');
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+}

--- a/services/service_lidarr/test/live_writes2_test.dart
+++ b/services/service_lidarr/test/live_writes2_test.dart
@@ -1,0 +1,440 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Second half of the live write coverage: the resource types with no schema
+/// endpoint, and the configuration screens.
+///
+/// Same contract as `live_writes_test.dart`: anything created is deleted,
+/// anything saved is compared against what was there before, so a passing run
+/// leaves the server untouched.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+  final String scratchRoot =
+      Platform.environment['LIDARR_SCRATCH_ROOT'] ?? '/data/media/zzatrium';
+
+  if (url.isEmpty || key.isEmpty) {
+    test('skipped: no live server configured', () {}, skip: true);
+    return;
+  }
+
+  late Dio dio;
+  late LidarrApi api;
+  final List<String> log = <String>[];
+  final List<String> failures = <String>[];
+
+  setUpAll(() {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: url,
+        headers: <String, String>{'X-Api-Key': key},
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 90),
+      ),
+    );
+    api = LidarrApi(dio);
+  });
+
+  tearDownAll(() {
+    // ignore: avoid_print
+    print('\n=== writes (part 2) ===\n${log.join('\n')}\n');
+  });
+
+  void pass(String what) => log.add('  OK    $what');
+
+  String describe(Object? why) {
+    if (why is LidarrError) {
+      final String m = why.message ?? why.description ?? 'unknown';
+      return why.errors.isEmpty ? m : '$m ${why.errors}';
+    }
+    return '$why';
+  }
+
+  void fail(String what, Object? why) {
+    log.add('  FAIL  $what -> ${describe(why)}');
+    failures.add('$what: ${describe(why)}');
+  }
+
+  Future<List<dynamic>> raw(String path) async {
+    final Response<dynamic> r = await dio.get<dynamic>(path);
+    final dynamic d = r.data;
+    return d is List ? d : <dynamic>[d];
+  }
+
+  /// Create, confirm listed, delete, confirm gone. For types Lidarr offers no
+  /// schema for, so the smallest valid body is written out by hand.
+  Future<void> bare({
+    required String label,
+    required String listPath,
+    required Map<String, dynamic> body,
+    required Future<dynamic> Function(Map<String, dynamic>) create,
+    required Future<dynamic> Function(int) remove,
+  }) async {
+    int? id;
+    try {
+      final dynamic made = await create(body);
+      // ignore: avoid_dynamic_calls
+      final bool ok = made.isSuccess == true;
+      // ignore: avoid_dynamic_calls
+      final Object? err = made.error;
+      if (!ok) {
+        fail('$label create', err);
+        return;
+      }
+      // ignore: avoid_dynamic_calls
+      id = made.data?.id as int?;
+      if (id == null) {
+        fail('$label create', 'no id came back');
+        return;
+      }
+      final List<dynamic> now = await raw(listPath);
+      if (!now.any((dynamic e) => e is Map && e['id'] == id)) {
+        fail('$label create', 'created but not listed');
+        return;
+      }
+      final dynamic gone = await remove(id);
+      // ignore: avoid_dynamic_calls
+      final bool removed = gone.isSuccess == true;
+      // ignore: avoid_dynamic_calls
+      final Object? gerr = gone.error;
+      if (!removed) {
+        fail('$label delete', gerr);
+        return;
+      }
+      final List<dynamic> post = await raw(listPath);
+      if (post.any((dynamic e) => e is Map && e['id'] == id)) {
+        fail('$label delete', 'still present after delete');
+        return;
+      }
+      id = null;
+      pass('$label create + delete');
+    } on Object catch (e) {
+      fail(label, '${e.runtimeType}: $e');
+    } finally {
+      if (id != null) {
+        try {
+          await remove(id);
+          log.add('  ..    $label cleaned up after failure');
+        } on Object catch (_) {
+          log.add('  WARN  $label LEFT BEHIND id=$id');
+        }
+      }
+    }
+  }
+
+  test('resource types without a schema can be created and deleted', () async {
+    final int qpId =
+        ((await raw('/api/v1/qualityprofile')).first as Map<String, dynamic>)
+            ['id'] as int;
+    final int mpId =
+        ((await raw('/api/v1/metadataprofile')).first as Map<String, dynamic>)
+            ['id'] as int;
+
+    // Lidarr refuses a delay profile or an auto tag that applies to nothing,
+    // so both need a real tag to point at. Removed again at the end.
+    final dynamic madeTag =
+        await api.tag.postTag(body: const TagResource(label: 'zz-atrium-tmp'));
+    // ignore: avoid_dynamic_calls
+    final int tmpTagId = madeTag.data!.id as int;
+    addTearDown(() => api.tag.deleteTagById(id: tmpTagId));
+
+    await bare(
+      label: 'rootFolder',
+      listPath: '/api/v1/rootfolder',
+      body: <String, dynamic>{
+        'path': scratchRoot,
+        'name': 'zz-atrium',
+        'defaultQualityProfileId': qpId,
+        'defaultMetadataProfileId': mpId,
+        'defaultMonitorOption': 'all',
+        'defaultNewItemMonitorOption': 'all',
+        'defaultTags': <int>[],
+      },
+      create: (Map<String, dynamic> b) =>
+          api.rootFolder.postRootfolder(body: RootFolderResource.fromJson(b)),
+      remove: (int id) => api.rootFolder.deleteRootfolderById(id: id),
+    );
+
+    await bare(
+      label: 'delayProfile',
+      listPath: '/api/v1/delayprofile',
+      body: <String, dynamic>{
+        'enableUsenet': true,
+        'enableTorrent': true,
+        'preferredProtocol': 'usenet',
+        'usenetDelay': 0,
+        'torrentDelay': 0,
+        'bypassIfHighestQuality': false,
+        'bypassIfAboveCustomFormatScore': false,
+        'minimumCustomFormatScore': 0,
+        'order': 99,
+        'tags': <int>[tmpTagId],
+      },
+      create: (Map<String, dynamic> b) => api.delayProfile
+          .postDelayprofile(body: DelayProfileResource.fromJson(b)),
+      remove: (int id) => api.delayProfile.deleteDelayprofileById(id: id),
+    );
+
+    await bare(
+      label: 'releaseProfile',
+      listPath: '/api/v1/releaseprofile',
+      body: <String, dynamic>{
+        'enabled': true,
+        'required': <String>['zzatrium'],
+        'ignored': <String>[],
+        'indexerId': 0,
+        'tags': <int>[],
+      },
+      create: (Map<String, dynamic> b) => api.releaseProfile
+          .postReleaseprofile(body: ReleaseProfileResource.fromJson(b)),
+      remove: (int id) => api.releaseProfile.deleteReleaseprofileById(id: id),
+    );
+
+    await bare(
+      label: 'customFormat',
+      listPath: '/api/v1/customformat',
+      body: <String, dynamic>{
+        'name': 'zz-atrium-cf',
+        'includeCustomFormatWhenRenaming': false,
+        'specifications': <dynamic>[
+          <String, dynamic>{
+            'name': 'zz',
+            'implementation': 'ReleaseTitleSpecification',
+            'negate': false,
+            'required': false,
+            'fields': <dynamic>[
+              <String, dynamic>{'name': 'value', 'value': 'zzatrium'},
+            ],
+          },
+        ],
+      },
+      create: (Map<String, dynamic> b) => api.customFormat
+          .postCustomformat(body: CustomFormatResource.fromJson(b)),
+      remove: (int id) => api.customFormat.deleteCustomformatById(id: id),
+    );
+
+    await bare(
+      label: 'autoTagging',
+      listPath: '/api/v1/autotagging',
+      body: <String, dynamic>{
+        'name': 'zz-atrium-at',
+        'removeTagsAutomatically': false,
+        'tags': <int>[tmpTagId],
+        'specifications': <dynamic>[
+          <String, dynamic>{
+            'name': 'zz',
+            'implementation': 'GenreSpecification',
+            'negate': false,
+            'required': false,
+            'fields': <dynamic>[
+              <String, dynamic>{'name': 'value', 'value': 'zzatrium'},
+            ],
+          },
+        ],
+      },
+      create: (Map<String, dynamic> b) => api.autoTagging
+          .postAutotagging(body: AutoTaggingResource.fromJson(b)),
+      remove: (int id) => api.autoTagging.deleteAutotaggingById(id: id),
+    );
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+
+  test('saving configuration back unchanged does not move any setting',
+      () async {
+    /// Reads a config, saves it straight back through the app, reads it again
+    /// and compares. A save that quietly rewrites settings is the worst thing
+    /// that can go wrong on these screens, so the comparison matters far more
+    /// than the status code.
+    Future<void> roundTrip(
+      String label,
+      String path,
+      Future<dynamic> Function(int id, Map<String, dynamic> body) put,
+    ) async {
+      try {
+        final Response<dynamic> before = await dio.get<dynamic>(path);
+        final Map<String, dynamic> was =
+            Map<String, dynamic>.from(before.data as Map);
+        final int id = was['id'] as int;
+
+        final dynamic saved =
+            await put(id, Map<String, dynamic>.from(was));
+        // ignore: avoid_dynamic_calls
+        final bool ok = saved.isSuccess == true;
+        // ignore: avoid_dynamic_calls
+        final Object? err = saved.error;
+        if (!ok) {
+          fail('$label save', err);
+          return;
+        }
+
+        final Response<dynamic> after = await dio.get<dynamic>(path);
+        final Map<String, dynamic> now =
+            Map<String, dynamic>.from(after.data as Map);
+        final List<String> moved = <String>[];
+        for (final String k in was.keys) {
+          if ('${was[k]}' != '${now[k]}') {
+            moved.add('$k: ${was[k]} -> ${now[k]}');
+          }
+        }
+        if (moved.isEmpty) {
+          pass('$label save is lossless');
+        } else {
+          fail('$label save CHANGED SETTINGS', moved.join('; '));
+        }
+      } on Object catch (e) {
+        fail(label, '${e.runtimeType}: $e');
+      }
+    }
+
+    await roundTrip(
+      'namingConfig',
+      '/api/v1/config/naming',
+      (int id, Map<String, dynamic> b) => api.namingConfig.putConfigNamingById(
+        id: '$id',
+        body: NamingConfigResource.fromJson(b),
+      ),
+    );
+    await roundTrip(
+      'mediaManagementConfig',
+      '/api/v1/config/mediamanagement',
+      (int id, Map<String, dynamic> b) =>
+          api.mediaManagementConfig.putConfigMediamanagementById(
+        id: '$id',
+        body: MediaManagementConfigResource.fromJson(b),
+      ),
+    );
+    await roundTrip(
+      'indexerConfig',
+      '/api/v1/config/indexer',
+      (int id, Map<String, dynamic> b) =>
+          api.indexerConfig.putConfigIndexerById(
+        id: '$id',
+        body: IndexerConfigResource.fromJson(b),
+      ),
+    );
+    await roundTrip(
+      'hostConfig',
+      '/api/v1/config/host',
+      (int id, Map<String, dynamic> b) => api.hostConfig.putConfigHostById(
+        id: '$id',
+        body: HostConfigResource.fromJson(b),
+      ),
+    );
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+
+  test('existing providers and profiles can be saved back unchanged', () async {
+    /// The edit path for things that already exist, which is what the settings
+    /// screens actually do most of the time.
+    Future<void> resave(
+      String label,
+      String listPath,
+      Future<dynamic> Function(int id, Map<String, dynamic> body) put,
+    ) async {
+      try {
+        final List<dynamic> all = await raw(listPath);
+        if (all.isEmpty || all.first is! Map) {
+          log.add('  SKIP  $label (none configured)');
+          return;
+        }
+        final Map<String, dynamic> was =
+            Map<String, dynamic>.from(all.first as Map);
+        final int id = was['id'] as int;
+        final dynamic saved = await put(id, Map<String, dynamic>.from(was));
+        // ignore: avoid_dynamic_calls
+        final bool ok = saved.isSuccess == true;
+        // ignore: avoid_dynamic_calls
+        final Object? err = saved.error;
+        if (!ok) {
+          fail('$label resave', err);
+          return;
+        }
+        final List<dynamic> after = await raw(listPath);
+        final Map<String, dynamic> now = Map<String, dynamic>.from(
+          after.firstWhere((dynamic e) => e is Map && e['id'] == id) as Map,
+        );
+        final List<String> moved = <String>[];
+        for (final String k in was.keys) {
+          if ('${was[k]}' != '${now[k]}') {
+            moved.add('$k changed');
+          }
+        }
+        if (moved.isEmpty) {
+          pass('$label resave is lossless');
+        } else {
+          fail('$label resave CHANGED IT', moved.join('; '));
+        }
+      } on Object catch (e) {
+        fail(label, '${e.runtimeType}: $e');
+      }
+    }
+
+    await resave(
+      'indexer',
+      '/api/v1/indexer',
+      (int id, Map<String, dynamic> b) => api.indexer
+          .putIndexerById(id: id, body: IndexerResource.fromJson(b)),
+    );
+    await resave(
+      'downloadClient',
+      '/api/v1/downloadclient',
+      (int id, Map<String, dynamic> b) => api.downloadClient
+          .putDownloadclientById(
+        id: id,
+        body: DownloadClientResource.fromJson(b),
+      ),
+    );
+    await resave(
+      'qualityProfile',
+      '/api/v1/qualityprofile',
+      (int id, Map<String, dynamic> b) => api.qualityProfile
+          .putQualityprofileById(
+        id: '$id',
+        body: QualityProfileResource.fromJson(b),
+      ),
+    );
+    await resave(
+      'metadataProfile',
+      '/api/v1/metadataprofile',
+      (int id, Map<String, dynamic> b) => api.metadataProfile
+          .putMetadataprofileById(
+        id: '$id',
+        body: MetadataProfileResource.fromJson(b),
+      ),
+    );
+    await resave(
+      'delayProfile',
+      '/api/v1/delayprofile',
+      (int id, Map<String, dynamic> b) => api.delayProfile
+          .putDelayprofileById(
+        id: '$id',
+        body: DelayProfileResource.fromJson(b),
+      ),
+    );
+    await resave(
+      'metadata',
+      '/api/v1/metadata',
+      (int id, Map<String, dynamic> b) => api.metadata
+          .putMetadataById(id: id, body: MetadataResource.fromJson(b)),
+    );
+    await resave(
+      'qualityDefinition',
+      '/api/v1/qualitydefinition',
+      (int id, Map<String, dynamic> b) => api.qualityDefinition
+          .putQualitydefinitionById(
+        id: '$id',
+        body: QualityDefinitionResource.fromJson(b),
+      ),
+    );
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 8)),);
+}

--- a/services/service_lidarr/test/live_writes3_test.dart
+++ b/services/service_lidarr/test/live_writes3_test.dart
@@ -1,0 +1,248 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Third part of the live write coverage: the actions that operate on library
+/// content rather than configuration, plus the provider connectivity tests.
+///
+/// The destructive ones work on a disposable artist this file adds and removes
+/// itself, so nothing in the real library is touched.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+
+  if (url.isEmpty || key.isEmpty) {
+    test('skipped: no live server configured', () {}, skip: true);
+    return;
+  }
+
+  late Dio dio;
+  late LidarrApi api;
+  final List<String> log = <String>[];
+  final List<String> failures = <String>[];
+
+  setUpAll(() {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: url,
+        headers: <String, String>{'X-Api-Key': key},
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 120),
+      ),
+    );
+    api = LidarrApi(dio);
+  });
+
+  tearDownAll(() {
+    // ignore: avoid_print
+    print('\n=== writes (part 3) ===\n${log.join('\n')}\n');
+  });
+
+  void pass(String what) => log.add('  OK    $what');
+
+  String describe(Object? why) {
+    if (why is LidarrError) {
+      final String m = why.message ?? why.description ?? 'unknown';
+      return why.errors.isEmpty ? m : '$m ${why.errors}';
+    }
+    return '$why';
+  }
+
+  void fail(String what, Object? why) {
+    log.add('  FAIL  $what -> ${describe(why)}');
+    failures.add('$what: ${describe(why)}');
+  }
+
+  Future<dynamic> rawGet(String path) async {
+    final Response<dynamic> r = await dio.get<dynamic>(path);
+    return r.data;
+  }
+
+  /// Runs one call and records the outcome, without letting a throw abort the
+  /// rest of the sweep.
+  Future<bool> step(String label, Future<dynamic> Function() call) async {
+    try {
+      final dynamic resp = await call();
+      // ignore: avoid_dynamic_calls
+      final bool ok = resp.isSuccess == true;
+      // ignore: avoid_dynamic_calls
+      final Object? err = resp.error;
+      if (ok) {
+        pass(label);
+        return true;
+      }
+      fail(label, err);
+      return false;
+    } on Object catch (e) {
+      fail(label, '${e.runtimeType}: $e');
+      return false;
+    }
+  }
+
+  test('provider connectivity tests can be run', () async {
+    // These post the saved provider back to its /test endpoint. A provider
+    // that is genuinely misconfigured will report so, which is a real answer
+    // rather than a failure of the app, so only a transport-level break counts.
+    for (final (String label, String path) probes in <(String, String)>[
+      ('indexer', '/api/v1/indexer'),
+      ('downloadClient', '/api/v1/downloadclient'),
+    ]) {
+      final (String label, String path) = probes;
+      final dynamic list = await rawGet(path);
+      if (list is! List || list.isEmpty) {
+        log.add('  SKIP  $label test (none configured)');
+        continue;
+      }
+      final Map<String, dynamic> first =
+          Map<String, dynamic>.from(list.first as Map);
+      try {
+        if (label == 'indexer') {
+          final dynamic r = await api.indexer
+              .postIndexerTest(body: IndexerResource.fromJson(first));
+          // ignore: avoid_dynamic_calls
+          log.add('  OK    indexer test ran (accepted=${r.isSuccess})');
+        } else {
+          final dynamic r = await api.downloadClient.postDownloadclientTest(
+            body: DownloadClientResource.fromJson(first),
+          );
+          // ignore: avoid_dynamic_calls
+          log.add('  OK    downloadClient test ran (accepted=${r.isSuccess})');
+        }
+      } on Object catch (e) {
+        fail('$label test', '${e.runtimeType}: $e');
+      }
+    }
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 4)),);
+
+  test('library actions work on a disposable artist', () async {
+    int? artistId;
+    try {
+      // Add an artist nobody would miss, unmonitored and with no search, so
+      // adding it cannot start a download.
+      final dynamic look = await api.artistLookup.getArtistLookup(
+        term: 'lidarr:db92a151-1ac2-438b-bc43-b82e149ddd50',
+      );
+      // ignore: avoid_dynamic_calls
+      final List<dynamic> hits = (look.data as List<dynamic>?) ?? <dynamic>[];
+      if (hits.isEmpty) {
+        log.add('  SKIP  library actions (lookup returned nothing)');
+        return;
+      }
+      final List<dynamic> folders = await rawGet('/api/v1/rootfolder') as List<dynamic>;
+      final List<dynamic> qps = await rawGet('/api/v1/qualityprofile') as List<dynamic>;
+      final List<dynamic> mps = await rawGet('/api/v1/metadataprofile') as List<dynamic>;
+
+      // ignore: avoid_dynamic_calls
+      final ArtistResource candidate = (hits.first as ArtistResource).copyWith(
+        rootFolderPath: (folders.first as Map<String, dynamic>)['path'] as String,
+        qualityProfileId: (qps.first as Map<String, dynamic>)['id'] as int,
+        metadataProfileId: (mps.first as Map<String, dynamic>)['id'] as int,
+        monitored: false,
+        addOptions: const AddArtistOptions(
+          monitor: MonitorTypes.none,
+          monitored: false,
+          searchForMissingAlbums: false,
+        ),
+      );
+
+      final dynamic added = await api.artist.postArtist(body: candidate);
+      // ignore: avoid_dynamic_calls
+      if (added.isSuccess != true) {
+        // ignore: avoid_dynamic_calls
+        fail('disposable artist add', added.error);
+        return;
+      }
+      // ignore: avoid_dynamic_calls
+      artistId = added.data!.id as int;
+      pass('artist add (unmonitored, no search)');
+
+      // Bulk editor, the path the multi-select bar uses.
+      await step(
+        'artistEditor bulk edit',
+        () => api.artistEditor.putArtistEditor(
+          body: ArtistEditorResource(
+            artistIds: <int>[artistId!],
+            monitored: true,
+          ),
+        ),
+      );
+
+      final dynamic reread = await api.artist.getArtistById(id: artistId);
+      // ignore: avoid_dynamic_calls
+      final bool nowMonitored = reread.data?.monitored == true;
+      if (nowMonitored) {
+        pass('artistEditor bulk edit took effect');
+      } else {
+        fail('artistEditor bulk edit', 'monitored did not change');
+      }
+
+      // Album level writes, on this artist's own albums only.
+      final dynamic albumsResp = await api.album.getAlbum(artistId: artistId);
+      // ignore: avoid_dynamic_calls
+      final List<dynamic> albums = (albumsResp.data as List<dynamic>?) ?? <dynamic>[];
+      if (albums.isNotEmpty) {
+        // ignore: avoid_dynamic_calls
+        final int albumId = albums.first.id as int;
+        await step(
+          'album monitor toggle',
+          () => api.album.putAlbumMonitor(
+            body: AlbumsMonitoredResource(
+              albumIds: <int>[albumId],
+              monitored: true,
+            ),
+          ),
+        );
+        await step(
+          'albumStudio bulk monitor',
+          () => api.albumStudio.postAlbumstudio(
+            body: AlbumStudioResource(
+              artist: <AlbumStudioArtistResource>[
+                AlbumStudioArtistResource(id: artistId),
+              ],
+              monitoringOptions: const MonitoringOptions(monitor: MonitorTypes.none),
+            ),
+          ),
+        );
+      } else {
+        log.add('  SKIP  album writes (artist has no albums)');
+      }
+
+      // Bulk delete, which is the other half of the multi-select bar.
+      await step(
+        'artistEditor bulk delete',
+        () => api.artistEditor.deleteArtistEditor(
+          body: ArtistEditorResource(artistIds: <int>[artistId!]),
+        ),
+      );
+      final dynamic after = await rawGet('/api/v1/artist');
+      final bool stillThere = (after as List<dynamic>).any(
+        (dynamic a) => a is Map && a['id'] == artistId,
+      );
+      if (stillThere) {
+        fail('artistEditor bulk delete', 'artist survived the delete');
+      } else {
+        pass('artistEditor bulk delete removed it');
+        artistId = null;
+      }
+    } on Object catch (e) {
+      fail('library actions', '${e.runtimeType}: $e');
+    } finally {
+      if (artistId != null) {
+        try {
+          await api.artist.deleteArtistById(id: artistId, deleteFiles: false);
+          log.add('  ..    disposable artist cleaned up after failure');
+        } on Object catch (_) {
+          log.add('  WARN  disposable artist LEFT BEHIND id=$artistId');
+        }
+      }
+    }
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 8)),);
+}

--- a/services/service_lidarr/test/live_writes_test.dart
+++ b/services/service_lidarr/test/live_writes_test.dart
@@ -1,0 +1,267 @@
+@Tags(<String>['live'])
+library;
+
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Exercises every write the Lidarr module can perform, against a real server.
+///
+/// Runs through [LidarrApi] rather than raw HTTP so it covers the same
+/// generated client, models and interceptors the screens use. Everything it
+/// creates it deletes again, and anything it edits it puts back, so a passing
+/// run leaves the server as it found it.
+///
+/// Needs LIDARR_URL and LIDARR_KEY. Never runs in the normal suite.
+void main() {
+  final String url = Platform.environment['LIDARR_URL'] ?? '';
+  final String key = Platform.environment['LIDARR_KEY'] ?? '';
+
+  if (url.isEmpty || key.isEmpty) {
+    test('skipped: no live server configured', () {}, skip: true);
+    return;
+  }
+
+  late Dio dio;
+  late LidarrApi api;
+  final List<String> log = <String>[];
+  final List<String> failures = <String>[];
+
+  setUpAll(() {
+    dio = Dio(
+      BaseOptions(
+        baseUrl: url,
+        headers: <String, String>{'X-Api-Key': key},
+        connectTimeout: const Duration(seconds: 20),
+        receiveTimeout: const Duration(seconds: 90),
+      ),
+    );
+    api = LidarrApi(dio);
+  });
+
+  tearDownAll(() {
+    // ignore: avoid_print
+    print('\n=== writes ===\n${log.join('\n')}\n');
+  });
+
+  void pass(String what) => log.add('  OK    $what');
+
+  /// LidarrError has no useful toString, so pull the message out by hand.
+  String describe(Object? why) {
+    if (why is LidarrError) {
+      final String m = why.message ?? why.description ?? 'unknown';
+      return why.errors.isEmpty ? m : '$m ${why.errors}';
+    }
+    return '$why';
+  }
+
+  void fail(String what, Object? why) {
+    log.add('  FAIL  $what -> ${describe(why)}');
+    failures.add('$what: ${describe(why)}');
+  }
+
+  /// Raw fetch, used to confirm a create or delete really landed.
+  Future<List<dynamic>> raw(String path) async {
+    final Response<dynamic> r = await dio.get<dynamic>(path);
+    final dynamic d = r.data;
+    return d is List ? d : <dynamic>[d];
+  }
+
+  /// Creates from the server's own schema, checks it exists, deletes it,
+  /// checks it is gone. The create is the case that was broken, so it is the
+  /// one worth running against every provider type rather than just one.
+  Future<void> lifecycle({
+    required String label,
+    required String schemaPath,
+    required String listPath,
+    required Future<dynamic> Function(Map<String, dynamic> body) create,
+    required Future<dynamic> Function(int id) remove,
+    Map<String, dynamic> Function(Map<String, dynamic>)? tweak,
+    int schemaIndex = 0,
+  }) async {
+    const String name = 'zz-atrium-test';
+    int? madeId;
+    try {
+      final List<dynamic> schemas = await raw(schemaPath);
+      if (schemas.isEmpty || schemas.first is! Map) {
+        log.add('  SKIP  $label (no schema)');
+        return;
+      }
+      final Map<String, dynamic> body = Map<String, dynamic>.from(
+        schemas[schemaIndex.clamp(0, schemas.length - 1)] as Map,
+      )..['name'] = name;
+      final Map<String, dynamic> payload =
+          tweak == null ? body : tweak(body);
+
+      final dynamic made = await create(payload);
+      // ignore: avoid_dynamic_calls
+      if (made.isSuccess != true) {
+        // ignore: avoid_dynamic_calls
+        fail('$label create', made.error);
+        return;
+      }
+      // ignore: avoid_dynamic_calls
+      madeId = made.data?.id as int?;
+      if (madeId == null) {
+        fail('$label create', 'no id came back');
+        return;
+      }
+
+      final List<dynamic> after = await raw(listPath);
+      final bool there = after.any(
+        (dynamic e) => e is Map && e['id'] == madeId,
+      );
+      if (!there) {
+        fail('$label create', 'created but not in the list');
+        return;
+      }
+
+      final dynamic gone = await remove(madeId);
+      // ignore: avoid_dynamic_calls
+      if (gone.isSuccess != true) {
+        // ignore: avoid_dynamic_calls
+        fail('$label delete', gone.error);
+        return;
+      }
+      final List<dynamic> post = await raw(listPath);
+      if (post.any((dynamic e) => e is Map && e['id'] == madeId)) {
+        fail('$label delete', 'still present after delete');
+        return;
+      }
+      madeId = null;
+      pass('$label create + delete');
+    } on Object catch (e) {
+      fail(label, '${e.runtimeType}: $e');
+    } finally {
+      if (madeId != null) {
+        // Never leave a test object behind, even on an unexpected throw.
+        try {
+          await remove(madeId);
+          log.add('  ..    $label cleaned up after failure');
+        } on Object catch (_) {
+          log.add('  WARN  $label LEFT BEHIND id=$madeId');
+        }
+      }
+    }
+  }
+
+  test('providers can be created and deleted', () async {
+    final List<dynamic> folders = await raw('/api/v1/rootfolder');
+    final String rootFolder =
+        (folders.first as Map<String, dynamic>)['path'] as String;
+    final List<dynamic> qps = await raw('/api/v1/qualityprofile');
+    final int qualityProfileId = (qps.first as Map<String, dynamic>)['id'] as int;
+    final List<dynamic> mps = await raw('/api/v1/metadataprofile');
+    final int metadataProfileId =
+        (mps.first as Map<String, dynamic>)['id'] as int;
+
+    await lifecycle(
+      label: 'indexer',
+      schemaPath: '/api/v1/indexer/schema',
+      listPath: '/api/v1/indexer',
+      create: (Map<String, dynamic> b) =>
+          api.indexer.postIndexer(body: IndexerResource.fromJson(b)),
+      remove: (int id) => api.indexer.deleteIndexerById(id: id),
+    );
+
+    await lifecycle(
+      label: 'downloadClient',
+      schemaPath: '/api/v1/downloadclient/schema',
+      listPath: '/api/v1/downloadclient',
+      create: (Map<String, dynamic> b) => api.downloadClient
+          .postDownloadclient(body: DownloadClientResource.fromJson(b)),
+      remove: (int id) =>
+          api.downloadClient.deleteDownloadclientById(id: id),
+    );
+
+    await lifecycle(
+      label: 'notification',
+      schemaPath: '/api/v1/notification/schema',
+      listPath: '/api/v1/notification',
+      create: (Map<String, dynamic> b) => api.notification
+          .postNotification(body: NotificationResource.fromJson(b)),
+      remove: (int id) => api.notification.deleteNotificationById(id: id),
+    );
+
+    await lifecycle(
+      label: 'importList',
+      schemaPath: '/api/v1/importlist/schema',
+      listPath: '/api/v1/importlist',
+      create: (Map<String, dynamic> b) =>
+          api.importList.postImportlist(body: ImportListResource.fromJson(b)),
+      remove: (int id) => api.importList.deleteImportlistById(id: id),
+      // The schema ships placeholders for these; a real one is only valid once
+      // the user has picked a folder and profiles, so the test does the same.
+      tweak: (Map<String, dynamic> b) => b
+        ..['rootFolderPath'] = rootFolder
+        ..['qualityProfileId'] = qualityProfileId
+        ..['metadataProfileId'] = metadataProfileId,
+    );
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+
+  test('profiles and tags can be created and deleted', () async {
+    // A tag is the simplest resource there is: no schema, just a label.
+    int? tagId;
+    try {
+      final dynamic made =
+          await api.tag.postTag(body: const TagResource(label: 'zz-atrium'));
+      // ignore: avoid_dynamic_calls
+      tagId = made.data?.id as int?;
+      // ignore: avoid_dynamic_calls
+      if (made.isSuccess == true && tagId != null) {
+        await api.tag.deleteTagById(id: tagId);
+        tagId = null;
+        pass('tag create + delete');
+      } else {
+        // ignore: avoid_dynamic_calls
+        fail('tag', made.error);
+      }
+    } on Object catch (e) {
+      fail('tag', e);
+    } finally {
+      if (tagId != null) {
+        await api.tag.deleteTagById(id: tagId);
+      }
+    }
+
+    await lifecycle(
+      label: 'qualityProfile',
+      schemaPath: '/api/v1/qualityprofile/schema',
+      listPath: '/api/v1/qualityprofile',
+      create: (Map<String, dynamic> b) => api.qualityProfile
+          .postQualityprofile(body: QualityProfileResource.fromJson(b)),
+      remove: (int id) =>
+          api.qualityProfile.deleteQualityprofileById(id: id),
+      // Every quality in the schema arrives disallowed, and Lidarr refuses a
+      // profile that permits nothing, so allow one and cut off there.
+      tweak: (Map<String, dynamic> b) {
+        final List<dynamic> items = (b['items'] as List<dynamic>?) ?? <dynamic>[];
+        for (final dynamic raw in items) {
+          if (raw is Map<String, dynamic> && raw['id'] != null) {
+            raw['allowed'] = true;
+            b['cutoff'] = raw['id'];
+            break;
+          }
+        }
+        return b;
+      },
+    );
+
+    await lifecycle(
+      label: 'metadataProfile',
+      schemaPath: '/api/v1/metadataprofile',
+      listPath: '/api/v1/metadataprofile',
+      create: (Map<String, dynamic> b) => api.metadataProfile
+          .postMetadataprofile(body: MetadataProfileResource.fromJson(b)),
+      remove: (int id) =>
+          api.metadataProfile.deleteMetadataprofileById(id: id),
+      tweak: (Map<String, dynamic> b) => b..remove('id'),
+    );
+
+    expect(failures, isEmpty, reason: failures.join('\n'));
+  }, timeout: const Timeout(Duration(minutes: 5)),);
+}

--- a/services/service_lidarr/test/plugin_enum_test.dart
+++ b/services/service_lidarr/test/plugin_enum_test.dart
@@ -1,0 +1,107 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_lidarr/service_lidarr.dart';
+
+/// Lidarr's plugin builds serve enum values no released OpenAPI spec lists.
+///
+/// Tubifarry and friends register their own download protocols, so a release
+/// off a plugin indexer comes back with `"protocol": "TorrentDownloadProtocol"`
+/// rather than one of the three the spec declares. json_serializable throws on
+/// a value it cannot map, and that took down the whole interactive search
+/// rather than one field: issue #134.
+void main() {
+  group('enum values the spec has never seen', () {
+    test('a plugin protocol parses instead of throwing', () {
+      // Verbatim shape from a plugin indexer, trimmed to what matters.
+      const String raw = '''
+      {
+        "guid": "tubifarry-1",
+        "title": "Some Artist - Some Album [FLAC]",
+        "protocol": "TorrentDownloadProtocol",
+        "indexer": "Slskd",
+        "size": 12345,
+        "approved": true,
+        "rejected": false
+      }
+      ''';
+
+      final ReleaseResource release = ReleaseResource.fromJson(
+        jsonDecode(raw) as Map<String, dynamic>,
+      );
+
+      expect(release.protocol, DownloadProtocol.torrent);
+      expect(release.title, 'Some Artist - Some Album [FLAC]');
+      expect(release.indexer, 'Slskd');
+      expect(release.approved, isTrue);
+    });
+
+    test('the protocols the spec does list still map correctly', () {
+      ReleaseResource of(String p) => ReleaseResource.fromJson(
+            <String, dynamic>{'guid': 'g', 'protocol': p},
+          );
+
+      expect(of('torrent').protocol, DownloadProtocol.torrent);
+      expect(of('usenet').protocol, DownloadProtocol.usenet);
+      expect(of('unknown').protocol, DownloadProtocol.unknown);
+    });
+
+    test('newer builds spell the standard protocols out in full', () {
+      // Not a plugin thing: nightly serialises the same two protocols as
+      // `TorrentDownloadProtocol` and `UsenetDownloadProtocol` where the
+      // released branch sends `torrent` and `usenet`. Losing that to
+      // `unknown` would blank the protocol chip on every row.
+      ReleaseResource of(String p) => ReleaseResource.fromJson(
+            <String, dynamic>{'guid': 'g', 'protocol': p},
+          );
+
+      expect(of('TorrentDownloadProtocol').protocol, DownloadProtocol.torrent);
+      expect(of('UsenetDownloadProtocol').protocol, DownloadProtocol.usenet);
+      expect(of('UnknownDownloadProtocol').protocol, DownloadProtocol.unknown);
+    });
+
+    test('a genuinely new protocol still lands on unknown', () {
+      // The six Tubifarry adds have no counterpart in the spec, so they can
+      // only degrade, but they must not throw.
+      for (final String p in <String>[
+        'SoulseekDownloadProtocol',
+        'QobuzDownloadProtocol',
+        'LucidaDownloadProtocol',
+        'SubSonicDownloadProtocol',
+        'AmazonMusicDownloadProtocol',
+        'YoutubeDownloadProtocol',
+      ]) {
+        final ReleaseResource r = ReleaseResource.fromJson(
+          <String, dynamic>{'guid': 'g', 'protocol': p},
+        );
+        expect(r.protocol, DownloadProtocol.unknown, reason: p);
+      }
+    });
+
+    test('a queue item on a plugin protocol parses too', () {
+      // The queue is the other screen that reads a protocol off every row, so
+      // an unmapped value there would empty Activity rather than one card.
+      final QueueResource item = QueueResource.fromJson(<String, dynamic>{
+        'id': 1,
+        'title': 'Some Artist - Some Album',
+        'protocol': 'SlskdDownloadProtocol',
+      });
+
+      expect(item.protocol, DownloadProtocol.unknown);
+      expect(item.title, 'Some Artist - Some Album');
+    });
+
+    test('an unknown value anywhere else degrades the same way', () {
+      // Not protocol-specific: any enum the server extends behaves this way,
+      // which is the point of doing it in the generator rather than by hand.
+      final BlocklistResource b = BlocklistResource.fromJson(<String, dynamic>{
+        'id': 2,
+        'sourceTitle': 'whatever',
+        'protocol': 'SubsonicDownloadProtocol',
+      });
+
+      expect(b.protocol, DownloadProtocol.unknown);
+      expect(b.sourceTitle, 'whatever');
+    });
+  });
+}

--- a/services/service_lidarr/tool/openapi_parser.dart
+++ b/services/service_lidarr/tool/openapi_parser.dart
@@ -27,6 +27,14 @@ class LidarrOpenApiParser {
   final String outputDir;
 
   final Map<String, String> schemaClassNames = {};
+
+  /// Enum class name -> the variant to fall back to when the server sends a
+  /// value this spec has never heard of. See [_collectEnumFallbacks].
+  final Map<String, String> enumFallbacks = {};
+
+  /// Enum class name -> the raw JSON values it declares, for string enums.
+  /// Used to recognise the same value under a different spelling.
+  final Map<String, List<String>> enumValues = {};
   final Map<String, dynamic> schemas = {};
   final Map<String, List<Map<String, dynamic>>> tagEndpoints = {};
   final Set<String> _writtenFilePaths = {};
@@ -428,9 +436,97 @@ class LidarrException implements Exception {
 ''';
     _writeFileIfChanged(
         '$outputDir/responses/lidarr_exception.dart', exceptionContent);
+
+    const normalizerContent = r'''
+/// Accepts either spelling Lidarr uses for an enum value.
+///
+/// Older builds serialise these in short form (`torrent`), while newer
+/// branches send the full C# member name (`TorrentDownloadProtocol`). The
+/// difference is systematic rather than per-plugin, so rather than teach every
+/// call site about it, the raw value is reconciled here before decoding.
+///
+/// Returns the declared spelling when it can recognise the value, and the
+/// original otherwise, leaving the generated `unknownEnumValue` to catch
+/// anything genuinely new such as a protocol a plugin has introduced.
+Object? normalizeLidarrEnum(
+  Object? raw,
+  String enumName,
+  List<String> allowed,
+) {
+  if (raw is! String) return raw;
+  if (allowed.contains(raw)) return raw;
+
+  var candidate = raw;
+  final lowerName = enumName.toLowerCase();
+  if (candidate.length > enumName.length &&
+      candidate.toLowerCase().endsWith(lowerName)) {
+    candidate = candidate.substring(0, candidate.length - enumName.length);
+  }
+
+  for (final value in allowed) {
+    if (value.toLowerCase() == candidate.toLowerCase()) return value;
+  }
+  return raw;
+}
+''';
+    _writeFileIfChanged(
+        '$outputDir/responses/enum_normalizer.dart', normalizerContent);
+  }
+
+  /// The identifiers [_buildEnumCode] will emit, in order, for one enum.
+  ///
+  /// Kept deliberately in step with that method: a fallback has to name a
+  /// variant that actually exists, collision suffix and all.
+  List<String> _enumIdentifiers(List<dynamic> enumList) {
+    final used = <String>{};
+    final out = <String>[];
+    for (final item in enumList) {
+      var identifier =
+          item is int ? 'val$item' : _toCamelCase(item.toString());
+      while (used.contains(identifier)) {
+        identifier = '${identifier}Alt';
+      }
+      used.add(identifier);
+      out.add(identifier);
+    }
+    return out;
+  }
+
+  /// Picks a landing spot for enum values this spec does not list.
+  ///
+  /// Lidarr's plugin builds introduce protocols and statuses no released spec
+  /// mentions, and json_serializable throws on a value it cannot map, which
+  /// loses the entire response rather than one field. Falling back keeps the
+  /// rest of the payload usable. An `unknown` variant is the natural home
+  /// where the enum has one; otherwise the first value is taken, since the
+  /// alternative is an exception.
+  void _collectEnumFallbacks() {
+    for (final entry in schemas.entries) {
+      final schema = (entry.value as Map).cast<String, dynamic>();
+      if (!schema.containsKey('enum')) continue;
+      final className = schemaClassNames[entry.key];
+      if (className == null) continue;
+      final enumList = schema['enum'] as List<dynamic>;
+      if (enumList.isEmpty) continue;
+
+      final identifiers = _enumIdentifiers(enumList);
+      var chosen = identifiers.first;
+      for (var i = 0; i < enumList.length; i++) {
+        final item = enumList[i];
+        if (item is! int && item.toString().toLowerCase() == 'unknown') {
+          chosen = identifiers[i];
+          break;
+        }
+      }
+      enumFallbacks[className] = chosen;
+      if (enumList.every((e) => e is! int)) {
+        enumValues[className] = enumList.map((e) => e.toString()).toList();
+      }
+    }
   }
 
   void _generateModelFiles() {
+    _collectEnumFallbacks();
     for (final entry in schemas.entries) {
       final fullKey = entry.key;
       final schema = (entry.value as Map).cast<String, dynamic>();
@@ -494,6 +590,7 @@ class LidarrException implements Exception {
     final imports = <String>{};
     final fields = <_ModelField>[];
     final usedFieldNames = <String>{};
+    final enumReadersNeeded = <String>{};
 
     for (final propEntry in properties.entries) {
       final propKey = propEntry.key;
@@ -538,6 +635,7 @@ class LidarrException implements Exception {
     buffer.writeln("// ignore_for_file: unused_import");
     buffer.writeln(
         "import 'package:freezed_annotation/freezed_annotation.dart';");
+    buffer.writeln("import '../responses/enum_normalizer.dart';");
     for (final imp in imports) {
       if (imp != className) {
         final impFileName = _toSnakeCase(imp);
@@ -592,8 +690,28 @@ class LidarrException implements Exception {
             ? (f.dartType.endsWith('?') ? f.dartType : '${f.dartType}?')
             : f.dartType;
         final prefix = f.isNullable ? '' : 'required ';
+        // Give an enum field somewhere to land when the server sends a value
+        // this spec does not list, rather than throwing and losing the whole
+        // response. Covers `List<Enum>` too, where it applies per element.
+        final baseType = typeStr
+            .replaceAll('?', '')
+            .replaceFirst('List<', '')
+            .replaceFirst('>', '');
+        final fallback = enumFallbacks[baseType];
+        final args = <String>["name: '${f.jsonKey}'"];
+        if (fallback != null) {
+          // Lidarr's newer branches serialise an enum by its C# member name
+          // (`TorrentDownloadProtocol`) where older ones sent the short form
+          // (`torrent`), so the raw value is normalised before decoding and
+          // anything still unrecognised lands on the fallback.
+          if (enumValues.containsKey(baseType)) {
+            enumReadersNeeded.add(baseType);
+            args.add('readValue: _read$baseType');
+          }
+          args.add('unknownEnumValue: $baseType.$fallback');
+        }
         buffer.writeln(
-            "    @JsonKey(name: '${f.jsonKey}') $prefix$typeStr ${f.fieldName},");
+            "    @JsonKey(${args.join(', ')}) $prefix$typeStr ${f.fieldName},");
       }
       buffer.writeln('  }) = _$className;');
     }
@@ -602,6 +720,21 @@ class LidarrException implements Exception {
         .writeln('  factory $className.fromJson(Map<String, dynamic> json) =>');
     buffer.writeln('      _\$${className}FromJson(json);');
     buffer.writeln('}');
+
+    for (final enumName in enumReadersNeeded) {
+      final allowed =
+          enumValues[enumName]!.map((v) => "'${v.replaceAll("'", r"'")}'").join(', ');
+      buffer.writeln();
+      buffer.writeln('/// Reads `\$key` allowing for either spelling of a');
+      buffer.writeln('/// [$enumName] value. See `normalizeLidarrEnum`.');
+      buffer.writeln(
+          'Object? _read$enumName(Map<dynamic, dynamic> json, String key) =>');
+      buffer.writeln('    normalizeLidarrEnum(');
+      buffer.writeln("      json[key],");
+      buffer.writeln("      '$enumName',");
+      buffer.writeln('      const <String>[$allowed],');
+      buffer.writeln('    );');
+    }
 
     return buffer.toString();
   }
@@ -1136,6 +1269,7 @@ class LidarrException implements Exception {
     buffer.writeln("export 'responses/api_response.dart';");
     buffer.writeln("export 'responses/lidarr_error.dart';");
     buffer.writeln("export 'responses/lidarr_exception.dart';");
+    buffer.writeln("export 'responses/enum_normalizer.dart';");
 
     for (final entry in schemas.entries) {
       final className = schemaClassNames[entry.key]!;

--- a/services/service_lidarr/tool/openapi_parser.dart
+++ b/services/service_lidarr/tool/openapi_parser.dart
@@ -40,8 +40,6 @@ class LidarrOpenApiParser {
   final Set<String> _writtenFilePaths = {};
   final List<String> _warnings = [];
 
-  final Map<String, String> _enumUnknownMap = {};
-
   int _modelsWritten = 0;
   int _modelsSkippedUnchanged = 0;
   int _apisWritten = 0;
@@ -59,27 +57,6 @@ class LidarrOpenApiParser {
 
     for (final fullKey in schemas.keys) {
       schemaClassNames[fullKey] = _resolveClassName(fullKey, rawSchemas);
-    }
-
-    for (final entry in schemas.entries) {
-      final s = entry.value is Map
-          ? (entry.value as Map).cast<String, dynamic>()
-          : <String, dynamic>{};
-      if (s.containsKey('enum')) {
-        final enumList = (s['enum'] as List<dynamic>?) ?? [];
-        final hasUnknown =
-            enumList.any((e) => e.toString().toLowerCase() == 'unknown');
-        if (hasUnknown) {
-          final unknownItem = enumList
-              .firstWhere((e) => e.toString().toLowerCase() == 'unknown');
-          final unknownId = unknownItem is int
-              ? 'val$unknownItem'
-              : _toCamelCase(unknownItem.toString());
-          final clsName = schemaClassNames[entry.key] ??
-              _resolveClassName(entry.key, rawSchemas);
-          _enumUnknownMap[clsName] = unknownId;
-        }
-      }
     }
   }
 
@@ -773,6 +750,7 @@ Object? normalizeLidarrEnum(
     buffer.writeln();
     buffer.writeln("part '$fileName.g.dart';");
     buffer.writeln();
+    buffer.writeln('/// Enum `$className`');
     buffer.writeln('@JsonEnum(alwaysCreate: true)');
     buffer.writeln('enum $className {');
 
@@ -800,34 +778,11 @@ Object? normalizeLidarrEnum(
         buffer.writeln("  $identifier('$escaped'),");
       }
     }
-    if (className == 'DownloadProtocol') {
-      if (!usedIdentifiers.contains('torrentDownloadProtocol')) {
-        buffer.writeln("  @JsonValue('TorrentDownloadProtocol')");
-        buffer.writeln("  torrentDownloadProtocol('TorrentDownloadProtocol'),");
-      }
-      if (!usedIdentifiers.contains('usenetDownloadProtocol')) {
-        buffer.writeln("  @JsonValue('UsenetDownloadProtocol')");
-        buffer.writeln("  usenetDownloadProtocol('UsenetDownloadProtocol'),");
-      }
-    }
     buffer.writeln(';');
     buffer.writeln();
     final valType = isIntEnum ? 'int' : 'String';
     buffer.writeln('  final $valType value;');
     buffer.writeln('  const $className(this.value);');
-    if (className == 'DownloadProtocol') {
-      buffer.writeln();
-      buffer.writeln(
-          '  bool get isTorrent => value.toLowerCase().contains("torrent");');
-      buffer.writeln(
-          '  bool get isUsenet => value.toLowerCase().contains("usenet");');
-      buffer.writeln();
-      buffer.writeln('  String get displayName {');
-      buffer.writeln('    if (isTorrent) return "Torrent";');
-      buffer.writeln('    if (isUsenet) return "Usenet";');
-      buffer.writeln('    return value;');
-      buffer.writeln('  }');
-    }
     buffer.writeln('}');
     return buffer.toString();
   }

--- a/services/service_lidarr/tool/openapi_parser.dart
+++ b/services/service_lidarr/tool/openapi_parser.dart
@@ -40,6 +40,8 @@ class LidarrOpenApiParser {
   final Set<String> _writtenFilePaths = {};
   final List<String> _warnings = [];
 
+  final Map<String, String> _enumUnknownMap = {};
+
   int _modelsWritten = 0;
   int _modelsSkippedUnchanged = 0;
   int _apisWritten = 0;
@@ -57,6 +59,27 @@ class LidarrOpenApiParser {
 
     for (final fullKey in schemas.keys) {
       schemaClassNames[fullKey] = _resolveClassName(fullKey, rawSchemas);
+    }
+
+    for (final entry in schemas.entries) {
+      final s = entry.value is Map
+          ? (entry.value as Map).cast<String, dynamic>()
+          : <String, dynamic>{};
+      if (s.containsKey('enum')) {
+        final enumList = (s['enum'] as List<dynamic>?) ?? [];
+        final hasUnknown =
+            enumList.any((e) => e.toString().toLowerCase() == 'unknown');
+        if (hasUnknown) {
+          final unknownItem = enumList
+              .firstWhere((e) => e.toString().toLowerCase() == 'unknown');
+          final unknownId = unknownItem is int
+              ? 'val$unknownItem'
+              : _toCamelCase(unknownItem.toString());
+          final clsName = schemaClassNames[entry.key] ??
+              _resolveClassName(entry.key, rawSchemas);
+          _enumUnknownMap[clsName] = unknownId;
+        }
+      }
     }
   }
 
@@ -750,7 +773,6 @@ Object? normalizeLidarrEnum(
     buffer.writeln();
     buffer.writeln("part '$fileName.g.dart';");
     buffer.writeln();
-    buffer.writeln('/// Enum `$className`');
     buffer.writeln('@JsonEnum(alwaysCreate: true)');
     buffer.writeln('enum $className {');
 
@@ -778,11 +800,34 @@ Object? normalizeLidarrEnum(
         buffer.writeln("  $identifier('$escaped'),");
       }
     }
+    if (className == 'DownloadProtocol') {
+      if (!usedIdentifiers.contains('torrentDownloadProtocol')) {
+        buffer.writeln("  @JsonValue('TorrentDownloadProtocol')");
+        buffer.writeln("  torrentDownloadProtocol('TorrentDownloadProtocol'),");
+      }
+      if (!usedIdentifiers.contains('usenetDownloadProtocol')) {
+        buffer.writeln("  @JsonValue('UsenetDownloadProtocol')");
+        buffer.writeln("  usenetDownloadProtocol('UsenetDownloadProtocol'),");
+      }
+    }
     buffer.writeln(';');
     buffer.writeln();
     final valType = isIntEnum ? 'int' : 'String';
     buffer.writeln('  final $valType value;');
     buffer.writeln('  const $className(this.value);');
+    if (className == 'DownloadProtocol') {
+      buffer.writeln();
+      buffer.writeln(
+          '  bool get isTorrent => value.toLowerCase().contains("torrent");');
+      buffer.writeln(
+          '  bool get isUsenet => value.toLowerCase().contains("usenet");');
+      buffer.writeln();
+      buffer.writeln('  String get displayName {');
+      buffer.writeln('    if (isTorrent) return "Torrent";');
+      buffer.writeln('    if (isUsenet) return "Usenet";');
+      buffer.writeln('    return value;');
+      buffer.writeln('  }');
+    }
     buffer.writeln('}');
     return buffer.toString();
   }

--- a/site/src/components/hero.html
+++ b/site/src/components/hero.html
@@ -1,7 +1,7 @@
 <section class="hero-section">
   <div class="grid middle-align">
     <div class="s12 m6 hero-text-col center-align-mobile">
-      <div class="chip border round">v1.5.0 Release</div>
+      <div class="chip border round">v1.5.1 Release</div>
       <h1 class="hero-title">Your self-hosted media, unified.</h1>
       <p class="hero-subtitle">One premium Android app that fronts Sonarr, Radarr, Plex, Jellyfin, qBittorrent, and more. Material 3 Expressive, multi-instance, and fully secure.</p>
       <div class="row hero-actions">


### PR DESCRIPTION
Patch release for the Lidarr fixes.

## What's new

**Fixed**

- Adding things in Lidarr works again. Adding an artist, indexer, download client, import list, notification, tag, root folder, custom format or any of the profiles was refused by the server, as was grabbing a release from an interactive search. Atrium was sending empty fields that Lidarr will not accept, and it rejected the whole request without saying which part it disliked.
- Interactive search no longer fails on Lidarr nightly and on builds with plugins installed. Those versions name their download protocols differently, and a single name Atrium did not recognise discarded the entire list of results rather than that one field.
- Lidarr screens no longer run off the edge at large system text sizes, in the track file editor, the unmapped files list and artist history.

**Improved**

- Lidarr activity history keeps loading as you scroll instead of stopping at the first page.