### PR TITLE
feat(radarr,sonarr): open torrent/indexer page and copy links in interactive search

### DIFF
--- a/services/service_radarr/lib/src/radarr_release_search_screen.dart
+++ b/services/service_radarr/lib/src/radarr_release_search_screen.dart
@@ -1,7 +1,9 @@
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'models/radarr_movie.dart';
 import 'radarr_providers.dart';
@@ -97,6 +99,23 @@ class _RadarrReleaseSearchScreenState
       }
     }
     return names;
+  }
+
+  String? _getReleaseWebUrl(Map<String, dynamic> r) {
+    final dynamic infoUrl = r['infoUrl'];
+    if (infoUrl is String && infoUrl.trim().isNotEmpty) {
+      return infoUrl.trim();
+    }
+    final dynamic commentUrl = r['commentUrl'];
+    if (commentUrl is String && commentUrl.trim().isNotEmpty) {
+      return commentUrl.trim();
+    }
+    final dynamic guid = r['guid'];
+    if (guid is String &&
+        (guid.startsWith('http://') || guid.startsWith('https://'))) {
+      return guid.trim();
+    }
+    return null;
   }
 
   Future<void> _download(
@@ -483,6 +502,11 @@ class _RadarrReleaseSearchScreenState
                       // Extract custom format score and custom formats safely
                       final int customFormatScore = _getCustomFormatScore(r);
                       final List<String> formatNames = _getCustomFormatNames(r);
+                      final String? webUrl = _getReleaseWebUrl(r);
+                      final String? downloadUrl =
+                          (r['downloadUrl'] as String?)?.trim();
+                      final String? magnetUrl =
+                          (r['magnetUrl'] as String?)?.trim();
 
                       return Card(
                         margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -576,8 +600,7 @@ class _RadarrReleaseSearchScreenState
                                             : customFormatScore < 0
                                                 ? colors.errorContainer
                                                     .withValues(alpha: 0.6)
-                                                : colors
-                                                    .surfaceContainerHighest
+                                                : colors.surfaceContainerHighest
                                                     .withValues(alpha: 0.6),
                                         borderRadius:
                                             BorderRadius.circular(Radii.sm),
@@ -747,7 +770,7 @@ class _RadarrReleaseSearchScreenState
                                       ),
                                     ),
                                     const SizedBox(height: 8),
-                                  ] else
+                                  ] else ...[
                                     Row(
                                       children: [
                                         Icon(
@@ -765,7 +788,148 @@ class _RadarrReleaseSearchScreenState
                                         ),
                                       ],
                                     ),
-                                  const SizedBox(height: 4),
+                                    const SizedBox(height: 8),
+                                  ],
+                                  if (webUrl != null ||
+                                      (downloadUrl != null &&
+                                          downloadUrl.isNotEmpty) ||
+                                      (magnetUrl != null &&
+                                          magnetUrl.isNotEmpty)) ...[
+                                    Wrap(
+                                      spacing: Insets.xs,
+                                      runSpacing: Insets.xs,
+                                      children: [
+                                        if (webUrl != null)
+                                          FilledButton.tonalIcon(
+                                            icon: const Icon(
+                                              Icons.open_in_browser,
+                                              size: 16,
+                                            ),
+                                            label: Text(
+                                              protocol == 'usenet'
+                                                  ? 'Open Indexer Page'
+                                                  : 'Open Torrent Page',
+                                            ),
+                                            style: FilledButton.styleFrom(
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                            ),
+                                            onPressed: () async {
+                                              final uri = Uri.tryParse(webUrl);
+                                              if (uri != null) {
+                                                try {
+                                                  final bool launched =
+                                                      await launchUrl(
+                                                    uri,
+                                                    mode: LaunchMode
+                                                        .externalApplication,
+                                                  );
+                                                  if (!launched &&
+                                                      context.mounted) {
+                                                    ScaffoldMessenger.of(
+                                                      context,
+                                                    ).showSnackBar(
+                                                      SnackBar(
+                                                        content: Text(
+                                                          protocol == 'usenet'
+                                                              ? 'Could not open indexer page URL'
+                                                              : 'Could not open torrent page URL',
+                                                        ),
+                                                        duration:
+                                                            const Duration(
+                                                          seconds: 2,
+                                                        ),
+                                                      ),
+                                                    );
+                                                  }
+                                                } catch (_) {
+                                                  if (context.mounted) {
+                                                    ScaffoldMessenger.of(
+                                                      context,
+                                                    ).showSnackBar(
+                                                      SnackBar(
+                                                        content: Text(
+                                                          protocol == 'usenet'
+                                                              ? 'Could not open indexer page URL'
+                                                              : 'Could not open torrent page URL',
+                                                        ),
+                                                        duration:
+                                                            const Duration(
+                                                          seconds: 2,
+                                                        ),
+                                                      ),
+                                                    );
+                                                  }
+                                                }
+                                              }
+                                            },
+                                          ),
+                                        if (downloadUrl != null &&
+                                            downloadUrl.isNotEmpty)
+                                          OutlinedButton.icon(
+                                            icon: const Icon(
+                                              Icons.copy,
+                                              size: 14,
+                                            ),
+                                            label: const Text(
+                                              'Copy Download URL',
+                                            ),
+                                            style: OutlinedButton.styleFrom(
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                            ),
+                                            onPressed: () {
+                                              Clipboard.setData(
+                                                ClipboardData(
+                                                  text: downloadUrl,
+                                                ),
+                                              );
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                const SnackBar(
+                                                  content: Text(
+                                                    'Download URL copied to clipboard',
+                                                  ),
+                                                  duration:
+                                                      Duration(seconds: 2),
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                        if (magnetUrl != null &&
+                                            magnetUrl.isNotEmpty)
+                                          OutlinedButton.icon(
+                                            icon: const Icon(
+                                              Icons.link,
+                                              size: 14,
+                                            ),
+                                            label: const Text(
+                                              'Copy Magnet Link',
+                                            ),
+                                            style: OutlinedButton.styleFrom(
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                            ),
+                                            onPressed: () {
+                                              Clipboard.setData(
+                                                ClipboardData(text: magnetUrl),
+                                              );
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                const SnackBar(
+                                                  content: Text(
+                                                    'Magnet link copied to clipboard',
+                                                  ),
+                                                  duration:
+                                                      Duration(seconds: 2),
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 4),
+                                  ],
                                 ],
                               ),
                             ),

--- a/services/service_radarr/test/radarr_release_search_test.dart
+++ b/services/service_radarr/test/radarr_release_search_test.dart
@@ -97,8 +97,7 @@ void main() {
 
       final highScorePos =
           tester.getTopLeft(find.textContaining('2160p.UHD.Remux'));
-      final lowScorePos =
-          tester.getTopLeft(find.textContaining('720p.HDTV'));
+      final lowScorePos = tester.getTopLeft(find.textContaining('720p.HDTV'));
       expect(highScorePos.dy, lessThan(lowScorePos.dy));
 
       // Verify Score badges and Custom Format pills are rendered
@@ -182,6 +181,105 @@ void main() {
       // is what proves the malformed payloads were absorbed, not thrown on.
       expect(find.text('Score: 0'), findsNothing);
       expect(find.text('ValidFormat'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'RadarrReleaseSearchScreen renders Open Torrent Page / Open Indexer Page and copy buttons when expanded',
+    (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final releasesWithLinks = [
+        <String, dynamic>{
+          'guid': 'https://tracker.example.com/guid/101',
+          'title': 'Inception.2010.Torrent.Release',
+          'indexer': 'Torrent Tracker',
+          'size': 2000000000,
+          'seeders': 25,
+          'leechers': 2,
+          'protocol': 'torrent',
+          'rejections': <String>[],
+          'infoUrl': 'https://tracker.example.com/details/101',
+          'downloadUrl': 'https://tracker.example.com/download/101.torrent',
+          'magnetUrl': 'magnet:?xt=urn:btih:abc123def456',
+        },
+        <String, dynamic>{
+          'guid': 'release-usenet-guid',
+          'title': 'Inception.2010.Usenet.Release',
+          'indexer': 'NZB Indexer',
+          'size': 3000000000,
+          'protocol': 'usenet',
+          'rejections': <String>['Quality not wanted in profile'],
+          'commentUrl': 'https://nzb.example.com/comments/202',
+          'downloadUrl': 'https://nzb.example.com/get/202.nzb',
+        },
+        <String, dynamic>{
+          'guid': 'plain-non-url-guid',
+          'title': 'Inception.2010.NoLinks.Release',
+          'indexer': 'Private Tracker',
+          'size': 1000000000,
+          'protocol': 'torrent',
+          'rejections': <String>[],
+        },
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            radarrReleasesProvider((instance, movie.id)).overrideWith(
+              (ref) async => releasesWithLinks,
+            ),
+          ],
+          child: const MaterialApp(
+            home: RadarrReleaseSearchScreen(
+              instance: instance,
+              movie: movie,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ExpansionTile), findsNWidgets(3));
+
+      // Expand the first release (Torrent with infoUrl, downloadUrl, magnetUrl)
+      await tester.tap(find.text('Inception.2010.Torrent.Release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Torrent Page'), findsOneWidget);
+      expect(find.text('Copy Download URL'), findsOneWidget);
+      expect(find.text('Copy Magnet Link'), findsOneWidget);
+
+      // Collapse first release
+      await tester.tap(find.text('Inception.2010.Torrent.Release'));
+      await tester.pumpAndSettle();
+
+      // Expand the second release (Usenet with commentUrl, downloadUrl, and rejections)
+      await tester.tap(find.text('Inception.2010.Usenet.Release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Indexer Page'), findsOneWidget);
+      expect(find.text('Rejection Reasons:'), findsOneWidget);
+      expect(find.text('• Quality not wanted in profile'), findsOneWidget);
+
+      // Collapse second release
+      await tester.tap(find.text('Inception.2010.Usenet.Release'));
+      await tester.pumpAndSettle();
+
+      // Expand the third release (No web URL, no download/magnet URL)
+      await tester.tap(find.text('Inception.2010.NoLinks.Release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Approved for download.'), findsOneWidget);
+      expect(find.text('Open Torrent Page'), findsNothing);
+      expect(find.text('Open Indexer Page'), findsNothing);
     },
   );
 }

--- a/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_release_search_screen.dart
@@ -1,7 +1,9 @@
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'models/sonarr_episode.dart';
 import 'models/sonarr_series.dart';
@@ -102,6 +104,23 @@ class _SonarrReleaseSearchScreenState
       }
     }
     return names;
+  }
+
+  String? _getReleaseWebUrl(Map<String, dynamic> r) {
+    final dynamic infoUrl = r['infoUrl'];
+    if (infoUrl is String && infoUrl.trim().isNotEmpty) {
+      return infoUrl.trim();
+    }
+    final dynamic commentUrl = r['commentUrl'];
+    if (commentUrl is String && commentUrl.trim().isNotEmpty) {
+      return commentUrl.trim();
+    }
+    final dynamic guid = r['guid'];
+    if (guid is String &&
+        (guid.startsWith('http://') || guid.startsWith('https://'))) {
+      return guid.trim();
+    }
+    return null;
   }
 
   Future<void> _download(
@@ -520,6 +539,11 @@ class _SonarrReleaseSearchScreenState
                       // Extract custom format score and custom formats safely
                       final int customFormatScore = _getCustomFormatScore(r);
                       final List<String> formatNames = _getCustomFormatNames(r);
+                      final String? webUrl = _getReleaseWebUrl(r);
+                      final String? downloadUrl =
+                          (r['downloadUrl'] as String?)?.trim();
+                      final String? magnetUrl =
+                          (r['magnetUrl'] as String?)?.trim();
 
                       return Card(
                         margin: const EdgeInsets.only(bottom: Insets.sm),
@@ -614,8 +638,7 @@ class _SonarrReleaseSearchScreenState
                                             : customFormatScore < 0
                                                 ? colors.errorContainer
                                                     .withValues(alpha: 0.6)
-                                                : colors
-                                                    .surfaceContainerHighest
+                                                : colors.surfaceContainerHighest
                                                     .withValues(alpha: 0.6),
                                         borderRadius:
                                             BorderRadius.circular(Radii.sm),
@@ -785,7 +808,7 @@ class _SonarrReleaseSearchScreenState
                                       ),
                                     ),
                                     const SizedBox(height: 8),
-                                  ] else
+                                  ] else ...[
                                     Row(
                                       children: [
                                         Icon(
@@ -803,7 +826,148 @@ class _SonarrReleaseSearchScreenState
                                         ),
                                       ],
                                     ),
-                                  const SizedBox(height: 4),
+                                    const SizedBox(height: 8),
+                                  ],
+                                  if (webUrl != null ||
+                                      (downloadUrl != null &&
+                                          downloadUrl.isNotEmpty) ||
+                                      (magnetUrl != null &&
+                                          magnetUrl.isNotEmpty)) ...[
+                                    Wrap(
+                                      spacing: Insets.xs,
+                                      runSpacing: Insets.xs,
+                                      children: [
+                                        if (webUrl != null)
+                                          FilledButton.tonalIcon(
+                                            icon: const Icon(
+                                              Icons.open_in_browser,
+                                              size: 16,
+                                            ),
+                                            label: Text(
+                                              protocol == 'usenet'
+                                                  ? 'Open Indexer Page'
+                                                  : 'Open Torrent Page',
+                                            ),
+                                            style: FilledButton.styleFrom(
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                            ),
+                                            onPressed: () async {
+                                              final uri = Uri.tryParse(webUrl);
+                                              if (uri != null) {
+                                                try {
+                                                  final bool launched =
+                                                      await launchUrl(
+                                                    uri,
+                                                    mode: LaunchMode
+                                                        .externalApplication,
+                                                  );
+                                                  if (!launched &&
+                                                      context.mounted) {
+                                                    ScaffoldMessenger.of(
+                                                      context,
+                                                    ).showSnackBar(
+                                                      SnackBar(
+                                                        content: Text(
+                                                          protocol == 'usenet'
+                                                              ? 'Could not open indexer page URL'
+                                                              : 'Could not open torrent page URL',
+                                                        ),
+                                                        duration:
+                                                            const Duration(
+                                                          seconds: 2,
+                                                        ),
+                                                      ),
+                                                    );
+                                                  }
+                                                } catch (_) {
+                                                  if (context.mounted) {
+                                                    ScaffoldMessenger.of(
+                                                      context,
+                                                    ).showSnackBar(
+                                                      SnackBar(
+                                                        content: Text(
+                                                          protocol == 'usenet'
+                                                              ? 'Could not open indexer page URL'
+                                                              : 'Could not open torrent page URL',
+                                                        ),
+                                                        duration:
+                                                            const Duration(
+                                                          seconds: 2,
+                                                        ),
+                                                      ),
+                                                    );
+                                                  }
+                                                }
+                                              }
+                                            },
+                                          ),
+                                        if (downloadUrl != null &&
+                                            downloadUrl.isNotEmpty)
+                                          OutlinedButton.icon(
+                                            icon: const Icon(
+                                              Icons.copy,
+                                              size: 14,
+                                            ),
+                                            label: const Text(
+                                              'Copy Download URL',
+                                            ),
+                                            style: OutlinedButton.styleFrom(
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                            ),
+                                            onPressed: () {
+                                              Clipboard.setData(
+                                                ClipboardData(
+                                                  text: downloadUrl,
+                                                ),
+                                              );
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                const SnackBar(
+                                                  content: Text(
+                                                    'Download URL copied to clipboard',
+                                                  ),
+                                                  duration:
+                                                      Duration(seconds: 2),
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                        if (magnetUrl != null &&
+                                            magnetUrl.isNotEmpty)
+                                          OutlinedButton.icon(
+                                            icon: const Icon(
+                                              Icons.link,
+                                              size: 14,
+                                            ),
+                                            label: const Text(
+                                              'Copy Magnet Link',
+                                            ),
+                                            style: OutlinedButton.styleFrom(
+                                              visualDensity:
+                                                  VisualDensity.compact,
+                                            ),
+                                            onPressed: () {
+                                              Clipboard.setData(
+                                                ClipboardData(text: magnetUrl),
+                                              );
+                                              ScaffoldMessenger.of(context)
+                                                  .showSnackBar(
+                                                const SnackBar(
+                                                  content: Text(
+                                                    'Magnet link copied to clipboard',
+                                                  ),
+                                                  duration:
+                                                      Duration(seconds: 2),
+                                                ),
+                                              );
+                                            },
+                                          ),
+                                      ],
+                                    ),
+                                    const SizedBox(height: 4),
+                                  ],
                                 ],
                               ),
                             ),

--- a/services/service_sonarr/test/sonarr_release_search_test.dart
+++ b/services/service_sonarr/test/sonarr_release_search_test.dart
@@ -100,8 +100,7 @@ void main() {
 
       final highScorePos =
           tester.getTopLeft(find.textContaining('1080p.Remux'));
-      final lowScorePos =
-          tester.getTopLeft(find.textContaining('720p.HDTV'));
+      final lowScorePos = tester.getTopLeft(find.textContaining('720p.HDTV'));
       expect(highScorePos.dy, lessThan(lowScorePos.dy));
 
       // Verify Score badges and Custom Format pills are rendered
@@ -186,6 +185,105 @@ void main() {
       // payloads were absorbed rather than thrown on.
       expect(find.text('Score: 0'), findsNothing);
       expect(find.text('ValidFormat'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'SonarrReleaseSearchScreen renders Open Torrent Page / Open Indexer Page and copy buttons when expanded',
+    (tester) async {
+      tester.view.physicalSize = const Size(800, 1400);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      final releasesWithLinks = [
+        <String, dynamic>{
+          'guid': 'https://tracker.example.com/guid/201',
+          'title': 'Show.S01E01.Torrent.Release',
+          'indexer': 'Torrent Tracker',
+          'size': 2000000000,
+          'seeders': 25,
+          'leechers': 2,
+          'protocol': 'torrent',
+          'rejections': <String>[],
+          'infoUrl': 'https://tracker.example.com/details/201',
+          'downloadUrl': 'https://tracker.example.com/download/201.torrent',
+          'magnetUrl': 'magnet:?xt=urn:btih:abc123def456',
+        },
+        <String, dynamic>{
+          'guid': 'release-usenet-guid',
+          'title': 'Show.S01E01.Usenet.Release',
+          'indexer': 'NZB Indexer',
+          'size': 3000000000,
+          'protocol': 'usenet',
+          'rejections': <String>['Quality not wanted in profile'],
+          'commentUrl': 'https://nzb.example.com/comments/302',
+          'downloadUrl': 'https://nzb.example.com/get/302.nzb',
+        },
+        <String, dynamic>{
+          'guid': 'plain-non-url-guid',
+          'title': 'Show.S01E01.NoLinks.Release',
+          'indexer': 'Private Tracker',
+          'size': 1000000000,
+          'protocol': 'torrent',
+          'rejections': <String>[],
+        },
+      ];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            sonarrReleasesProvider((instance, episode.id)).overrideWith(
+              (ref) async => releasesWithLinks,
+            ),
+          ],
+          child: const MaterialApp(
+            home: SonarrReleaseSearchScreen(
+              instance: instance,
+              episode: episode,
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      await tester.pumpAndSettle();
+
+      expect(find.byType(ExpansionTile), findsNWidgets(3));
+
+      // Expand the first release (Torrent with infoUrl, downloadUrl, magnetUrl)
+      await tester.tap(find.text('Show.S01E01.Torrent.Release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Torrent Page'), findsOneWidget);
+      expect(find.text('Copy Download URL'), findsOneWidget);
+      expect(find.text('Copy Magnet Link'), findsOneWidget);
+
+      // Collapse first release
+      await tester.tap(find.text('Show.S01E01.Torrent.Release'));
+      await tester.pumpAndSettle();
+
+      // Expand the second release (Usenet with commentUrl, downloadUrl, and rejections)
+      await tester.tap(find.text('Show.S01E01.Usenet.Release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Open Indexer Page'), findsOneWidget);
+      expect(find.text('Rejection Reasons:'), findsOneWidget);
+      expect(find.text('• Quality not wanted in profile'), findsOneWidget);
+
+      // Collapse second release
+      await tester.tap(find.text('Show.S01E01.Usenet.Release'));
+      await tester.pumpAndSettle();
+
+      // Expand the third release (No web URL, no download/magnet URL)
+      await tester.tap(find.text('Show.S01E01.NoLinks.Release'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Approved for download.'), findsOneWidget);
+      expect(find.text('Open Torrent Page'), findsNothing);
+      expect(find.text('Open Indexer Page'), findsNothing);
     },
   );
 }


### PR DESCRIPTION
Resolves #145

### Changes
- Adds an "Open Torrent Page" (or "Open Indexer Page" for Usenet) button in expanded release cards in Radarr and Sonarr release search.
- Adds "Copy Download URL" and "Copy Magnet Link" action buttons with clipboard integration.
- Extracts the release web URL by evaluating `infoUrl`, `commentUrl`, and HTTP/HTTPS `guid`.
- Adds widget tests covering button rendering, protocol labeling, and missing URL handling in both `service_radarr` and `service_sonarr`.

### Verification
- `flutter test` passes in `services/service_radarr` and `services/service_sonarr`.
- `dart analyze` reports 0 issues across both services.
