### PR TITLE
Release 1.6.1

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-	github: retransmit
+github: [retransmit]

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+	github: retransmit

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: Atrium version
       description: Settings, then About.
-      placeholder: "1.6.0"
+      placeholder: "1.6.1"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ whether you're on the home Wi-Fi or out in the world.
 
 **[Website][site]** - screenshots and a tour, no install needed.
 
-> **Status:** v1.6.0. Install from [F-Droid][fdroid], or grab a signed APK
+> **Status:** v1.6.1. Install from [F-Droid][fdroid], or grab a signed APK
 > from the [releases page][releases].
 
 ## Why

--- a/app/lib/app.dart
+++ b/app/lib/app.dart
@@ -36,6 +36,14 @@ class AtriumApp extends ConsumerWidget {
       if (!mapEquals(ref.read(globalHeadersProvider), next)) {
         ref.read(globalHeadersProvider.notifier).state = next;
       }
+      // Artwork does not go through Dio, so it needs the same headers by a
+      // second route. Rebuilt unconditionally rather than under the compare
+      // above: an instance's own headers or its URL can change while the
+      // profile-wide map stays identical.
+      ArtworkHeaders.update(
+        instances: profile?.instances ?? const <Instance>[],
+        global: next,
+      );
     }
 
     ref.listen<Profile?>(

--- a/app/lib/src/activity/activity_cards.dart
+++ b/app/lib/src/activity/activity_cards.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -48,7 +47,7 @@ class ActivityStreamCard extends StatelessWidget {
             fit: StackFit.expand,
             children: <Widget>[
               if (imageUrl != null && imageUrl.isNotEmpty)
-                CachedNetworkImage(
+                AtriumNetworkImage(
                   imageUrl: imageUrl,
                   fit: BoxFit.cover,
                   placeholder: (BuildContext context, String _) => ColoredBox(
@@ -190,7 +189,7 @@ class _UserPill extends StatelessWidget {
             backgroundColor: Colors.black.withValues(alpha: 0.4),
             foregroundImage: (avatarUrl == null || avatarUrl!.isEmpty)
                 ? null
-                : CachedNetworkImageProvider(avatarUrl!),
+                : atriumImageProvider(avatarUrl!),
             onForegroundImageError:
                 (avatarUrl == null || avatarUrl!.isEmpty) ? null : (_, __) {},
             child: Text(

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -177,6 +177,7 @@ class DashboardBoard extends ConsumerWidget {
   }
 
   void _refreshAll(WidgetRef ref, List<Instance> instances) {
+    ref.read(lastHealthRefreshProvider.notifier).markRefreshed();
     for (final Instance i in instances) {
       ref.invalidate(instanceHealthProvider(i.id));
       switch (i.kind) {

--- a/app/lib/src/dashboard/dashboard_board.dart
+++ b/app/lib/src/dashboard/dashboard_board.dart
@@ -30,6 +30,7 @@ import 'widgets/recently_downloaded_widget.dart';
 import 'widgets/requests_widget.dart';
 import 'widgets/server_info_widget.dart';
 import 'widgets/speedtest_results_widget.dart';
+import 'widgets/wake_on_lan_widget.dart';
 import 'widgets/streams_widget.dart';
 import 'widgets/upcoming_widget.dart';
 
@@ -49,6 +50,8 @@ class DashboardBoard extends ConsumerWidget {
     final List<DashboardWidgetConfig> layout =
         ref.watch(dashboardLayoutProvider);
     final bool editing = ref.watch(dashboardEditModeProvider);
+    final int wolCount =
+        ref.watch(activeProfileProvider)?.wolDevices.length ?? 0;
 
     if (editing) {
       return _EditBoard(layout: layout, instances: instances);
@@ -57,7 +60,7 @@ class DashboardBoard extends ConsumerWidget {
     final List<DashboardWidgetConfig> visible = <DashboardWidgetConfig>[
       for (final DashboardWidgetConfig c in layout)
         if (c.enabled &&
-            _configured(c.kind, instances) &&
+            _configured(c.kind, instances, wolDeviceCount: wolCount) &&
             _hasLiveContent(ref, c.kind))
           c,
     ];
@@ -91,7 +94,20 @@ class DashboardBoard extends ConsumerWidget {
     );
   }
 
-  static bool _configured(DashboardWidgetKind kind, List<Instance> instances) {
+  /// Whether a widget has anything behind it to show.
+  ///
+  /// Almost every widget is answered by a service, so having one configured is
+  /// the test. Wake-on-LAN is not: it points at machines rather than servers,
+  /// so it is set up once a device exists on the profile, and the usual test
+  /// would call it unconfigured forever.
+  static bool _configured(
+    DashboardWidgetKind kind,
+    List<Instance> instances, {
+    int wolDeviceCount = 0,
+  }) {
+    if (kind.isDeviceBacked) {
+      return wolDeviceCount > 0;
+    }
     return instances.any((Instance i) => kind.serviceKinds.contains(i.kind));
   }
 
@@ -155,6 +171,8 @@ class DashboardBoard extends ConsumerWidget {
         return DashboardSpeedtestResultsWidget(
           instances: _byKind(instances, ServiceKind.speedtestTracker),
         );
+      case DashboardWidgetKind.wakeOnLan:
+        return const DashboardWakeOnLanWidget();
     }
   }
 
@@ -220,6 +238,8 @@ class _EditBoard extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final int wolCount =
+        ref.watch(activeProfileProvider)?.wolDevices.length ?? 0;
     final List<DashboardWidgetConfig> enabled = <DashboardWidgetConfig>[
       for (final DashboardWidgetConfig c in layout)
         if (c.enabled) c,
@@ -258,17 +278,26 @@ class _EditBoard extends ConsumerWidget {
                       child: _EditTile(
                         config: c,
                         instances: instances,
+                        wolDeviceCount: wolCount,
                         // Showing a widget nothing feeds puts it back on a
                         // board that filters it straight out again, which
                         // reads as the button having failed. The tile says
                         // which service it wants instead.
                         trailing: IconButton(
-                          tooltip: DashboardBoard._configured(c.kind, instances)
+                          tooltip: DashboardBoard._configured(
+                            c.kind,
+                            instances,
+                            wolDeviceCount: wolCount,
+                          )
                               ? 'Show widget'
-                              : 'Needs a service that can fill it',
+                              : 'Needs something that can fill it',
                           icon: const Icon(Icons.add_circle_outline),
                           onPressed:
-                              DashboardBoard._configured(c.kind, instances)
+                              DashboardBoard._configured(
+                            c.kind,
+                            instances,
+                            wolDeviceCount: wolCount,
+                          )
                                   ? () => ref
                                       .read(dashboardLayoutProvider.notifier)
                                       .setEnabled(c.kind, true)
@@ -319,6 +348,9 @@ class _EditBoard extends ConsumerWidget {
 /// the whole reason a widget that can never fill looked broken rather than
 /// unavailable.
 String _needsLabel(DashboardWidgetKind kind) {
+  if (kind.isDeviceBacked) {
+    return 'Needs a device';
+  }
   final List<String> names = <String>[
     for (final ServiceKind k in kind.serviceKinds) k.displayName,
   ];
@@ -333,17 +365,26 @@ class _EditTile extends StatelessWidget {
     required this.config,
     required this.instances,
     required this.trailing,
+    this.wolDeviceCount = 0,
   });
 
   final DashboardWidgetConfig config;
   final List<Instance> instances;
   final Widget trailing;
 
+  /// Wake-on-LAN is set up by adding devices, not a service, so its tile needs
+  /// the device count to know whether it is configured.
+  final int wolDeviceCount;
+
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
-    final bool configured = DashboardBoard._configured(config.kind, instances);
+    final bool configured = DashboardBoard._configured(
+      config.kind,
+      instances,
+      wolDeviceCount: wolDeviceCount,
+    );
     return Container(
       padding: const EdgeInsets.symmetric(
         horizontal: Insets.md,

--- a/app/lib/src/dashboard/dashboard_widget_kind.dart
+++ b/app/lib/src/dashboard/dashboard_widget_kind.dart
@@ -11,6 +11,7 @@ enum DashboardWidgetKind {
   requests,
   serverInfo,
   speedtestResults,
+  wakeOnLan,
 }
 
 extension DashboardWidgetKindX on DashboardWidgetKind {
@@ -23,6 +24,7 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.requests => 'Requests',
         DashboardWidgetKind.serverInfo => 'Server info',
         DashboardWidgetKind.speedtestResults => 'Speedtest results',
+        DashboardWidgetKind.wakeOnLan => 'Wake on LAN',
       };
 
   IconData get icon => switch (this) {
@@ -34,6 +36,7 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.requests => Icons.bookmark_added_outlined,
         DashboardWidgetKind.serverInfo => Icons.memory,
         DashboardWidgetKind.speedtestResults => Icons.speed_outlined,
+        DashboardWidgetKind.wakeOnLan => Icons.power_settings_new_rounded,
       };
 
   /// Service kinds whose presence makes this widget "configured".
@@ -70,5 +73,16 @@ extension DashboardWidgetKindX on DashboardWidgetKind {
         DashboardWidgetKind.speedtestResults => const <ServiceKind>[
             ServiceKind.speedtestTracker
           ],
+        // Wake-on-LAN answers to no service. Its targets are machines on the
+        // network, kept on the profile beside the instances, so there is no
+        // service whose presence could stand in for being set up.
+        DashboardWidgetKind.wakeOnLan => const <ServiceKind>[],
       };
+
+  /// Whether this widget is set up by adding devices rather than a service.
+  ///
+  /// [serviceKinds] is empty for these, so the usual "is one of these services
+  /// configured" test would call them permanently unconfigured and never show
+  /// them.
+  bool get isDeviceBacked => this == DashboardWidgetKind.wakeOnLan;
 }

--- a/app/lib/src/dashboard/widgets/downloads_widget.dart
+++ b/app/lib/src/dashboard/widgets/downloads_widget.dart
@@ -16,15 +16,30 @@ import '../dashboard_widget_card.dart';
 import '../dashboard_widget_kind.dart';
 import 'package:progress_indicator_m3e/progress_indicator_m3e.dart';
 
-/// qBittorrent states that count as actively downloading.
-const Set<String> _activeDlStates = <String>{
+/// qBittorrent states where data is actually moving, or about to.
+const Set<String> _movingDlStates = <String>{
   'downloading',
   'forcedDL',
   'metaDL',
-  'stalledDL',
-  'queuedDL',
   'checkingDL',
   'allocating',
+};
+
+/// States that belong on the card but are not going anywhere yet: queued is
+/// waiting its turn, stalled is connected to nobody.
+const Set<String> _waitingDlStates = <String>{
+  'stalledDL',
+  'queuedDL',
+};
+
+/// qBittorrent states that count as a download in progress.
+///
+/// Queued and stalled are included on purpose: they are downloads someone is
+/// waiting on, and dropping them would understate the count. They are ranked
+/// below moving ones for display, which is a separate matter to being counted.
+const Set<String> _activeDlStates = <String>{
+  ..._movingDlStates,
+  ..._waitingDlStates,
 };
 
 /// Live count of active downloads across every qBittorrent + SABnzbd + NZBGet
@@ -98,11 +113,21 @@ class _DownloadRow {
     required this.name,
     required this.progress,
     required this.instance,
+    this.moving = true,
   });
 
   final String name;
   final double progress;
   final Instance instance;
+
+  /// Whether data is actually moving for this one.
+  ///
+  /// The card only has room for a few rows, and sorting purely on progress put
+  /// a torrent queued at 90% above one downloading at 10%, so a busy queue
+  /// hid the very thing the card exists to show. Only qBittorrent reports a
+  /// state fine-grained enough to tell; every other client is already filtered
+  /// to what is downloading, so they default to moving.
+  final bool moving;
 }
 
 /// Combined qBittorrent + SABnzbd + NZBGet + Deluge activity: total speed,
@@ -146,6 +171,7 @@ class DashboardDownloadsWidget extends ConsumerWidget {
             name: t.name,
             progress: t.progress.clamp(0, 1).toDouble(),
             instance: i,
+            moving: _movingDlStates.contains(t.state),
           ));
         }
       }
@@ -242,8 +268,15 @@ class DashboardDownloadsWidget extends ConsumerWidget {
       totalSpeed += ref.watch(rtorrentGlobalProvider(i)).value?.downRate ?? 0;
     }
 
-    rows.sort(
-        (_DownloadRow a, _DownloadRow b) => b.progress.compareTo(a.progress));
+    // What is moving comes first, then furthest along. Progress alone let a
+    // queue full of nearly-complete torrents push the live download off a card
+    // that only shows three.
+    rows.sort((_DownloadRow a, _DownloadRow b) {
+      if (a.moving != b.moving) {
+        return a.moving ? -1 : 1;
+      }
+      return b.progress.compareTo(a.progress);
+    });
     final List<_DownloadRow> top = rows.take(3).toList();
 
     Widget body;

--- a/app/lib/src/dashboard/widgets/recently_added_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_added_widget.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
@@ -240,7 +239,7 @@ class _PosterTile extends StatelessWidget {
                 height: 140,
                 child: (poster == null || poster.isEmpty)
                     ? _posterFallback(cs)
-                    : CachedNetworkImage(
+                    : AtriumNetworkImage(
                         imageUrl: poster,
                         fit: BoxFit.cover,
                         memCacheWidth: 220,

--- a/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
+++ b/app/lib/src/dashboard/widgets/recently_downloaded_widget.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
@@ -309,7 +308,7 @@ class _DashboardRecentlyDownloadedWidgetState
                         child: InkWell(
                           onTap: () => _openDetail(context, item),
                           child: item.posterUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   imageUrl: item.posterUrl!,
                                   fit: BoxFit.cover,
                                   errorWidget: (_, __, ___) => Icon(

--- a/app/lib/src/dashboard/widgets/requests_widget.dart
+++ b/app/lib/src/dashboard/widgets/requests_widget.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
@@ -173,7 +172,7 @@ class _RequestRow extends ConsumerWidget {
               height: 56,
               child: posterUrl == null
                   ? _posterFallback(cs, r.type)
-                  : CachedNetworkImage(
+                  : AtriumNetworkImage(
                       imageUrl: posterUrl,
                       fit: BoxFit.cover,
                       memCacheWidth: 120,

--- a/app/lib/src/dashboard/widgets/streams_widget.dart
+++ b/app/lib/src/dashboard/widgets/streams_widget.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_profile/core_profile.dart';
 import 'package:core_router/core_router.dart';
@@ -287,7 +286,7 @@ class _StreamBannerState extends State<_StreamBanner> {
     _lastPosterUrl = posterUrl;
 
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
     ).then((PaletteGenerator palette) {
       if (mounted) {
@@ -341,7 +340,7 @@ class _StreamBannerState extends State<_StreamBanner> {
             fit: StackFit.expand,
             children: <Widget>[
               if (hasArt)
-                CachedNetworkImage(
+                AtriumNetworkImage(
                   imageUrl: backdrop,
                   fit: BoxFit.cover,
                   alignment: Alignment.center,
@@ -349,7 +348,7 @@ class _StreamBannerState extends State<_StreamBanner> {
                   errorWidget: (_, __, ___) => (backdrop != poster &&
                           poster != null &&
                           poster.trim().isNotEmpty)
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: poster,
                           fit: BoxFit.cover,
                           alignment: Alignment.center,
@@ -399,7 +398,7 @@ class _StreamBannerState extends State<_StreamBanner> {
                                 height: 66,
                                 child: (poster == null || poster.isEmpty)
                                     ? _posterFallback(cs)
-                                    : CachedNetworkImage(
+                                    : AtriumNetworkImage(
                                         imageUrl: poster,
                                         fit: BoxFit.cover,
                                         memCacheWidth: 132,

--- a/app/lib/src/dashboard/widgets/upcoming_widget.dart
+++ b/app/lib/src/dashboard/widgets/upcoming_widget.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -198,7 +197,7 @@ class _ReleaseBanner extends StatelessWidget {
           fit: StackFit.expand,
           children: <Widget>[
             if (hasArt)
-              CachedNetworkImage(
+              AtriumNetworkImage(
                 imageUrl: backdrop,
                 fit: BoxFit.cover,
                 memCacheWidth: 600,
@@ -231,7 +230,7 @@ class _ReleaseBanner extends StatelessWidget {
                       height: 66,
                       child: poster == null
                           ? _posterFallback(cs)
-                          : CachedNetworkImage(
+                          : AtriumNetworkImage(
                               imageUrl: poster,
                               fit: BoxFit.cover,
                               memCacheWidth: 132,

--- a/app/lib/src/dashboard/widgets/wake_on_lan_widget.dart
+++ b/app/lib/src/dashboard/widgets/wake_on_lan_widget.dart
@@ -1,0 +1,155 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../screens/wake_on_lan_screen.dart';
+import '../dashboard_widget_card.dart';
+import '../dashboard_widget_kind.dart';
+
+/// Wakes the machines on the active profile without a detour into settings.
+///
+/// Issue #151: waking something was buried behind the settings screen, which
+/// is a long way to go for a button you press when a server is asleep. The
+/// devices themselves still live on the profile and are managed there; this is
+/// only a shortcut to firing at them.
+class DashboardWakeOnLanWidget extends ConsumerStatefulWidget {
+  const DashboardWakeOnLanWidget({super.key});
+
+  @override
+  ConsumerState<DashboardWakeOnLanWidget> createState() =>
+      _DashboardWakeOnLanWidgetState();
+}
+
+class _DashboardWakeOnLanWidgetState
+    extends ConsumerState<DashboardWakeOnLanWidget> {
+  /// The device a packet is in flight for, so only that row shows a spinner.
+  String? _sendingId;
+
+  Future<void> _wake(WolDevice device) async {
+    final ScaffoldMessengerState messenger = ScaffoldMessenger.of(context);
+    setState(() => _sendingId = device.id);
+    try {
+      await sendWol(
+        mac: device.mac,
+        broadcastAddress: device.broadcastAddress,
+        port: device.port,
+      );
+      if (!mounted) return;
+      // A magic packet is fire and forget: nothing answers it, and the machine
+      // takes a while to come up. Saying "sent" is the honest claim; saying
+      // "woken" would be a promise this cannot keep.
+      messenger.showSnackBar(
+        SnackBar(content: Text('Magic packet sent to ${device.name}')),
+      );
+    } on Object {
+      if (!mounted) return;
+      messenger.showSnackBar(
+        SnackBar(content: Text('Could not reach the network for '
+            '${device.name}')),
+      );
+    } finally {
+      if (mounted) setState(() => _sendingId = null);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+    final List<WolDevice> devices =
+        ref.watch(activeProfileProvider)?.wolDevices ?? const <WolDevice>[];
+
+    return DashboardWidgetCard(
+      kind: DashboardWidgetKind.wakeOnLan,
+      accent: cs.primary,
+      // Managing devices stays where it was; this only shortcuts to it.
+      onTap: () => pushScreen<void>(context, const WakeOnLanScreen()),
+      child: devices.isEmpty
+          ? const DashboardIdleRow(text: 'No devices yet')
+          : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                for (final WolDevice d in devices.take(4))
+                  _WakeRow(
+                    device: d,
+                    sending: _sendingId == d.id,
+                    // One packet at a time keeps the spinner honest about
+                    // which row it belongs to.
+                    onWake: _sendingId == null ? () => _wake(d) : null,
+                  ),
+                if (devices.length > 4)
+                  DashboardIdleRow(text: '+${devices.length - 4} more'),
+              ],
+            ),
+    );
+  }
+}
+
+class _WakeRow extends StatelessWidget {
+  const _WakeRow({
+    required this.device,
+    required this.sending,
+    required this.onWake,
+  });
+
+  final WolDevice device;
+  final bool sending;
+  final VoidCallback? onWake;
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+    final ColorScheme cs = theme.colorScheme;
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: Insets.xxs),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(
+                  device.name,
+                  style: theme.textTheme.bodyMedium
+                      ?.copyWith(fontWeight: FontWeight.w600),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                Text(
+                  device.mac,
+                  style: theme.textTheme.bodySmall
+                      ?.copyWith(color: cs.onSurfaceVariant),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: Insets.sm),
+          if (sending)
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: Insets.sm),
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          else
+            FilledButton.tonalIcon(
+              onPressed: onWake,
+              icon: const Icon(Icons.power_settings_new_rounded, size: 18),
+              label: const Text('Wake'),
+              style: FilledButton.styleFrom(
+                visualDensity: VisualDensity.compact,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/app/lib/src/health_providers.dart
+++ b/app/lib/src/health_providers.dart
@@ -20,3 +20,19 @@ final instanceHealthProvider =
   if (instance == null) return Health.unknown;
   return ref.watch(healthProbeProvider).check(instance);
 });
+
+/// Tracks when service health probes were last refreshed across the app.
+class LastHealthRefreshNotifier extends Notifier<DateTime?> {
+  @override
+  DateTime? build() => null;
+
+  void markRefreshed() {
+    state = DateTime.now();
+  }
+}
+
+final NotifierProvider<LastHealthRefreshNotifier, DateTime?>
+    lastHealthRefreshProvider =
+    NotifierProvider<LastHealthRefreshNotifier, DateTime?>(
+  LastHealthRefreshNotifier.new,
+);

--- a/app/lib/src/screens/calendar_screen.dart
+++ b/app/lib/src/screens/calendar_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_router/core_router.dart';
@@ -1358,7 +1357,7 @@ class _Poster extends StatelessWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 100,

--- a/app/lib/src/screens/changelog/release_notes.dart
+++ b/app/lib/src/screens/changelog/release_notes.dart
@@ -27,6 +27,26 @@ class ReleaseNote {
 /// Newest first. Update alongside appVersion and the pubspec at each release.
 const List<ReleaseNote> releaseNotes = <ReleaseNote>[
   ReleaseNote(
+    version: '1.6.1',
+    date: '2026-09-11',
+    groups: <ChangeGroup>[
+      ChangeGroup(ChangeCategory.added, <String>[
+        'A Wake-on-LAN widget for the dashboard. The machines you have set up can be woken with one tap from the board, without going into settings to find them. It tells you the magic packet was sent rather than that the machine woke, since nothing answers one and a machine takes a while to come up.',
+        'Adding a torrent in qBittorrent fills in the save path from the server, using its default location or the path the chosen category defines, so it no longer has to be typed out for every torrent.',
+        'The sidebar can be pulled down to refresh the health of every service. It also checks again when you open it if the last check is more than a minute old, and keeps them current every 30 seconds while it stays open.',
+      ]),
+      ChangeGroup(ChangeCategory.improved, <String>[
+        'Custom headers warn you when a header will not survive the trip. Several services use Authorization for their own sign-in and overwrite yours, and qBittorrent refuses one it did not issue, so the warning names the affected services and suggests Proxy-Authorization, which works wherever your proxy accepts it.',
+        'The health check no longer mistakes the login page of a reverse proxy for a working server. It used to follow the redirect to a sign-in page, get a normal answer back, and report the service as online. It now recognises a login page and shows a warning instead.',
+      ]),
+      ChangeGroup(ChangeCategory.fixed, <String>[
+        'Posters and backdrops load behind a reverse proxy. Artwork never carried your custom headers, so behind Authelia, Cloudflare Access or similar every image was refused and came up blank while the rest of the app worked.',
+        'Headers set for the whole profile now reach every request. Test connection, the health dot on each service, and the Beszel, dashdot and Glances clients all dropped them, which is why Test connection could fail while the app itself worked fine.',
+        'The Active downloads widget shows what is actually downloading. It sorted purely by progress, so a queue of nearly finished torrents could push the one live download off the card.',
+      ]),
+    ],
+  ),
+  ReleaseNote(
     version: '1.6.0',
     date: '2026-08-30',
     groups: <ChangeGroup>[

--- a/app/lib/src/screens/custom_headers_screen.dart
+++ b/app/lib/src/screens/custom_headers_screen.dart
@@ -1,4 +1,5 @@
 import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
 import 'package:core_profile/core_profile.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -94,7 +95,11 @@ class _CustomHeadersScreenState extends ConsumerState<CustomHeadersScreen> {
     final MapEntry<String, String>? result =
         await showDialog<MapEntry<String, String>>(
       context: context,
-      builder: (BuildContext context) => _HeaderDialog(initial: original),
+      builder: (BuildContext context) => _HeaderDialog(
+        initial: original,
+        appliesTo: ref.read(activeProfileProvider)?.instances ??
+            const <Instance>[],
+      ),
     );
     if (result == null || !mounted) {
       return;
@@ -199,10 +204,15 @@ class _InstanceHeadersScreenState
   Future<void> _editHeader({
     MapEntry<String, String>? original,
   }) async {
+    final Instance? target = ref.read(instanceByIdProvider(widget.instanceId));
     final MapEntry<String, String>? result =
         await showDialog<MapEntry<String, String>>(
       context: context,
-      builder: (BuildContext context) => _HeaderDialog(initial: original),
+      builder: (BuildContext context) => _HeaderDialog(
+        initial: original,
+        appliesTo:
+            target == null ? const <Instance>[] : <Instance>[target],
+      ),
     );
     if (result == null || !mounted) {
       return;
@@ -460,9 +470,14 @@ class _InstanceRow extends StatelessWidget {
 
 /// Add / edit form for one header. Pops with a `MapEntry(name, value)`.
 class _HeaderDialog extends StatefulWidget {
-  const _HeaderDialog({this.initial});
+  const _HeaderDialog({this.initial, this.appliesTo = const <Instance>[]});
 
   final MapEntry<String, String>? initial;
+
+  /// The instances this header will be sent to: every one in the profile for
+  /// a global header, or the single one for a per-instance header. Used only
+  /// to warn about names that will not survive the trip.
+  final List<Instance> appliesTo;
 
   @override
   State<_HeaderDialog> createState() => _HeaderDialogState();
@@ -471,6 +486,10 @@ class _HeaderDialog extends StatefulWidget {
 class _HeaderDialogState extends State<_HeaderDialog> {
   /// RFC 7230 token characters - the set allowed in an HTTP header name.
   static final RegExp _tokenPattern = RegExp(r'^[!#$%&*+.^_|~0-9A-Za-z-]+$');
+
+  /// Why the name being typed will not do what the user expects, if so.
+  String? get _conflict =>
+      headerConflictWarning(_name.text, widget.appliesTo);
 
   final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
   late final TextEditingController _name =
@@ -507,10 +526,14 @@ class _HeaderDialogState extends State<_HeaderDialog> {
               controller: _name,
               autofocus: widget.initial == null,
               textInputAction: TextInputAction.next,
+              // Proxy-Authorization rather than X-Api-Key: this screen exists
+              // for reverse-proxy auth, and it is the one name no service in
+              // the stack overwrites or refuses.
               decoration: const InputDecoration(
                 labelText: 'Header name',
-                hintText: 'X-Api-Key',
+                hintText: proxyAuthHeaderName,
               ),
+              onChanged: (String _) => setState(() {}),
               validator: (String? v) {
                 final String name = (v ?? '').trim();
                 if (name.isEmpty) {
@@ -522,6 +545,28 @@ class _HeaderDialogState extends State<_HeaderDialog> {
                 return null;
               },
             ),
+            if (_conflict != null) ...<Widget>[
+              const SizedBox(height: Insets.sm),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: <Widget>[
+                  Icon(
+                    Icons.warning_amber_rounded,
+                    size: 18,
+                    color: Theme.of(context).colorScheme.error,
+                  ),
+                  const SizedBox(width: Insets.xs),
+                  Expanded(
+                    child: Text(
+                      _conflict!,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            color: Theme.of(context).colorScheme.error,
+                          ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
             const SizedBox(height: Insets.md),
             TextFormField(
               controller: _value,

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -1,9 +1,12 @@
+import 'dart:async';
+
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_profile/core_profile.dart';
 import 'package:core_router/core_router.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
@@ -72,7 +75,7 @@ class DashboardScreen extends ConsumerWidget {
 /// The sidebar: configured services grouped by role (each with a live health
 /// dot), with settings, add-service and the active-profile pill along the
 /// bottom.
-class ServicesDrawer extends ConsumerWidget {
+class ServicesDrawer extends ConsumerStatefulWidget {
   const ServicesDrawer({
     required this.instances,
     required this.profile,
@@ -83,7 +86,77 @@ class ServicesDrawer extends ConsumerWidget {
   final Profile? profile;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  ConsumerState<ServicesDrawer> createState() => _ServicesDrawerState();
+}
+
+class _ServicesDrawerState extends ConsumerState<ServicesDrawer> {
+  Timer? _pollingTimer;
+  Future<void>? _activeRefreshFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _checkHealthFreshness();
+      _startPolling();
+    });
+  }
+
+  @override
+  void dispose() {
+    _pollingTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startPolling() {
+    _pollingTimer?.cancel();
+    _pollingTimer = Timer.periodic(const Duration(seconds: 30), (_) {
+      if (!mounted) return;
+      final AppLifecycleState? state =
+          SchedulerBinding.instance.lifecycleState;
+      if (state == null || state == AppLifecycleState.resumed) {
+        _refreshHealth();
+      }
+    });
+  }
+
+  void _checkHealthFreshness() {
+    final DateTime? lastCheck = ref.read(lastHealthRefreshProvider);
+    if (lastCheck == null ||
+        DateTime.now().difference(lastCheck) > const Duration(seconds: 60)) {
+      _refreshHealth();
+    }
+  }
+
+  Future<void> _refreshHealth() {
+    if (_activeRefreshFuture != null) {
+      return _activeRefreshFuture!;
+    }
+    if (widget.instances.isEmpty || !mounted) {
+      return Future<void>.value();
+    }
+    final AppLifecycleState? state =
+        SchedulerBinding.instance.lifecycleState;
+    if (state != null && state != AppLifecycleState.resumed) {
+      return Future<void>.value();
+    }
+
+    ref.read(lastHealthRefreshProvider.notifier).markRefreshed();
+    final Future<void> future = Future.wait(
+      widget.instances.map(
+        (Instance i) => ref.refresh(instanceHealthProvider(i.id).future),
+      ),
+    ).then((_) {}).catchError((_) {}).whenComplete(() {
+      _activeRefreshFuture = null;
+    });
+
+    _activeRefreshFuture = future;
+    return future;
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
     final ColorScheme cs = theme.colorScheme;
     final List<Profile> profiles =
@@ -135,7 +208,7 @@ class ServicesDrawer extends ConsumerWidget {
             ),
             const Divider(height: 1),
             Expanded(
-              child: instances.isEmpty
+              child: widget.instances.isEmpty
                   ? Center(
                       child: Padding(
                         padding: const EdgeInsets.all(Insets.lg),
@@ -148,7 +221,10 @@ class ServicesDrawer extends ConsumerWidget {
                         ),
                       ),
                     )
-                  : _ServicesList(instances: instances),
+                  : _ServicesList(
+                      instances: widget.instances,
+                      onRefresh: _refreshHealth,
+                    ),
             ),
             Padding(
               padding: const EdgeInsets.all(Insets.md),
@@ -165,7 +241,7 @@ class ServicesDrawer extends ConsumerWidget {
                     onPressed: () =>
                         _navTo(context, AtriumRoutes.addInstanceName),
                   ),
-                  if (instances.isNotEmpty)
+                  if (widget.instances.isNotEmpty)
                     IconButton(
                       tooltip: 'Reorder sidebar',
                       icon: Icon(Icons.reorder, color: cs.onSurfaceVariant),
@@ -185,7 +261,7 @@ class ServicesDrawer extends ConsumerWidget {
                     child: Builder(
                       builder: (BuildContext pillContext) {
                         return _ProfilePill(
-                          label: profile?.name ?? 'Default',
+                          label: widget.profile?.name ?? 'Default',
                           onTap: () async {
                             final RenderBox button =
                                 pillContext.findRenderObject()! as RenderBox;
@@ -218,7 +294,7 @@ class ServicesDrawer extends ConsumerWidget {
                                         Icon(
                                           Icons.smartphone,
                                           size: 16,
-                                          color: p.id == profile?.id
+                                          color: p.id == widget.profile?.id
                                               ? cs.primary
                                               : cs.outline,
                                         ),
@@ -227,13 +303,13 @@ class ServicesDrawer extends ConsumerWidget {
                                           child: Text(
                                             p.name,
                                             style: TextStyle(
-                                              fontWeight: p.id == profile?.id
+                                              fontWeight: p.id == widget.profile?.id
                                                   ? FontWeight.bold
                                                   : FontWeight.normal,
                                             ),
                                           ),
                                         ),
-                                        if (p.id == profile?.id)
+                                        if (p.id == widget.profile?.id)
                                           Icon(
                                             Icons.check,
                                             size: 16,
@@ -306,9 +382,13 @@ class ServicesDrawer extends ConsumerWidget {
 }
 
 class _ServicesList extends StatelessWidget {
-  const _ServicesList({required this.instances});
+  const _ServicesList({
+    required this.instances,
+    required this.onRefresh,
+  });
 
   final List<Instance> instances;
+  final RefreshCallback onRefresh;
 
   @override
   Widget build(BuildContext context) {
@@ -330,34 +410,37 @@ class _ServicesList extends StatelessWidget {
       }
     }
 
-    return ListView.builder(
-      physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.all(Insets.sm),
-      itemCount: items.length,
-      itemBuilder: (BuildContext context, int index) {
-        final _SidebarItem item = items[index];
-        if (item.header != null) {
+    return RefreshIndicator(
+      onRefresh: onRefresh,
+      child: ListView.builder(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(Insets.sm),
+        itemCount: items.length,
+        itemBuilder: (BuildContext context, int index) {
+          final _SidebarItem item = items[index];
+          if (item.header != null) {
+            return Padding(
+              padding: const EdgeInsets.only(
+                top: Insets.md,
+                bottom: Insets.xs,
+                left: Insets.sm,
+              ),
+              child: Text(
+                ServiceVisuals.roleLabel(item.header!),
+                style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
+              ),
+            );
+          }
           return Padding(
-            padding: const EdgeInsets.only(
-              top: Insets.md,
-              bottom: Insets.xs,
-              left: Insets.sm,
-            ),
-            child: Text(
-              ServiceVisuals.roleLabel(item.header!),
-              style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    color: Theme.of(context).colorScheme.primary,
-                  ),
+            padding: const EdgeInsets.only(bottom: Insets.xs),
+            child: RepaintBoundary(
+              child: _HealthAwareTile(instance: item.tile!),
             ),
           );
-        }
-        return Padding(
-          padding: const EdgeInsets.only(bottom: Insets.xs),
-          child: RepaintBoundary(
-            child: _HealthAwareTile(instance: item.tile!),
-          ),
-        );
-      },
+        },
+      ),
     );
   }
 }

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -410,7 +410,16 @@ class _ServicesList extends StatelessWidget {
       }
     }
 
-    return RefreshIndicator(
+    return EasyRefresh(
+      header: const ClassicHeader(
+        dragText: 'Pull to refresh',
+        armedText: 'Release ready',
+        readyText: 'Refreshing...',
+        processingText: 'Refreshing...',
+        processedText: 'Succeeded',
+        failedText: 'Failed',
+        messageText: 'Last updated at %T',
+      ),
       onRefresh: onRefresh,
       child: ListView.builder(
         physics: const AlwaysScrollableScrollPhysics(),

--- a/app/lib/src/screens/dashboard_screen.dart
+++ b/app/lib/src/screens/dashboard_screen.dart
@@ -89,13 +89,15 @@ class ServicesDrawer extends ConsumerStatefulWidget {
   ConsumerState<ServicesDrawer> createState() => _ServicesDrawerState();
 }
 
-class _ServicesDrawerState extends ConsumerState<ServicesDrawer> {
+class _ServicesDrawerState extends ConsumerState<ServicesDrawer>
+    with WidgetsBindingObserver {
   Timer? _pollingTimer;
   Future<void>? _activeRefreshFuture;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _checkHealthFreshness();
@@ -106,18 +108,30 @@ class _ServicesDrawerState extends ConsumerState<ServicesDrawer> {
   @override
   void dispose() {
     _pollingTimer?.cancel();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Stop the timer outright rather than letting it fire and return early.
+    // A drawer left open behind a locked screen otherwise wakes every 30
+    // seconds for the rest of the session to decide it has nothing to do.
+    if (state == AppLifecycleState.resumed) {
+      if (_pollingTimer == null) {
+        _startPolling();
+      }
+    } else {
+      _pollingTimer?.cancel();
+      _pollingTimer = null;
+    }
   }
 
   void _startPolling() {
     _pollingTimer?.cancel();
     _pollingTimer = Timer.periodic(const Duration(seconds: 30), (_) {
       if (!mounted) return;
-      final AppLifecycleState? state =
-          SchedulerBinding.instance.lifecycleState;
-      if (state == null || state == AppLifecycleState.resumed) {
-        _refreshHealth();
-      }
+      _refreshHealth();
     });
   }
 
@@ -142,12 +156,20 @@ class _ServicesDrawerState extends ConsumerState<ServicesDrawer> {
       return Future<void>.value();
     }
 
-    ref.read(lastHealthRefreshProvider.notifier).markRefreshed();
+    // Marked on completion, not on entry. A probe that has been fired but
+    // has not answered yet is not a fresh result, and stamping it up front
+    // meant a round that failed immediately still counted as fresh for the
+    // next sixty seconds. Overlapping rounds are held off by
+    // _activeRefreshFuture above instead.
     final Future<void> future = Future.wait(
       widget.instances.map(
         (Instance i) => ref.refresh(instanceHealthProvider(i.id).future),
       ),
-    ).then((_) {}).catchError((_) {}).whenComplete(() {
+    ).then((_) {
+      if (mounted) {
+        ref.read(lastHealthRefreshProvider.notifier).markRefreshed();
+      }
+    }).catchError((_) {}).whenComplete(() {
       _activeRefreshFuture = null;
     });
 
@@ -418,7 +440,11 @@ class _ServicesList extends StatelessWidget {
         processingText: 'Refreshing...',
         processedText: 'Succeeded',
         failedText: 'Failed',
-        messageText: 'Last updated at %T',
+        // No "last updated at" line. EasyRefresh renders %T as a raw
+        // DateTime.hour, so it reads 0:05 where the device clock says 12:05
+        // AM and 13:05 where it says 1:05 PM, and the package offers no hook
+        // to format it against the device's locale.
+        showMessage: false,
       ),
       onRefresh: onRefresh,
       child: ListView.builder(

--- a/app/lib/src/update_check/app_version.dart
+++ b/app/lib/src/update_check/app_version.dart
@@ -2,4 +2,4 @@
 ///
 /// Source of truth for the update check and the Settings version line. Bump
 /// this at release time together with pubspec.
-const String appVersion = '1.6.0';
+const String appVersion = '1.6.1';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -2,7 +2,7 @@ name: atrium
 description: Atrium - mobile controller for a self-hosted media stack.
 publish_to: none
 resolution: workspace
-version: 1.6.0+21
+version: 1.6.1+22
 
 environment:
   sdk: ^3.6.0

--- a/app/test/dashboard_downloads_order_test.dart
+++ b/app/test/dashboard_downloads_order_test.dart
@@ -1,0 +1,168 @@
+import 'package:atrium/src/dashboard/widgets/downloads_widget.dart';
+import 'package:core_models/core_models.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+
+import 'dashboard_widgets_test.dart' show makeInstance, pumpBody;
+
+/// What is moving has to outrank what is waiting.
+///
+/// Issue #144 follow-up: the card shows three rows and sorted purely on
+/// progress, so a queue full of nearly-complete torrents pushed the one
+/// actually downloading off the bottom. Someone with a busy queue saw a card
+/// called "Active downloads" that never showed the active download.
+void main() {
+  testWidgets('a live download outranks queued ones sitting at more progress',
+      (WidgetTester tester) async {
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+
+    await pumpBody(
+      tester,
+      <Override>[
+        qbitRawTorrentsProvider(qbit).overrideWith(
+          (Ref ref) async => const <QbitTorrent>[
+            // Three queued and nearly done. On progress alone these take every
+            // slot on the card.
+            QbitTorrent(
+              hash: 'q1',
+              name: 'Queued A',
+              state: 'queuedDL',
+              progress: 0.98,
+            ),
+            QbitTorrent(
+              hash: 'q2',
+              name: 'Queued B',
+              state: 'queuedDL',
+              progress: 0.97,
+            ),
+            QbitTorrent(
+              hash: 'q3',
+              name: 'Queued C',
+              state: 'queuedDL',
+              progress: 0.96,
+            ),
+            // Barely started, but it is the one actually running.
+            QbitTorrent(
+              hash: 'd1',
+              name: 'Actually Downloading',
+              state: 'downloading',
+              progress: 0.04,
+              dlspeed: 1048576,
+            ),
+          ],
+        ),
+        qbitTransferProvider(qbit).overrideWith(
+          (Ref ref) async => const QbitTransferInfo(dlSpeed: 1048576),
+        ),
+      ],
+      DashboardDownloadsWidget(
+        qbitInstances: <Instance>[qbit],
+        sabInstances: const <Instance>[],
+        nzbgetInstances: const <Instance>[],
+        delugeInstances: const <Instance>[],
+        transmissionInstances: const <Instance>[],
+        rtorrentInstances: const <Instance>[],
+      ),
+    );
+
+    expect(
+      find.text('Actually Downloading'),
+      findsOneWidget,
+      reason: 'the only moving download must make the card, whatever its '
+          'progress next to a queue of nearly-complete torrents',
+    );
+    // Only three rows fit, so the lowest-progress queued one gives up its slot
+    // rather than the live download.
+    expect(find.text('Queued C'), findsNothing);
+  });
+
+  testWidgets('a stalled download ranks below a moving one',
+      (WidgetTester tester) async {
+    // Stalled means connected to nobody. It is still a download someone is
+    // waiting on, so it stays counted and visible, just not ahead of one that
+    // is actually transferring.
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+
+    await pumpBody(
+      tester,
+      <Override>[
+        qbitRawTorrentsProvider(qbit).overrideWith(
+          (Ref ref) async => const <QbitTorrent>[
+            QbitTorrent(
+              hash: 's1',
+              name: 'Stalled One',
+              state: 'stalledDL',
+              progress: 0.9,
+            ),
+            QbitTorrent(
+              hash: 'd1',
+              name: 'Moving One',
+              state: 'downloading',
+              progress: 0.1,
+            ),
+          ],
+        ),
+        qbitTransferProvider(qbit).overrideWith(
+          (Ref ref) async => const QbitTransferInfo(),
+        ),
+      ],
+      DashboardDownloadsWidget(
+        qbitInstances: <Instance>[qbit],
+        sabInstances: const <Instance>[],
+        nzbgetInstances: const <Instance>[],
+        delugeInstances: const <Instance>[],
+        transmissionInstances: const <Instance>[],
+        rtorrentInstances: const <Instance>[],
+      ),
+    );
+
+    final Offset moving = tester.getTopLeft(find.text('Moving One'));
+    final Offset stalled = tester.getTopLeft(find.text('Stalled One'));
+    expect(moving.dy, lessThan(stalled.dy));
+  });
+
+  testWidgets('queued still counts, it is only ranked lower',
+      (WidgetTester tester) async {
+    // Dropping queued from the count would understate how much is on the go,
+    // which is not what was asked for.
+    final Instance qbit = makeInstance(ServiceKind.qbittorrent);
+
+    await pumpBody(
+      tester,
+      <Override>[
+        qbitRawTorrentsProvider(qbit).overrideWith(
+          (Ref ref) async => const <QbitTorrent>[
+            QbitTorrent(
+              hash: 'q1',
+              name: 'Queued A',
+              state: 'queuedDL',
+              progress: 0.5,
+            ),
+            QbitTorrent(
+              hash: 'd1',
+              name: 'Moving One',
+              state: 'downloading',
+              progress: 0.2,
+            ),
+          ],
+        ),
+        qbitTransferProvider(qbit).overrideWith(
+          (Ref ref) async => const QbitTransferInfo(),
+        ),
+      ],
+      DashboardDownloadsWidget(
+        qbitInstances: <Instance>[qbit],
+        sabInstances: const <Instance>[],
+        nzbgetInstances: const <Instance>[],
+        delugeInstances: const <Instance>[],
+        transmissionInstances: const <Instance>[],
+        rtorrentInstances: const <Instance>[],
+      ),
+    );
+
+    expect(find.text('Queued A'), findsOneWidget);
+    expect(find.text('Moving One'), findsOneWidget);
+  });
+}

--- a/app/test/dashboard_layout_test.dart
+++ b/app/test/dashboard_layout_test.dart
@@ -105,15 +105,15 @@ void main() {
           .where((DashboardWidgetConfig c) => c.enabled)
           .map((DashboardWidgetConfig c) => c.kind)
           .toList();
-      expect(enabled, <DashboardWidgetKind>[
-        DashboardWidgetKind.upcoming,
-        DashboardWidgetKind.recentlyAdded,
-        DashboardWidgetKind.downloads,
-        DashboardWidgetKind.recentlyDownloaded,
-        DashboardWidgetKind.requests,
-        DashboardWidgetKind.serverInfo,
-        DashboardWidgetKind.speedtestResults,
-      ]);
+      // Derived rather than frozen: a new widget kind appends to this list,
+      // and spelling it out here means every one of them breaks this test for
+      // no reason. moveEnabled(0, 2) is just a remove-and-insert.
+      final List<DashboardWidgetKind> expected = <DashboardWidgetKind>[
+        for (final DashboardWidgetKind k in DashboardWidgetKind.values)
+          if (k != DashboardWidgetKind.streams) k,
+      ];
+      expected.insert(2, expected.removeAt(0));
+      expect(enabled, expected);
       // The disabled widget is still present, at the end.
       final List<DashboardWidgetConfig> all =
           container.read(dashboardLayoutProvider);

--- a/app/test/dashboard_wake_on_lan_test.dart
+++ b/app/test/dashboard_wake_on_lan_test.dart
@@ -1,0 +1,86 @@
+import 'package:atrium/src/dashboard/dashboard_layout.dart';
+import 'package:atrium/src/dashboard/dashboard_widget_kind.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Wake-on-LAN is the first widget with no service behind it.
+///
+/// Issue #151: it points at machines rather than servers, so its devices live
+/// on the profile. Every other widget is "configured" when one of its
+/// [DashboardWidgetKindX.serviceKinds] has an instance, and that test would
+/// call this one unconfigured forever, leaving it permanently hidden.
+void main() {
+  test('wake on lan claims no service kinds', () {
+    expect(DashboardWidgetKind.wakeOnLan.serviceKinds, isEmpty);
+  });
+
+  test('it is the one kind flagged as device backed', () {
+    final List<DashboardWidgetKind> deviceBacked = <DashboardWidgetKind>[
+      for (final DashboardWidgetKind k in DashboardWidgetKind.values)
+        if (k.isDeviceBacked) k,
+    ];
+
+    expect(deviceBacked, <DashboardWidgetKind>[DashboardWidgetKind.wakeOnLan]);
+  });
+
+  test('every other kind names at least one service that fills it', () {
+    // A widget with neither a service nor the device-backed flag can never be
+    // shown, which is the trap this pair of ideas exists to close.
+    for (final DashboardWidgetKind kind in DashboardWidgetKind.values) {
+      if (kind.isDeviceBacked) {
+        continue;
+      }
+      expect(
+        kind.serviceKinds,
+        isNotEmpty,
+        reason: '${kind.name} has no services and is not device backed, so '
+            'nothing could ever make it appear',
+      );
+    }
+  });
+
+  test('it has a label and an icon like any other widget', () {
+    expect(DashboardWidgetKind.wakeOnLan.label, 'Wake on LAN');
+    expect(DashboardWidgetKind.wakeOnLan.icon, isNotNull);
+  });
+
+  group('layout', () {
+    test('a saved layout from before it existed gains it, enabled', () {
+      // mergeLayout appends kinds it has not seen, so an existing dashboard
+      // picks the widget up without a migration.
+      final List<DashboardWidgetConfig> stored = <DashboardWidgetConfig>[
+        const DashboardWidgetConfig(
+          kind: DashboardWidgetKind.downloads,
+          enabled: true,
+        ),
+      ];
+
+      final List<DashboardWidgetConfig> merged = mergeLayout(stored);
+      final DashboardWidgetConfig wol = merged.firstWhere(
+        (DashboardWidgetConfig c) => c.kind == DashboardWidgetKind.wakeOnLan,
+      );
+
+      expect(wol.enabled, isTrue);
+      // The stored one keeps its place at the front.
+      expect(merged.first.kind, DashboardWidgetKind.downloads);
+    });
+
+    test('it round-trips by name, so the order of the enum can change', () {
+      // Storing an index would repoint every saved dashboard the moment a
+      // value is inserted above it.
+      final List<DashboardWidgetConfig> layout = <DashboardWidgetConfig>[
+        const DashboardWidgetConfig(
+          kind: DashboardWidgetKind.wakeOnLan,
+          enabled: false,
+        ),
+      ];
+
+      final List<DashboardWidgetConfig> back = decodeLayout(
+        encodeLayout(layout),
+      );
+
+      expect(back.single.kind, DashboardWidgetKind.wakeOnLan);
+      expect(back.single.enabled, isFalse);
+      expect(encodeLayout(layout), contains('wakeOnLan'));
+    });
+  });
+}

--- a/app/test/dashboard_widgets_test.dart
+++ b/app/test/dashboard_widgets_test.dart
@@ -477,13 +477,20 @@ void main() {
       const DashboardBoard(),
     );
     // All eight widgets are arrangeable in edit mode, configured or not.
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(8));
+    // Counted from the enum so adding a widget does not break this.
+    expect(
+      find.byIcon(Icons.drag_indicator),
+      findsNWidgets(DashboardWidgetKind.values.length),
+    );
     expect(find.text('Hidden'), findsNothing);
     // Hide the first widget -> it moves to the Hidden section.
     await tester.tap(find.byIcon(Icons.visibility_off_outlined).first);
     await tester.pump();
     expect(find.text('Hidden'), findsOneWidget);
-    expect(find.byIcon(Icons.drag_indicator), findsNWidgets(7));
+    expect(
+      find.byIcon(Icons.drag_indicator),
+      findsNWidgets(DashboardWidgetKind.values.length - 1),
+    );
     expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
   });
 

--- a/app/test/image_auth_headers_test.dart
+++ b/app/test/image_auth_headers_test.dart
@@ -1,0 +1,108 @@
+import 'package:atrium/src/dashboard/widgets/recently_added_widget.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_riverpod/misc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_sonarr/service_sonarr.dart';
+
+import 'dashboard_widgets_test.dart' show pumpBody;
+
+/// Artwork has to carry the same auth the API calls do.
+///
+/// Behind a forward-auth proxy (Authelia, Cloudflare Access) every request
+/// needs the configured header or the proxy answers it instead of the service.
+/// API calls get theirs from the dio factory, which merges the profile's
+/// global headers with the instance's. Artwork never goes through dio: it goes
+/// out through CachedNetworkImage on its own client, and unless it is handed
+/// `httpHeaders` it sends none.
+///
+/// This asserts on the widget rather than on a socket deliberately.
+/// TestWidgetsFlutterBinding stubs HttpClient to answer 400 without opening a
+/// connection, so a network-level test here reports "no header arrived" when
+/// in truth no request was ever made. What the app controls, and what this
+/// needs to pin down, is whether the headers are passed in at all.
+void main() {
+  testWidgets('a poster request carries the instance custom headers',
+      (WidgetTester tester) async {
+    const String base = 'http://sonarr.example.test';
+    final Instance sonarr = Instance(
+      id: 'sonarr-headers',
+      name: 'Sonarr',
+      kind: ServiceKind.sonarr,
+      localUrl: base,
+      externalUrl: '',
+      urlMode: UrlMode.auto,
+      auth: const InstanceAuth.apiKey(apiKey: 'k'),
+      customHeaders: const <String, String>{
+        'Authorization': 'Basic dGVzdDp0ZXN0',
+      },
+    );
+
+    // A real api, so the poster URL is built by the same code as in the app.
+    final SonarrApi api = SonarrApi(
+      Dio(BaseOptions(baseUrl: '$base/')),
+      apiKey: 'k',
+    );
+
+    // What app.dart does whenever the active profile changes. Artwork headers
+    // are resolved from a lookup rather than a provider, because artwork is
+    // requested from places with no ref to read.
+    addTearDown(ArtworkHeaders.reset);
+    ArtworkHeaders.update(
+      instances: <Instance>[sonarr],
+      global: const <String, String>{},
+    );
+
+    await pumpBody(
+      tester,
+      <Override>[
+        sonarrApiProvider(sonarr).overrideWith((Ref ref) async => api),
+        sonarrSeriesProvider(sonarr).overrideWith(
+          (Ref ref) async => const <SonarrSeries>[
+            SonarrSeries(
+              title: 'Header Test',
+              year: 2026,
+              added: '2026-09-09T00:00:00Z',
+              images: <SonarrImage>[
+                SonarrImage(
+                  coverType: 'poster',
+                  url: '/MediaCover/1/poster.jpg',
+                ),
+              ],
+            ),
+          ],
+        ),
+      ],
+      DashboardRecentlyAddedWidget(
+        sonarrInstances: <Instance>[sonarr],
+        radarrInstances: const <Instance>[],
+      ),
+      pumps: 5,
+    );
+
+    final Finder posters = find.byType(CachedNetworkImage);
+    expect(
+      posters,
+      findsOneWidget,
+      reason: 'no poster was rendered, so this test proves nothing about its '
+          'headers',
+    );
+
+    final CachedNetworkImage poster = tester.widget<CachedNetworkImage>(posters);
+    expect(
+      poster.imageUrl,
+      contains('/api/v3/mediacover/'),
+      reason: 'the url should resolve to the instance, not a third party',
+    );
+    expect(
+      poster.httpHeaders,
+      containsPair('Authorization', 'Basic dGVzdDp0ZXN0'),
+      reason: 'without the configured header the proxy answers the poster '
+          'request instead of the service, which is why artwork comes up '
+          'blank behind Authelia while everything else works',
+    );
+  });
+}

--- a/app/test/services_drawer_test.dart
+++ b/app/test/services_drawer_test.dart
@@ -1,0 +1,212 @@
+import 'package:atrium/src/health_providers.dart';
+import 'package:atrium/src/screens/dashboard_screen.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_profile/core_profile.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Profile _testProfile() => const Profile(
+      id: 'p1',
+      name: 'Home',
+      instances: <Instance>[
+        Instance(
+          id: 'i1',
+          name: 'Sonarr',
+          kind: ServiceKind.sonarr,
+          localUrl: 'http://localhost:8989',
+          externalUrl: '',
+          urlMode: UrlMode.auto,
+          auth: InstanceAuth.apiKey(apiKey: 'k1'),
+        ),
+      ],
+    );
+
+class _FakeProfileListController extends ProfileListController {
+  @override
+  Future<List<Profile>> build() async => <Profile>[_testProfile()];
+}
+
+void main() {
+  testWidgets('ServicesDrawer renders RefreshIndicator and triggers refresh on pull', (
+    WidgetTester tester,
+  ) async {
+    int probeCount = 0;
+    final Profile profile = _testProfile();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activeProfileProvider.overrideWith((Ref ref) => profile),
+          profileListProvider.overrideWith(_FakeProfileListController.new),
+          instanceHealthProvider.overrideWith((Ref ref, String id) {
+            probeCount++;
+            return Health.ok;
+          }),
+        ],
+        child: MaterialApp(
+          theme: AtriumTheme.light(null),
+          home: Scaffold(
+            drawer: ServicesDrawer(
+              instances: profile.instances,
+              profile: profile,
+            ),
+            body: Builder(
+              builder: (BuildContext context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open Drawer'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Open the drawer.
+    await tester.tap(find.text('Open Drawer'));
+    await tester.pumpAndSettle();
+
+    // Verify RefreshIndicator exists around the service list.
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+    expect(find.text('Sonarr'), findsOneWidget);
+
+    final int initialProbes = probeCount;
+    expect(initialProbes, greaterThanOrEqualTo(1));
+
+    // Pull down on the service list to trigger pull-to-refresh.
+    await tester.fling(find.text('Sonarr'), const Offset(0, 300), 1000);
+    await tester.pump();
+    // Allow RefreshIndicator animation and async future to complete.
+    await tester.pump(const Duration(seconds: 1));
+    await tester.pumpAndSettle();
+
+    // Verify health was re-probed.
+    expect(probeCount, greaterThan(initialProbes));
+  });
+
+  testWidgets('ServicesDrawer refreshes health on open if stale (>60s)', (
+    WidgetTester tester,
+  ) async {
+    int probeCount = 0;
+    final Profile profile = _testProfile();
+    final ProviderContainer container = ProviderContainer(
+      overrides: [
+        activeProfileProvider.overrideWith((Ref ref) => profile),
+        profileListProvider.overrideWith(_FakeProfileListController.new),
+        instanceHealthProvider.overrideWith((Ref ref, String id) {
+          probeCount++;
+          return Health.ok;
+        }),
+      ],
+    );
+
+    // Set last health refresh to 5 minutes ago (stale).
+    container.read(lastHealthRefreshProvider.notifier).state =
+        DateTime.now().subtract(const Duration(minutes: 5));
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: AtriumTheme.light(null),
+          home: Scaffold(
+            drawer: ServicesDrawer(
+              instances: profile.instances,
+              profile: profile,
+            ),
+            body: Builder(
+              builder: (BuildContext context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(probeCount, 0);
+
+    // Open drawer.
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    // Freshness check triggers post-frame refresh when stale.
+    expect(probeCount, greaterThanOrEqualTo(1));
+    expect(
+      container.read(lastHealthRefreshProvider),
+      isNotNull,
+    );
+  });
+
+  testWidgets('ServicesDrawer polls health every 30s while open, stops when closed', (
+    WidgetTester tester,
+  ) async {
+    int probeCount = 0;
+    final Profile profile = _testProfile();
+    final ProviderContainer container = ProviderContainer(
+      overrides: [
+        activeProfileProvider.overrideWith((Ref ref) => profile),
+        profileListProvider.overrideWith(_FakeProfileListController.new),
+        instanceHealthProvider.overrideWith((Ref ref, String id) {
+          probeCount++;
+          return Health.ok;
+        }),
+      ],
+    );
+
+    // Mark as just refreshed so opening doesn't trigger staleness check.
+    container.read(lastHealthRefreshProvider.notifier).state = DateTime.now();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: AtriumTheme.light(null),
+          home: Scaffold(
+            drawer: ServicesDrawer(
+              instances: profile.instances,
+              profile: profile,
+            ),
+            body: Builder(
+              builder: (BuildContext context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    // Open drawer.
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    final int countAfterOpen = probeCount;
+
+    // Advance by 31 seconds while drawer is open.
+    await tester.pump(const Duration(seconds: 31));
+    await tester.pumpAndSettle();
+
+    // Verify polling triggered a probe.
+    final int countAfter30s = probeCount;
+    expect(countAfter30s, greaterThan(countAfterOpen));
+
+    // Close the drawer.
+    final ScaffoldState scaffold = tester.state(find.byType(Scaffold));
+    scaffold.closeDrawer();
+    await tester.pumpAndSettle();
+
+    // Verify ServicesDrawer is no longer in the tree.
+    expect(find.byType(ServicesDrawer), findsNothing);
+
+    // Advance time another 60 seconds with drawer closed.
+    await tester.pump(const Duration(seconds: 60));
+    await tester.pumpAndSettle();
+
+    // Verify no additional probes occurred while closed.
+    expect(probeCount, equals(countAfter30s));
+  });
+}

--- a/app/test/services_drawer_test.dart
+++ b/app/test/services_drawer_test.dart
@@ -210,4 +210,79 @@ void main() {
     // Verify no additional probes occurred while closed.
     expect(probeCount, equals(countAfter30s));
   });
+
+  testWidgets('polling stops while the app is backgrounded and resumes after',
+      (WidgetTester tester) async {
+    // The drawer can be left open behind a lock screen. The timer is stopped
+    // outright there rather than left ticking to decide it has nothing to do,
+    // so this checks the timer is really gone and really comes back.
+    int probeCount = 0;
+    final Profile profile = _testProfile();
+    final ProviderContainer container = ProviderContainer(
+      overrides: [
+        activeProfileProvider.overrideWith((Ref ref) => profile),
+        profileListProvider.overrideWith(_FakeProfileListController.new),
+        instanceHealthProvider.overrideWith((Ref ref, String id) {
+          probeCount++;
+          return Health.ok;
+        }),
+      ],
+    );
+    container.read(lastHealthRefreshProvider.notifier).state = DateTime.now();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: MaterialApp(
+          theme: AtriumTheme.light(null),
+          home: Scaffold(
+            drawer: ServicesDrawer(
+              instances: profile.instances,
+              profile: profile,
+            ),
+            body: Builder(
+              builder: (BuildContext context) => ElevatedButton(
+                onPressed: () => Scaffold.of(context).openDrawer(),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+
+    await tester.pump(const Duration(seconds: 31));
+    await tester.pumpAndSettle();
+    final int whileOpen = probeCount;
+    expect(
+      whileOpen,
+      greaterThan(0),
+      reason: 'polling should be running before it can be shown to stop',
+    );
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.paused);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 120));
+    await tester.pumpAndSettle();
+
+    expect(
+      probeCount,
+      equals(whileOpen),
+      reason: 'a backgrounded app must not keep probing every 30 seconds',
+    );
+
+    tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.resumed);
+    await tester.pump();
+    await tester.pump(const Duration(seconds: 31));
+    await tester.pumpAndSettle();
+
+    expect(
+      probeCount,
+      greaterThan(whileOpen),
+      reason: 'coming back to the foreground has to start the timer again',
+    );
+  });
 }

--- a/app/test/services_drawer_test.dart
+++ b/app/test/services_drawer_test.dart
@@ -67,7 +67,8 @@ void main() {
     await tester.tap(find.text('Open Drawer'));
     await tester.pumpAndSettle();
 
-    // Verify RefreshIndicator exists around the service list.
+    // Verify EasyRefresh exists around the service list.
+    expect(find.byType(EasyRefresh), findsOneWidget);
     expect(find.byType(RefreshIndicator), findsOneWidget);
     expect(find.text('Sonarr'), findsOneWidget);
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -9,14 +9,21 @@ this](#why-it-is-like-this) before changing any of it.
 
 ## Cutting a release
 
-1. **Bump the version.** `app/pubspec.yaml` (`version: X.Y.Z+N`), the
-   `appVersion` constant in `app/lib/src/update_check/app_version.dart` (keep it
-   equal to the pubspec `version:`; it is the baseline the update check compares
-   against, and the settings screen shows `$appVersion`, so bumping the constant
-   also updates the displayed version), a new entry in
-   `app/lib/src/screens/changelog_screen.dart`, and a new
-   `fastlane/metadata/android/en-US/changelogs/<N>.txt` named for the build
-   number, not the version.
+1. **Bump the version.** Seven places. Searching the repository for the old
+   version string is the quickest way to be sure none is missed.
+
+   - `app/pubspec.yaml`: `version: X.Y.Z+N`
+   - `app/lib/src/update_check/app_version.dart`: the `appVersion` constant.
+     Keep it equal to the pubspec `version:`. It is the baseline the update
+     check compares against and what the settings screen shows, so bumping it
+     also updates the displayed version. A test holds the two equal.
+   - `app/lib/src/screens/changelog/release_notes.dart`: a new entry at the
+     top of `releaseNotes`
+   - `fastlane/metadata/android/en-US/changelogs/<N>.txt`, named for the build
+     number, not the version
+   - `README.md`: the status line
+   - `.github/ISSUE_TEMPLATE/bug_report.yml`: the version placeholder
+   - `site/src/components/hero.html`: the version chip
 
 2. **Verify.** `flutter analyze` and `flutter test` from `app/`, both clean.
 

--- a/fastlane/metadata/android/en-US/changelogs/22.txt
+++ b/fastlane/metadata/android/en-US/changelogs/22.txt
@@ -1,0 +1,12 @@
+Wake machines from the dashboard with a new Wake-on-LAN widget, and adding a
+torrent in qBittorrent now fills in the save path from the server, including
+the path each category defines. The sidebar can be pulled down to refresh
+service health, and keeps it current while open.
+
+Behind a reverse proxy, posters and backdrops now load, headers set for the
+whole profile reach every request including Test connection, and a proxy's
+login page is no longer reported as a working server. Custom headers warn you
+when a header will not survive, and suggest Proxy-Authorization.
+
+Fixed: the Active downloads widget shows what is downloading rather than what
+is queued.

--- a/packages/core_networking/lib/core_networking.dart
+++ b/packages/core_networking/lib/core_networking.dart
@@ -15,5 +15,6 @@ export 'src/network_fingerprint.dart';
 export 'src/networking_providers.dart';
 export 'src/polling.dart';
 export 'src/rate_limit_interceptor.dart';
+export 'src/service_auth_headers.dart';
 export 'src/service_health.dart';
 export 'src/wol.dart';

--- a/packages/core_networking/lib/src/dio_factory.dart
+++ b/packages/core_networking/lib/src/dio_factory.dart
@@ -21,14 +21,27 @@ import 'rate_limit_interceptor.dart';
 ///
 /// The returned client is owned by the caller - close it when done with it.
 class DioFactory {
-  DioFactory({required ConnectionResolver resolver}) : _resolver = resolver;
+  DioFactory({
+    required ConnectionResolver resolver,
+    Map<String, String> globalHeaders = const <String, String>{},
+  })  : _resolver = resolver,
+        _globalHeaders = globalHeaders;
 
   final ConnectionResolver _resolver;
 
-  Future<Dio> create(
-    Instance instance, {
-    Map<String, String> globalHeaders = const <String, String>{},
-  }) async {
+  /// The active profile's headers, held here rather than taken per call.
+  ///
+  /// It used to be an optional argument to [create] defaulting to none, which
+  /// read as harmless and was not: five of the six call sites never passed it,
+  /// so the health probe, the connection tester and the Beszel, dashdot and
+  /// Glances clients all silently dropped the profile's headers while the rest
+  /// of the app sent them. Anyone behind a forward-auth proxy who configured
+  /// headers globally, which is the obvious place to put them when the proxy
+  /// fronts everything, got a working app whose "Test connection" failed.
+  /// Holding them on the factory means a caller cannot forget.
+  final Map<String, String> _globalHeaders;
+
+  Future<Dio> create(Instance instance) async {
     final Uri resolvedUrl = await _resolver.resolve(instance);
     final String baseUrlStr = resolvedUrl.toString();
     final String baseUrl =
@@ -49,7 +62,7 @@ class DioFactory {
     // collision. The AuthInterceptor below still wins last for its own keys
     // because it runs per-request.
     dio.options.headers
-        .addAll(mergeHeaders(globalHeaders, instance.customHeaders));
+        .addAll(mergeHeaders(_globalHeaders, instance.customHeaders));
 
     if (instance.allowSelfSignedCerts) {
       // The user has explicitly chosen to skip cert validation for this

--- a/packages/core_networking/lib/src/networking_providers.dart
+++ b/packages/core_networking/lib/src/networking_providers.dart
@@ -25,7 +25,12 @@ final Provider<ConnectionResolver> connectionResolverProvider =
 
 /// Builds [Dio] clients for instances, using the resolver above.
 final Provider<DioFactory> dioFactoryProvider = Provider<DioFactory>((Ref ref) {
-  return DioFactory(resolver: ref.watch(connectionResolverProvider));
+  // Watching the headers here rebuilds the factory, and every client built
+  // from it, whenever the active profile's headers change.
+  return DioFactory(
+    resolver: ref.watch(connectionResolverProvider),
+    globalHeaders: ref.watch(globalHeadersProvider),
+  );
 });
 
 /// Profile-wide HTTP headers applied to every instance request.
@@ -42,10 +47,7 @@ final StateProvider<Map<String, String>> globalHeadersProvider =
 /// watched.
 final instanceDioProvider =
     FutureProvider.family<Dio, Instance>((Ref ref, Instance instance) async {
-  final Map<String, String> global = ref.watch(globalHeadersProvider);
-  final Dio dio = await ref
-      .watch(dioFactoryProvider)
-      .create(instance, globalHeaders: global);
+  final Dio dio = await ref.watch(dioFactoryProvider).create(instance);
   ref.onDispose(() => dio.close(force: true));
   return dio;
 });

--- a/packages/core_networking/lib/src/service_auth_headers.dart
+++ b/packages/core_networking/lib/src/service_auth_headers.dart
@@ -59,8 +59,14 @@ bool rejectsForeignAuthorization(ServiceKind kind) =>
 ///
 /// `Proxy-Authorization` is what RFC 7235 reserves for an intermediary, and
 /// it is the only name that survives every service in the stack: nothing
-/// overwrites it and nothing rejects it. Authelia accepts it on an authz
-/// endpoint carrying the `HeaderProxyAuthorization` strategy.
+/// overwrites it and nothing rejects it.
+///
+/// Whether the proxy reads it is a separate question, and not every one does.
+/// Verified: Authelia accepts it on an authz endpoint carrying the
+/// `HeaderProxyAuthorization` strategy, while nginx's `auth_basic`, which is
+/// what an nginx Proxy Manager access list runs on, only ever reads
+/// `Authorization`. Hence "where your proxy accepts it" in the warning rather
+/// than a flat recommendation.
 const String proxyAuthHeaderName = 'Proxy-Authorization';
 
 /// Why [headerName] will not do what the user expects for [instances], or
@@ -105,6 +111,7 @@ String? headerConflictWarning(String headerName, List<Instance> instances) {
         '${refused.length == 1 ? 'refuses' : 'refuse'} a header of this name '
         'that it did not issue, and will answer 401. ');
   }
-  buffer.write('Use $proxyAuthHeaderName for reverse-proxy auth instead.');
+  buffer.write('Use $proxyAuthHeaderName instead where your proxy accepts '
+      'it, such as Authelia. nginx basic auth only reads this header.');
   return buffer.toString();
 }

--- a/packages/core_networking/lib/src/service_auth_headers.dart
+++ b/packages/core_networking/lib/src/service_auth_headers.dart
@@ -1,0 +1,110 @@
+import 'package:core_models/core_models.dart';
+
+/// The header names [AuthInterceptor] sets for an instance itself.
+///
+/// A user-configured header of the same name never reaches the wire: the
+/// interceptor runs per request, after the profile's headers are installed as
+/// client defaults, so it overwrites them. That matters for reverse-proxy
+/// auth, where the whole point of the header is to be seen by something in
+/// front of the service. `Authorization` is the one that collides in
+/// practice, because five kinds spend it on their own credentials.
+///
+/// Kept beside the interceptor so the two cannot drift; a test asserts this
+/// agrees with what the interceptor actually sends for every kind.
+Set<String> serviceAuthHeaderNames(ServiceKind kind, InstanceAuth auth) {
+  switch (auth) {
+    case InstanceAuthApiKey():
+      switch (kind) {
+        case ServiceKind.speedtestTracker || ServiceKind.tracearr:
+          return const <String>{'Authorization', 'Accept'};
+        case ServiceKind.sabnzbd || ServiceKind.tautulli:
+          // Query parameter, not a header, so nothing collides.
+          return const <String>{};
+        case _:
+          return const <String>{'X-Api-Key'};
+      }
+    case InstanceAuthPlex():
+      return const <String>{'X-Plex-Token', 'Accept'};
+    case InstanceAuthUserPass(
+          :final String username,
+          :final String password,
+        )
+        when kind == ServiceKind.nzbget ||
+            kind == ServiceKind.transmission ||
+            kind == ServiceKind.rtorrent:
+      // Transmission's auth is optional and rTorrent has none of its own, so
+      // with no credentials entered the interceptor sends no header at all.
+      return username.isEmpty && password.isEmpty
+          ? const <String>{}
+          : const <String>{'Authorization'};
+    case InstanceAuthUserPass() || InstanceAuthCookie():
+      // Token and cookie flows are handled by the service's own session
+      // manager rather than by a static header.
+      return const <String>{};
+  }
+}
+
+/// Whether [kind] refuses a request carrying an `Authorization` header it did
+/// not issue itself.
+///
+/// qBittorrent parses the header rather than ignoring it and answers 401
+/// instead of falling back to its session cookie, so a proxy credential sent
+/// this way locks the user out of a service that is otherwise reachable.
+/// Verified against qBittorrent 5.x: the same request answers 403 without the
+/// header and 401 with it. `Proxy-Authorization` is not affected.
+bool rejectsForeignAuthorization(ServiceKind kind) =>
+    kind == ServiceKind.qbittorrent;
+
+/// The header to reach for when the credential is meant for a reverse proxy.
+///
+/// `Proxy-Authorization` is what RFC 7235 reserves for an intermediary, and
+/// it is the only name that survives every service in the stack: nothing
+/// overwrites it and nothing rejects it. Authelia accepts it on an authz
+/// endpoint carrying the `HeaderProxyAuthorization` strategy.
+const String proxyAuthHeaderName = 'Proxy-Authorization';
+
+/// Why [headerName] will not do what the user expects for [instances], or
+/// null when it is fine.
+///
+/// Two ways a header can be configured and still not work: a service spends
+/// that name on its own sign-in and overwrites it before the request leaves,
+/// or the service refuses one it did not issue. Both are worth saying at the
+/// moment the header is typed rather than leaving someone to wonder why a
+/// proxy keeps rejecting them.
+String? headerConflictWarning(String headerName, List<Instance> instances) {
+  final String name = headerName.trim();
+  if (name.isEmpty) {
+    return null;
+  }
+  final String lower = name.toLowerCase();
+
+  final List<String> overwritten = <String>[
+    for (final Instance i in instances)
+      if (serviceAuthHeaderNames(i.kind, i.auth)
+          .any((String h) => h.toLowerCase() == lower))
+        i.name,
+  ];
+  final List<String> refused = <String>[
+    if (lower == 'authorization')
+      for (final Instance i in instances)
+        if (rejectsForeignAuthorization(i.kind)) i.name,
+  ];
+
+  if (overwritten.isEmpty && refused.isEmpty) {
+    return null;
+  }
+  final StringBuffer buffer = StringBuffer();
+  if (overwritten.isNotEmpty) {
+    final bool one = overwritten.length == 1;
+    buffer.write('${overwritten.join(', ')} ${one ? 'uses' : 'use'} this '
+        'header for ${one ? 'its' : 'their'} own sign-in, so your value is '
+        'replaced before the request is sent. ');
+  }
+  if (refused.isNotEmpty) {
+    buffer.write('${refused.join(', ')} '
+        '${refused.length == 1 ? 'refuses' : 'refuse'} a header of this name '
+        'that it did not issue, and will answer 401. ');
+  }
+  buffer.write('Use $proxyAuthHeaderName for reverse-proxy auth instead.');
+  return buffer.toString();
+}

--- a/packages/core_networking/lib/src/service_health.dart
+++ b/packages/core_networking/lib/src/service_health.dart
@@ -155,6 +155,7 @@ class HealthProbe {
         instance.kind,
         status,
         resp.data,
+        contentType: resp.headers.value(Headers.contentTypeHeader),
       );
     } on DioException {
       return Health.error;
@@ -172,11 +173,33 @@ class HealthProbe {
 Health interpretServiceHealthResponse(
   ServiceKind kind,
   int status,
-  Object? data,
-) {
+  Object? data, {
+  String? contentType,
+}) {
   if (status == 0) {
     return Health.error;
   }
+
+  // A page where an API should be.
+  //
+  // Every health endpoint here answers with JSON, or XML-RPC in rTorrent's
+  // case. None answer with a web page. A forward-auth proxy redirects an
+  // unauthenticated request to its login portal, the probe follows the
+  // redirect as any client would, and the portal returns a perfectly healthy
+  // 200 full of markup. Status alone cannot tell that apart from a working
+  // server, so a login page was being reported as Online.
+  //
+  // Read from the content type rather than the body: Authelia's portal opens
+  // with a licence comment, so looking for a leading <html would miss it.
+  // Restricted to 2xx because several services legitimately answer with a
+  // page on an error, Transmission's 409 and rTorrent's 502 among them, and
+  // those are already interpreted correctly.
+  if (status >= 200 &&
+      status < 300 &&
+      (contentType?.toLowerCase().contains('text/html') ?? false)) {
+    return Health.warning;
+  }
+
   final _HealthMode mode = _config(kind).mode;
   switch (mode) {
     case _HealthMode.authed:

--- a/packages/core_networking/test/global_headers_reach_every_client_test.dart
+++ b/packages/core_networking/test/global_headers_reach_every_client_test.dart
@@ -1,0 +1,124 @@
+import 'dart:typed_data';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// The profile's headers have to reach every client, not just the ones the
+/// screens use.
+///
+/// Reported by a user running Authelia: the app worked, but "Test connection"
+/// answered "Reachable, but the check did not pass" and the dashboard showed
+/// warnings. The headers were configured globally, which is the natural place
+/// when one proxy fronts everything, and [DioFactory.create] used to take them
+/// as an optional argument that five of its six callers never passed. Holding
+/// them on the factory is what makes forgetting impossible, so these pin that
+/// down rather than the old per-call behaviour.
+void main() {
+  Instance instance({Map<String, String> headers = const <String, String>{}}) =>
+      Instance(
+        id: 'sonarr',
+        name: 'Sonarr',
+        kind: ServiceKind.sonarr,
+        localUrl: 'http://sonarr.example.test',
+        externalUrl: '',
+        urlMode: UrlMode.auto,
+        auth: const InstanceAuth.apiKey(apiKey: 'k'),
+        customHeaders: headers,
+      );
+
+  ConnectionResolver resolverFor(Dio Function() probe) => ConnectionResolver(
+        connectivity: Connectivity(),
+        probeClientFactory: (bool _) => probe(),
+      );
+
+  DioFactory factoryWith(
+    Map<String, String> global, {
+    HttpClientAdapter? adapter,
+  }) =>
+      DioFactory(
+        resolver: resolverFor(
+          () => Dio()..httpClientAdapter = adapter ?? _OkAdapter(),
+        ),
+        globalHeaders: global,
+      );
+
+  test('a client carries the profile headers without being asked', () async {
+    final Dio dio = await factoryWith(
+      const <String, String>{'Authorization': 'Basic dGVzdDp0ZXN0'},
+    ).create(instance());
+
+    expect(dio.options.headers['Authorization'], 'Basic dGVzdDp0ZXN0');
+  });
+
+  test('an instance header still wins over the profile one', () async {
+    final Dio dio = await factoryWith(
+      const <String, String>{'X-Which': 'global'},
+    ).create(instance(headers: const <String, String>{'X-Which': 'instance'}));
+
+    expect(dio.options.headers['X-Which'], 'instance');
+  });
+
+  test('profile headers the instance does not mention still ride along',
+      () async {
+    final Dio dio = await factoryWith(
+      const <String, String>{'CF-Access-Client-Id': 'id'},
+    ).create(instance(headers: const <String, String>{'X-Other': 'x'}));
+
+    expect(dio.options.headers['CF-Access-Client-Id'], 'id');
+    expect(dio.options.headers['X-Other'], 'x');
+  });
+
+  test('the health probe sends them too', () async {
+    // The probe builds its own client off the factory. This is the call site
+    // the user actually hit: the dashboard dot and "Test connection" both go
+    // through here, and both used to drop the profile's headers.
+    final _RecordingAdapter recorder = _RecordingAdapter();
+    final Dio dio = await factoryWith(
+      const <String, String>{'Authorization': 'Basic seen'},
+    ).create(instance());
+    dio.httpClientAdapter = recorder;
+
+    await dio.get<dynamic>(
+      'api/v3/system/status',
+      options: Options(validateStatus: (_) => true),
+    );
+
+    expect(recorder.seen['Authorization'], 'Basic seen');
+  });
+}
+
+/// Answers any probe so the resolver settles on the local URL.
+class _OkAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async =>
+      ResponseBody.fromString('{}', 200);
+
+  @override
+  void close({bool force = false}) {}
+}
+
+class _RecordingAdapter implements HttpClientAdapter {
+  Map<String, dynamic> seen = <String, dynamic>{};
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    seen = options.headers;
+    return ResponseBody.fromString('{}', 200, headers: <String, List<String>>{
+      Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+    });
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/packages/core_networking/test/service_auth_headers_test.dart
+++ b/packages/core_networking/test/service_auth_headers_test.dart
@@ -1,0 +1,189 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// [serviceAuthHeaderNames] has to keep telling the truth about what
+/// [AuthInterceptor] actually sends.
+///
+/// The Custom Headers screen warns people off names the interceptor is going
+/// to overwrite, so if the two drift the warning either cries wolf or, worse,
+/// stays quiet while a reverse-proxy credential is silently dropped.
+void main() {
+  /// Runs a request through the interceptor and reports the headers it set.
+  Set<String> headersActuallySet(ServiceKind kind, InstanceAuth auth) {
+    final RequestOptions options = RequestOptions(path: '/probe');
+    final AuthInterceptor interceptor =
+        AuthInterceptor(kind: kind, auth: auth);
+    interceptor.onRequest(options, RequestInterceptorHandler());
+    return options.headers.keys.toSet();
+  }
+
+  const InstanceAuth apiKey = InstanceAuth.apiKey(apiKey: 'k');
+  const InstanceAuth plex = InstanceAuth.plexToken(token: 't');
+  const InstanceAuth userPass =
+      InstanceAuth.userPass(username: 'u', password: 'p');
+  const InstanceAuth blankUserPass =
+      InstanceAuth.userPass(username: '', password: '');
+
+  test('it matches the interceptor for every kind and auth', () {
+    for (final ServiceKind kind in ServiceKind.values) {
+      for (final InstanceAuth auth in <InstanceAuth>[
+        apiKey,
+        plex,
+        userPass,
+        blankUserPass,
+      ]) {
+        expect(
+          serviceAuthHeaderNames(kind, auth),
+          headersActuallySet(kind, auth),
+          reason: 'drifted for ${kind.name} with ${auth.runtimeType}',
+        );
+      }
+    }
+  });
+
+  test('the five kinds that spend Authorization on themselves are named', () {
+    // These are the ones where a user's own Authorization header never
+    // reaches the wire, which is the whole reason the warning exists.
+    final Set<ServiceKind> owners = <ServiceKind>{
+      for (final ServiceKind kind in ServiceKind.values)
+        for (final InstanceAuth auth in <InstanceAuth>[apiKey, userPass])
+          if (serviceAuthHeaderNames(kind, auth).contains('Authorization'))
+            kind,
+    };
+
+    expect(owners, <ServiceKind>{
+      ServiceKind.speedtestTracker,
+      ServiceKind.tracearr,
+      ServiceKind.nzbget,
+      ServiceKind.transmission,
+      ServiceKind.rtorrent,
+    });
+  });
+
+  test('an unconfigured transmission or rtorrent collides with nothing', () {
+    // Their auth is optional, so with nothing entered there is no header to
+    // overwrite and no reason to warn.
+    expect(
+      serviceAuthHeaderNames(ServiceKind.transmission, blankUserPass),
+      isEmpty,
+    );
+    expect(
+      serviceAuthHeaderNames(ServiceKind.rtorrent, blankUserPass),
+      isEmpty,
+    );
+  });
+
+  test('the query-key services collide with nothing', () {
+    // SABnzbd and Tautulli carry the key in the query string.
+    expect(serviceAuthHeaderNames(ServiceKind.sabnzbd, apiKey), isEmpty);
+    expect(serviceAuthHeaderNames(ServiceKind.tautulli, apiKey), isEmpty);
+  });
+
+  test('qBittorrent is flagged as refusing a foreign Authorization', () {
+    expect(rejectsForeignAuthorization(ServiceKind.qbittorrent), isTrue);
+    expect(rejectsForeignAuthorization(ServiceKind.sonarr), isFalse);
+  });
+
+  group('conflict warning', _warningTests);
+
+  test('the recommended proxy header is one nothing else touches', () {
+    // If any service ever starts setting Proxy-Authorization itself, the
+    // advice in the Custom Headers screen stops being true.
+    for (final ServiceKind kind in ServiceKind.values) {
+      for (final InstanceAuth auth in <InstanceAuth>[
+        apiKey,
+        plex,
+        userPass,
+      ]) {
+        expect(
+          serviceAuthHeaderNames(kind, auth),
+          isNot(contains(proxyAuthHeaderName)),
+          reason: '${kind.name} would overwrite the proxy header',
+        );
+      }
+    }
+  });
+}
+
+/// The warning the Custom Headers screen shows while a name is being typed.
+void _warningTests() {
+  Instance inst(String name, ServiceKind kind, InstanceAuth auth) => Instance(
+        id: name,
+        name: name,
+        kind: kind,
+        localUrl: 'http://x',
+        externalUrl: '',
+        urlMode: UrlMode.auto,
+        auth: auth,
+      );
+
+  const InstanceAuth key = InstanceAuth.apiKey(apiKey: 'k');
+  const InstanceAuth up = InstanceAuth.userPass(username: 'u', password: 'p');
+
+  test('Authorization warns about the services that overwrite it', () {
+    final String? w = headerConflictWarning('Authorization', <Instance>[
+      inst('NZBGet', ServiceKind.nzbget, up),
+      inst('Sonarr', ServiceKind.sonarr, key),
+    ]);
+
+    expect(w, contains('NZBGet'));
+    expect(w, isNot(contains('Sonarr')), reason: 'Sonarr is unaffected');
+    expect(w, contains('Proxy-Authorization'));
+  });
+
+  test('Authorization warns that qBittorrent refuses it', () {
+    final String? w = headerConflictWarning('Authorization', <Instance>[
+      inst('qBittorrent', ServiceKind.qbittorrent, key),
+    ]);
+
+    expect(w, contains('qBittorrent'));
+    expect(w, contains('401'));
+  });
+
+  test('the recommended header warns about nothing', () {
+    expect(
+      headerConflictWarning('Proxy-Authorization', <Instance>[
+        inst('qBittorrent', ServiceKind.qbittorrent, key),
+        inst('NZBGet', ServiceKind.nzbget, up),
+        inst('Sonarr', ServiceKind.sonarr, key),
+      ]),
+      isNull,
+    );
+  });
+
+  test('an ordinary header name warns about nothing', () {
+    expect(
+      headerConflictWarning('CF-Access-Client-Id', <Instance>[
+        inst('Sonarr', ServiceKind.sonarr, key),
+      ]),
+      isNull,
+    );
+  });
+
+  test('X-Api-Key warns for the services that set it themselves', () {
+    // The old placeholder on that field. Configuring it globally would have
+    // been overwritten for every *arr in the profile.
+    expect(
+      headerConflictWarning('X-Api-Key', <Instance>[
+        inst('Sonarr', ServiceKind.sonarr, key),
+      ]),
+      contains('Sonarr'),
+    );
+  });
+
+  test('the match ignores header case, as HTTP does', () {
+    expect(
+      headerConflictWarning('authorization', <Instance>[
+        inst('qBittorrent', ServiceKind.qbittorrent, key),
+      ]),
+      isNotNull,
+    );
+  });
+
+  test('empty and whitespace names warn about nothing', () {
+    expect(headerConflictWarning('', <Instance>[]), isNull);
+    expect(headerConflictWarning('   ', <Instance>[]), isNull);
+  });
+}

--- a/packages/core_networking/test/service_health_test.dart
+++ b/packages/core_networking/test/service_health_test.dart
@@ -3,6 +3,7 @@ import 'package:core_networking/core_networking.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  group('proxy interception', _interceptionTests);
   group('Unraid GraphQL health', () {
     test('a query that actually ran is online', () {
       expect(
@@ -90,5 +91,99 @@ void main() {
         );
       }
     });
+  });
+}
+
+// ---
+
+/// A forward-auth proxy answering instead of the service.
+///
+/// Reproduced against real Authelia behind nginx: an unauthenticated probe is
+/// redirected to the login portal, the client follows it, and the portal
+/// answers 200 with text/html. Every health endpoint here speaks JSON or
+/// XML-RPC, so a page is proof the service never saw the request.
+void _interceptionTests() {
+  const String html = 'text/html; charset=utf-8';
+  const String json = 'application/json';
+
+  test('a 200 page is not a healthy service', () {
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.sonarr, 200, '<!--SPDX--><!DOCTYPE html>',
+        contentType: html,
+      ),
+      Health.warning,
+    );
+  });
+
+  test('it applies to the public-endpoint services too', () {
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.jellyfin, 200, '<html>', contentType: html,
+      ),
+      Health.warning,
+    );
+  });
+
+  test('and to the ones judged only on reachability', () {
+    // qBittorrent is called healthy on any answer at all, which would happily
+    // accept a login portal.
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.qbittorrent, 200, '<html>', contentType: html,
+      ),
+      Health.warning,
+    );
+  });
+
+  test('a real json answer is still healthy', () {
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.sonarr, 200, <String, dynamic>{'version': '4.0'},
+        contentType: json,
+      ),
+      Health.ok,
+    );
+  });
+
+  test('transmission answering 409 with a page is left alone', () {
+    // Its own conflict response is markup and means the daemon is up. Only
+    // 2xx is treated as an interception for exactly this reason.
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.transmission, 409, '<h1>409: Conflict</h1>',
+        contentType: html,
+      ),
+      Health.ok,
+    );
+  });
+
+  test('rtorrent answering 502 with a page is left alone', () {
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.rtorrent, 502, '<html>502</html>', contentType: html,
+      ),
+      Health.warning,
+    );
+  });
+
+  test('rtorrent xml-rpc is not mistaken for a page', () {
+    // XML-RPC opens with a tag too, which is why this reads the content type
+    // rather than sniffing the body.
+    expect(
+      interpretServiceHealthResponse(
+        ServiceKind.rtorrent, 200,
+        '<?xml version="1.0"?><methodResponse></methodResponse>',
+        contentType: 'text/xml',
+      ),
+      Health.ok,
+    );
+  });
+
+  test('no content type at all changes nothing', () {
+    expect(
+      interpretServiceHealthResponse(ServiceKind.sonarr, 200, <String, dynamic>{}),
+      Health.ok,
+    );
   });
 }

--- a/packages/core_ui/lib/core_ui.dart
+++ b/packages/core_ui/lib/core_ui.dart
@@ -10,12 +10,14 @@ library;
 export 'package:easy_refresh/easy_refresh.dart' hide EasyRefresh, HeaderLocator;
 export 'package:flex_color_scheme/flex_color_scheme.dart';
 
+export 'src/artwork_headers.dart';
 export 'src/design_tokens.dart';
 export 'src/navigation.dart';
 export 'src/performance_logger.dart';
 export 'src/service_visuals.dart';
 export 'src/theme.dart';
 export 'src/widgets/async_value_view.dart';
+export 'src/widgets/atrium_network_image.dart';
 export 'src/widgets/beta_badge.dart';
 export 'src/widgets/bottom_nav.dart';
 export 'src/widgets/collapsed_title.dart';

--- a/packages/core_ui/lib/src/artwork_headers.dart
+++ b/packages/core_ui/lib/src/artwork_headers.dart
@@ -1,0 +1,96 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_networking/core_networking.dart';
+
+/// The headers an artwork request needs, worked out from its URL.
+///
+/// Artwork is the one thing in the app that does not go through Dio. Posters,
+/// banners and backdrops are fetched by `CachedNetworkImage` on its own HTTP
+/// client, which sends nothing but what it is handed, so the user-configured
+/// headers the Dio factory installs never reached them. Behind a forward-auth
+/// proxy (Authelia, Cloudflare Access, an nginx `auth_request`) that means the
+/// proxy answered every image request instead of the service and every poster
+/// came up blank, silently, while the rest of the app worked.
+///
+/// This is a static holder rather than a provider on purpose. Artwork is
+/// requested from places that have no `ref` to read: `PaletteGenerator` calls
+/// in plain `State` classes, `DecorationImage`, helper functions several
+/// layers down a service module. Threading a ref to all of them would be a
+/// far larger change than the bug warrants. It is written from exactly one
+/// place, the profile listener in `app.dart`, alongside the existing
+/// `globalHeadersProvider` sync, so there is one writer and many readers.
+abstract final class ArtworkHeaders {
+  /// Normalised instance base URL to the headers requests under it need.
+  ///
+  /// Both the local and external URL of an instance map to the same headers,
+  /// since either may be the one the artwork URL was built from.
+  static Map<String, Map<String, String>> _byBase =
+      const <String, Map<String, String>>{};
+
+  /// Rebuilds the lookup for [instances], merging each instance's headers
+  /// over [global] exactly as the Dio factory does.
+  static void update({
+    required Iterable<Instance> instances,
+    required Map<String, String> global,
+  }) {
+    final Map<String, Map<String, String>> next =
+        <String, Map<String, String>>{};
+    for (final Instance instance in instances) {
+      final Map<String, String> headers =
+          mergeHeaders(global, instance.customHeaders);
+      if (headers.isEmpty) {
+        continue;
+      }
+      for (final String base in <String>[
+        instance.localUrl,
+        instance.externalUrl,
+      ]) {
+        final String key = _normalise(base);
+        if (key.isNotEmpty) {
+          next[key] = headers;
+        }
+      }
+    }
+    _byBase = next;
+  }
+
+  /// Headers for [url], or null when it belongs to no configured instance.
+  ///
+  /// Null rather than an empty map because that is what `CachedNetworkImage`
+  /// and `Image.network` already treat as "send nothing", and because artwork
+  /// for something not in the library yet points at TMDB or Fanart.tv, where
+  /// the user's proxy credentials have no business being sent.
+  static Map<String, String>? forUrl(String? url) {
+    if (url == null || url.isEmpty || _byBase.isEmpty) {
+      return null;
+    }
+    final String target = _normalise(url);
+
+    // Longest match wins, so an instance served from a sub-path is preferred
+    // over another one sitting at the root of the same host.
+    String? best;
+    for (final String base in _byBase.keys) {
+      if (target == base || target.startsWith('$base/')) {
+        if (best == null || base.length > best.length) {
+          best = base;
+        }
+      }
+    }
+    return best == null ? null : _byBase[best];
+  }
+
+  /// Drops every mapping. Only for tests, so one does not leak into the next.
+  static void reset() => _byBase = const <String, Map<String, String>>{};
+
+  /// Lowercased and stripped of trailing slashes so the comparison survives
+  /// the ways a base URL and the URL built from it can differ in spelling.
+  /// Case folding the path too is deliberate: hosts are case-insensitive, and
+  /// treating a prefix loosely here can only widen the match to another URL on
+  /// the user's own server.
+  static String _normalise(String raw) {
+    String value = raw.trim();
+    while (value.endsWith('/')) {
+      value = value.substring(0, value.length - 1);
+    }
+    return value.toLowerCase();
+  }
+}

--- a/packages/core_ui/lib/src/widgets/atrium_network_image.dart
+++ b/packages/core_ui/lib/src/widgets/atrium_network_image.dart
@@ -1,0 +1,87 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../artwork_headers.dart';
+
+/// A network image that carries the instance's configured headers.
+///
+/// Use this rather than `CachedNetworkImage` directly for anything served by
+/// a user's own instance. It is a drop-in for the parameters the app actually
+/// uses; the only difference is that it resolves the headers for the URL and
+/// passes them along, which is what makes artwork work behind a forward-auth
+/// proxy. See [ArtworkHeaders] for why that lookup is by URL.
+class AtriumNetworkImage extends StatelessWidget {
+  const AtriumNetworkImage({
+    required this.imageUrl,
+    super.key,
+    this.fit,
+    this.width,
+    this.height,
+    this.memCacheWidth,
+    this.memCacheHeight,
+    this.maxWidthDiskCache,
+    this.maxHeightDiskCache,
+    this.placeholder,
+    this.errorWidget,
+    this.imageBuilder,
+    this.alignment = Alignment.center,
+    this.filterQuality = FilterQuality.low,
+    this.fadeInDuration = const Duration(milliseconds: 500),
+    this.color,
+    this.colorBlendMode,
+  });
+
+  final String imageUrl;
+  final BoxFit? fit;
+  final double? width;
+  final double? height;
+  final int? memCacheWidth;
+  final int? memCacheHeight;
+  final int? maxWidthDiskCache;
+  final int? maxHeightDiskCache;
+  final PlaceholderWidgetBuilder? placeholder;
+  final LoadingErrorWidgetBuilder? errorWidget;
+  final ImageWidgetBuilder? imageBuilder;
+  final Alignment alignment;
+  final FilterQuality filterQuality;
+  final Duration fadeInDuration;
+  final Color? color;
+  final BlendMode? colorBlendMode;
+
+  @override
+  Widget build(BuildContext context) => CachedNetworkImage(
+        imageUrl: imageUrl,
+        httpHeaders: ArtworkHeaders.forUrl(imageUrl),
+        fit: fit,
+        width: width,
+        height: height,
+        memCacheWidth: memCacheWidth,
+        memCacheHeight: memCacheHeight,
+        maxWidthDiskCache: maxWidthDiskCache,
+        maxHeightDiskCache: maxHeightDiskCache,
+        placeholder: placeholder,
+        errorWidget: errorWidget,
+        imageBuilder: imageBuilder,
+        alignment: alignment,
+        filterQuality: filterQuality,
+        fadeInDuration: fadeInDuration,
+        color: color,
+        colorBlendMode: colorBlendMode,
+      );
+}
+
+/// The same idea as [AtriumNetworkImage] for the places that need an
+/// `ImageProvider` rather than a widget: `DecorationImage` backgrounds and
+/// `PaletteGenerator`, which pulls the poster colours for the now-playing
+/// cards and would otherwise fetch a login page and theme the card from it.
+CachedNetworkImageProvider atriumImageProvider(
+  String url, {
+  int? maxWidth,
+  int? maxHeight,
+}) =>
+    CachedNetworkImageProvider(
+      url,
+      headers: ArtworkHeaders.forUrl(url),
+      maxWidth: maxWidth,
+      maxHeight: maxHeight,
+    );

--- a/packages/core_ui/pubspec.yaml
+++ b/packages/core_ui/pubspec.yaml
@@ -10,7 +10,9 @@ environment:
   flutter: ^3.27.0
 
 dependencies:
+  cached_network_image: ^3.4.1
   core_models:
+  core_networking:
   dynamic_system_colors: ^1.9.0
   easy_refresh: ^3.4.0
   flex_color_scheme: ^8.4.0

--- a/packages/core_ui/test/artwork_headers_test.dart
+++ b/packages/core_ui/test/artwork_headers_test.dart
@@ -1,0 +1,169 @@
+import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Artwork headers are resolved from the URL, so the matching is the whole
+/// correctness story: too loose and a user's proxy credentials go to TMDB,
+/// too strict and posters stay blank behind Authelia.
+void main() {
+  tearDown(ArtworkHeaders.reset);
+
+  Instance instance(
+    String id, {
+    String local = 'http://sonarr.example.test',
+    String external = '',
+    Map<String, String> headers = const <String, String>{},
+  }) =>
+      Instance(
+        id: id,
+        name: id,
+        kind: ServiceKind.sonarr,
+        localUrl: local,
+        externalUrl: external,
+        urlMode: UrlMode.auto,
+        auth: const InstanceAuth.apiKey(apiKey: 'k'),
+        customHeaders: headers,
+      );
+
+  test('a url under an instance gets that instance headers', () {
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a', headers: const <String, String>{'Authorization': 'Basic x'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(
+      ArtworkHeaders.forUrl('http://sonarr.example.test/api/v3/mediacover/1/poster.jpg'),
+      <String, String>{'Authorization': 'Basic x'},
+    );
+  });
+
+  test('global headers reach every instance, instance keys win', () {
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a', headers: const <String, String>{'X-Which': 'instance'}),
+      ],
+      global: const <String, String>{
+        'X-Which': 'global',
+        'CF-Access-Client-Id': 'id',
+      },
+    );
+
+    final Map<String, String>? headers =
+        ArtworkHeaders.forUrl('http://sonarr.example.test/poster.jpg');
+
+    expect(headers?['X-Which'], 'instance');
+    expect(headers?['CF-Access-Client-Id'], 'id');
+  });
+
+  test('artwork on a third party gets nothing', () {
+    // Add-search results point at TMDB and Fanart.tv. Sending the user's
+    // proxy credentials to those would leak them off the network entirely.
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a', headers: const <String, String>{'Authorization': 'Basic x'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(ArtworkHeaders.forUrl('https://image.tmdb.org/t/p/w500/x.jpg'), isNull);
+  });
+
+  test('the longest matching base wins', () {
+    // Two services behind one hostname on different sub-paths. Matching the
+    // shorter base first would hand over the wrong instance's headers.
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('root',
+            local: 'https://home.example.test',
+            headers: const <String, String>{'X-Who': 'root'}),
+        instance('sub',
+            local: 'https://home.example.test/sonarr',
+            headers: const <String, String>{'X-Who': 'sub'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(
+      ArtworkHeaders.forUrl('https://home.example.test/sonarr/api/v3/mediacover/1/poster.jpg')?['X-Who'],
+      'sub',
+    );
+    expect(
+      ArtworkHeaders.forUrl('https://home.example.test/other/poster.jpg')?['X-Who'],
+      'root',
+    );
+  });
+
+  test('a trailing slash or different casing still matches', () {
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a',
+            local: 'http://Sonarr.Example.Test:8989/',
+            headers: const <String, String>{'Authorization': 'Basic x'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(
+      ArtworkHeaders.forUrl('http://sonarr.example.test:8989/api/v3/mediacover/1/poster.jpg'),
+      isNotNull,
+    );
+  });
+
+  test('the external url matches as well as the local one', () {
+    // Which of the two an artwork url was built from depends on where the
+    // device is, so both have to resolve.
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a',
+            local: 'http://192.168.0.10:8989',
+            external: 'https://sonarr.example.test',
+            headers: const <String, String>{'Authorization': 'Basic x'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(ArtworkHeaders.forUrl('http://192.168.0.10:8989/p.jpg'), isNotNull);
+    expect(ArtworkHeaders.forUrl('https://sonarr.example.test/p.jpg'), isNotNull);
+  });
+
+  test('an instance with no headers configured resolves to null', () {
+    // Null rather than an empty map, so the image widgets keep their existing
+    // "send nothing" behaviour for everyone not behind a proxy.
+    ArtworkHeaders.update(
+      instances: <Instance>[instance('a')],
+      global: const <String, String>{},
+    );
+
+    expect(ArtworkHeaders.forUrl('http://sonarr.example.test/p.jpg'), isNull);
+  });
+
+  test('a host that merely starts with an instance host does not match', () {
+    // sonarr.example.test.evil.com must not pick up the credentials for
+    // sonarr.example.test.
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a', headers: const <String, String>{'Authorization': 'Basic x'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(
+      ArtworkHeaders.forUrl('http://sonarr.example.test.evil.example/p.jpg'),
+      isNull,
+    );
+  });
+
+  test('an empty or null url resolves to null', () {
+    ArtworkHeaders.update(
+      instances: <Instance>[
+        instance('a', headers: const <String, String>{'Authorization': 'Basic x'}),
+      ],
+      global: const <String, String>{},
+    );
+
+    expect(ArtworkHeaders.forUrl(null), isNull);
+    expect(ArtworkHeaders.forUrl(''), isNull);
+  });
+}

--- a/services/service_emby/lib/src/emby_home.dart
+++ b/services/service_emby/lib/src/emby_home.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -845,7 +844,7 @@ class EmbyPosterCard extends ConsumerWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 300,
@@ -1031,7 +1030,7 @@ class EmbyBannerCard extends ConsumerWidget {
                     child: Stack(
                       fit: StackFit.expand,
                       children: <Widget>[
-                        CachedNetworkImage(
+                        AtriumNetworkImage(
                           imageUrl: (backdropUrl ?? imageUrl)!,
                           fit: BoxFit.cover,
                           alignment: Alignment.topCenter,
@@ -1195,7 +1194,7 @@ class EmbyBannerCard extends ConsumerWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       placeholder: (BuildContext context, String url) => Container(
@@ -1512,7 +1511,7 @@ class _SessionCardState extends State<_SessionCard> {
     _lastPosterUrl = posterUrl;
 
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
     ).then((PaletteGenerator palette) {
       if (mounted) {
@@ -1572,6 +1571,7 @@ class _SessionCardState extends State<_SessionCard> {
                     children: <Widget>[
                       Image.network(
                         session.posterUrl!,
+                        headers: ArtworkHeaders.forUrl(session.posterUrl!),
                         fit: BoxFit.cover,
                         alignment: Alignment.topCenter,
                         errorBuilder: (_, __, ___) => const SizedBox.shrink(),
@@ -1622,7 +1622,7 @@ class _SessionCardState extends State<_SessionCard> {
                             ],
                             image: session.posterUrl != null
                                 ? DecorationImage(
-                                    image: CachedNetworkImageProvider(
+                                    image: atriumImageProvider(
                                       session.posterUrl!,
                                     ),
                                     fit: BoxFit.cover,

--- a/services/service_emby/lib/src/emby_identify_screen.dart
+++ b/services/service_emby/lib/src/emby_identify_screen.dart
@@ -238,6 +238,7 @@ class _EmbyIdentifyScreenState extends ConsumerState<EmbyIdentifyScreen> {
                     leading: res.imageUrl != null
                         ? Image.network(
                             res.imageUrl!,
+                            headers: ArtworkHeaders.forUrl(res.imageUrl!),
                             width: 40,
                             height: 60,
                             fit: BoxFit.cover,

--- a/services/service_emby/lib/src/emby_item_detail.dart
+++ b/services/service_emby/lib/src/emby_item_detail.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -165,7 +164,7 @@ class EmbyItemDetailScreen extends ConsumerWidget {
                         child: Stack(
                           children: <Widget>[
                             Positioned.fill(
-                              child: CachedNetworkImage(
+                              child: AtriumNetworkImage(
                                 key: ValueKey<String>(backdropUrl),
                                 imageUrl: backdropUrl,
                                 fit: BoxFit.cover,
@@ -349,7 +348,7 @@ class _Header extends StatelessWidget {
                 if (posterUrl != null)
                   ClipRRect(
                     borderRadius: Radii.card,
-                    child: CachedNetworkImage(
+                    child: AtriumNetworkImage(
                       key: ValueKey<String>(posterUrl),
                       imageUrl: posterUrl,
                       width: 140,
@@ -539,7 +538,7 @@ class _PeopleRow extends StatelessWidget {
                     CircleAvatar(
                       radius: 50,
                       backgroundImage: personImageUrl != null
-                          ? CachedNetworkImageProvider(personImageUrl)
+                          ? atriumImageProvider(personImageUrl)
                           : null,
                       child: personImageUrl == null
                           ? const Icon(Icons.person, size: 40)
@@ -635,7 +634,7 @@ class _SeasonsGrid extends ConsumerWidget {
                         child: ClipRRect(
                           borderRadius: Radii.card,
                           child: posterUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                 )

--- a/services/service_emby/lib/src/emby_music_screens.dart
+++ b/services/service_emby/lib/src/emby_music_screens.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -67,7 +66,7 @@ class EmbyAlbumScreen extends ConsumerWidget {
                       child: Stack(
                         children: <Widget>[
                           Positioned.fill(
-                            child: CachedNetworkImage(
+                            child: AtriumNetworkImage(
                               imageUrl: albumImageUrl!,
                               fit: BoxFit.cover,
                             ),
@@ -250,7 +249,7 @@ class EmbyAlbumScreen extends ConsumerWidget {
                                 if (imageUrl != null)
                                   ClipRRect(
                                     borderRadius: BorderRadius.circular(4),
-                                    child: CachedNetworkImage(
+                                    child: AtriumNetworkImage(
                                       imageUrl: imageUrl,
                                       width: 48,
                                       height: 48,
@@ -320,7 +319,7 @@ class EmbyAlbumScreen extends ConsumerWidget {
           if (albumImageUrl != null)
             ClipRRect(
               borderRadius: Radii.card,
-              child: CachedNetworkImage(
+              child: AtriumNetworkImage(
                 imageUrl: albumImageUrl!,
                 width: 140,
                 height: 140,

--- a/services/service_emby/lib/src/emby_remote_images_screen.dart
+++ b/services/service_emby/lib/src/emby_remote_images_screen.dart
@@ -215,7 +215,7 @@ class _EmbyRemoteImagesScreenState
                     borderRadius: Radii.card,
                     child: ClipRRect(
                       borderRadius: Radii.card,
-                      child: CachedNetworkImage(
+                      child: AtriumNetworkImage(
                         imageUrl: validUrl,
                         fit: BoxFit.cover,
                         placeholder: (BuildContext context, String url) =>

--- a/services/service_emby/lib/src/emby_season_screen.dart
+++ b/services/service_emby/lib/src/emby_season_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -75,7 +74,7 @@ class EmbySeasonScreen extends ConsumerWidget {
                       if (seasonImageUrl != null)
                         ClipRRect(
                           borderRadius: BorderRadius.circular(8),
-                          child: CachedNetworkImage(
+                          child: AtriumNetworkImage(
                             imageUrl: seasonImageUrl!,
                             width: 120,
                             height: 180,

--- a/services/service_emby/lib/src/emby_session_detail_screen.dart
+++ b/services/service_emby/lib/src/emby_session_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 import 'dart:ui';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -41,7 +40,7 @@ class _EmbySessionDetailScreenState
     _lastPosterUrl = posterUrl;
 
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
     ).then((PaletteGenerator palette) {
       if (mounted) {
@@ -143,7 +142,7 @@ class _EmbySessionDetailScreenState
           children: <Widget>[
             // Background blurred image
             if (session.posterUrl != null)
-              CachedNetworkImage(
+              AtriumNetworkImage(
                 imageUrl: session.posterUrl!,
                 fit: BoxFit.cover,
                 errorWidget: (_, __, ___) =>
@@ -307,7 +306,7 @@ class _EmbySessionDetailScreenState
                                     ],
                                     image: session.posterUrl != null
                                         ? DecorationImage(
-                                            image: CachedNetworkImageProvider(
+                                            image: atriumImageProvider(
                                               session.posterUrl!,
                                             ),
                                             fit: BoxFit.cover,

--- a/services/service_jellyfin/lib/src/jellyfin_home.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_home.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -814,7 +813,7 @@ class JellyfinPosterCard extends ConsumerWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 300,
@@ -997,7 +996,7 @@ class JellyfinBannerCard extends ConsumerWidget {
                     child: Stack(
                       fit: StackFit.expand,
                       children: <Widget>[
-                        CachedNetworkImage(
+                        AtriumNetworkImage(
                           imageUrl: (backdropUrl ?? imageUrl)!,
                           fit: BoxFit.cover,
                           alignment: Alignment.topCenter,
@@ -1161,7 +1160,7 @@ class JellyfinBannerCard extends ConsumerWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       placeholder: (BuildContext context, String url) => Container(
@@ -1480,7 +1479,7 @@ class _SessionCardState extends State<_SessionCard> {
     _lastPosterUrl = posterUrl;
 
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
     ).then((PaletteGenerator palette) {
       if (mounted) {
@@ -1540,6 +1539,7 @@ class _SessionCardState extends State<_SessionCard> {
                     children: <Widget>[
                       Image.network(
                         session.posterUrl!,
+                        headers: ArtworkHeaders.forUrl(session.posterUrl!),
                         fit: BoxFit.cover,
                         alignment: Alignment.topCenter,
                         errorBuilder: (_, __, ___) => const SizedBox.shrink(),

--- a/services/service_jellyfin/lib/src/jellyfin_identify_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_identify_screen.dart
@@ -240,6 +240,7 @@ class _JellyfinIdentifyScreenState
                     leading: res.imageUrl != null
                         ? Image.network(
                             res.imageUrl!,
+                            headers: ArtworkHeaders.forUrl(res.imageUrl!),
                             width: 40,
                             height: 60,
                             fit: BoxFit.cover,

--- a/services/service_jellyfin/lib/src/jellyfin_item_detail.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_item_detail.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -158,7 +157,7 @@ class JellyfinItemDetailScreen extends ConsumerWidget {
                         child: Stack(
                           children: <Widget>[
                             Positioned.fill(
-                              child: CachedNetworkImage(
+                              child: AtriumNetworkImage(
                                 key: ValueKey<String>(backdropUrl),
                                 imageUrl: backdropUrl,
                                 fit: BoxFit.cover,
@@ -342,7 +341,7 @@ class _Header extends StatelessWidget {
                 if (posterUrl != null)
                   ClipRRect(
                     borderRadius: Radii.card,
-                    child: CachedNetworkImage(
+                    child: AtriumNetworkImage(
                       key: ValueKey<String>(posterUrl),
                       imageUrl: posterUrl,
                       width: 140,
@@ -528,7 +527,7 @@ class _PeopleRow extends StatelessWidget {
                     CircleAvatar(
                       radius: 50,
                       backgroundImage: personImageUrl != null
-                          ? CachedNetworkImageProvider(personImageUrl)
+                          ? atriumImageProvider(personImageUrl)
                           : null,
                       child: personImageUrl == null
                           ? const Icon(Icons.person, size: 40)
@@ -626,7 +625,7 @@ class _SeasonsGrid extends ConsumerWidget {
                         child: ClipRRect(
                           borderRadius: Radii.card,
                           child: posterUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                 )

--- a/services/service_jellyfin/lib/src/jellyfin_music_screens.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_music_screens.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -68,7 +67,7 @@ class JellyfinAlbumScreen extends ConsumerWidget {
                       child: Stack(
                         children: <Widget>[
                           Positioned.fill(
-                            child: CachedNetworkImage(
+                            child: AtriumNetworkImage(
                               imageUrl: albumImageUrl!,
                               fit: BoxFit.cover,
                             ),
@@ -255,7 +254,7 @@ class JellyfinAlbumScreen extends ConsumerWidget {
                                 if (imageUrl != null)
                                   ClipRRect(
                                     borderRadius: BorderRadius.circular(4),
-                                    child: CachedNetworkImage(
+                                    child: AtriumNetworkImage(
                                       imageUrl: imageUrl,
                                       width: 48,
                                       height: 48,
@@ -325,7 +324,7 @@ class JellyfinAlbumScreen extends ConsumerWidget {
           if (albumImageUrl != null)
             ClipRRect(
               borderRadius: Radii.card,
-              child: CachedNetworkImage(
+              child: AtriumNetworkImage(
                 imageUrl: albumImageUrl!,
                 width: 140,
                 height: 140,

--- a/services/service_jellyfin/lib/src/jellyfin_remote_images_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_remote_images_screen.dart
@@ -215,7 +215,7 @@ class _JellyfinRemoteImagesScreenState
                     borderRadius: Radii.card,
                     child: ClipRRect(
                       borderRadius: Radii.card,
-                      child: CachedNetworkImage(
+                      child: AtriumNetworkImage(
                         imageUrl: url,
                         fit: BoxFit.cover,
                         placeholder: (BuildContext context, String url) =>

--- a/services/service_jellyfin/lib/src/jellyfin_season_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_season_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -79,7 +78,7 @@ class JellyfinSeasonScreen extends ConsumerWidget {
                       if (seasonImageUrl != null)
                         ClipRRect(
                           borderRadius: BorderRadius.circular(8),
-                          child: CachedNetworkImage(
+                          child: AtriumNetworkImage(
                             imageUrl: seasonImageUrl!,
                             width: 120,
                             height: 180,

--- a/services/service_jellyfin/lib/src/jellyfin_session_detail_screen.dart
+++ b/services/service_jellyfin/lib/src/jellyfin_session_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:math';
 import 'dart:ui';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -41,7 +40,7 @@ class _JellyfinSessionDetailScreenState
     _lastPosterUrl = posterUrl;
 
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
     ).then((PaletteGenerator palette) {
       if (mounted) {
@@ -144,7 +143,7 @@ class _JellyfinSessionDetailScreenState
             // Background blurred image
             if (session.posterUrl != null)
               Image(
-                image: CachedNetworkImageProvider(session.posterUrl!),
+                image: atriumImageProvider(session.posterUrl!),
                 fit: BoxFit.cover,
                 errorBuilder: (_, __, ___) =>
                     Container(color: theme.colorScheme.surface),
@@ -307,7 +306,7 @@ class _JellyfinSessionDetailScreenState
                                     ],
                                     image: session.posterUrl != null
                                         ? DecorationImage(
-                                            image: CachedNetworkImageProvider(
+                                            image: atriumImageProvider(
                                               session.posterUrl!,
                                             ),
                                             fit: BoxFit.cover,

--- a/services/service_lidarr/lib/src/features/activity/views/queue_view.dart
+++ b/services/service_lidarr/lib/src/features/activity/views/queue_view.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -220,7 +219,7 @@ class _QueueViewState extends ConsumerState<QueueView> {
                         width: 72,
                         height: 72,
                         child: coverUrl != null
-                            ? CachedNetworkImage(
+                            ? AtriumNetworkImage(
                                 imageUrl: coverUrl,
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) => Container(
@@ -880,7 +879,7 @@ class _QueueArtistGroupCard extends StatelessWidget {
                     width: 44,
                     height: 44,
                     child: coverUrl != null
-                        ? CachedNetworkImage(
+                        ? AtriumNetworkImage(
                             imageUrl: coverUrl,
                             fit: BoxFit.cover,
                             errorWidget: (_, __, ___) => Container(
@@ -1232,7 +1231,7 @@ class _QueueCard extends StatelessWidget {
                       width: 48,
                       height: 48,
                       child: coverUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: coverUrl,
                               fit: BoxFit.cover,
                               errorWidget: (_, __, ___) => Container(

--- a/services/service_lidarr/lib/src/features/albums/album_detail_screen.dart
+++ b/services/service_lidarr/lib/src/features/albums/album_detail_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -713,7 +712,7 @@ class _AlbumHeroCard extends StatelessWidget {
                 width: 72,
                 height: 72,
                 child: coverUrl != null
-                    ? CachedNetworkImage(
+                    ? AtriumNetworkImage(
                         imageUrl: coverUrl,
                         fit: BoxFit.cover,
                         errorWidget: (_, __, ___) => Container(

--- a/services/service_lidarr/lib/src/features/artists/add_artist_search_screen.dart
+++ b/services/service_lidarr/lib/src/features/artists/add_artist_search_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -508,7 +507,7 @@ class _PosterImage extends ConsumerWidget {
       );
     }
 
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: url,
       fit: BoxFit.cover,
       placeholder: (context, url) => Container(

--- a/services/service_lidarr/lib/src/features/artists/add_artist_sheet.dart
+++ b/services/service_lidarr/lib/src/features/artists/add_artist_sheet.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -233,7 +232,7 @@ class _LidarrAddArtistSheetState extends ConsumerState<LidarrAddArtistSheet> {
                                 width: 70,
                                 height: 105,
                                 child: posterUrl != null
-                                    ? CachedNetworkImage(
+                                    ? AtriumNetworkImage(
                                         imageUrl: posterUrl,
                                         fit: BoxFit.cover,
                                         alignment: Alignment.topCenter,

--- a/services/service_lidarr/lib/src/features/artists/album_studio_screen.dart
+++ b/services/service_lidarr/lib/src/features/artists/album_studio_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -519,7 +518,7 @@ class _ArtistMatrixCard extends ConsumerWidget {
                       height: 44,
                       color: cs.surfaceContainerHighest,
                       child: posterUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               errorWidget: (_, __, ___) => Icon(
@@ -820,7 +819,7 @@ class _DiscographyMatrix extends StatelessWidget {
                         height: 38,
                         color: cs.surfaceContainerHighest,
                         child: coverUrl != null
-                            ? CachedNetworkImage(
+                            ? AtriumNetworkImage(
                                 imageUrl: coverUrl,
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) => Icon(

--- a/services/service_lidarr/lib/src/features/artists/artist_detail_screen.dart
+++ b/services/service_lidarr/lib/src/features/artists/artist_detail_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -1016,7 +1015,7 @@ class _Backdrop extends StatelessWidget {
       fit: StackFit.expand,
       children: [
         if (fanartUrl != null)
-          CachedNetworkImage(
+          AtriumNetworkImage(
             imageUrl: fanartUrl,
             fit: BoxFit.cover,
             alignment: Alignment.topCenter,
@@ -1315,7 +1314,7 @@ class _ArtistHeroHeader extends StatelessWidget {
                   width: 76,
                   height: 76,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl,
                           fit: BoxFit.cover,
                           alignment: Alignment.topCenter,

--- a/services/service_lidarr/lib/src/features/artists/artist_info_sheet.dart
+++ b/services/service_lidarr/lib/src/features/artists/artist_info_sheet.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -133,7 +132,7 @@ void showLidarrArtistInfoSheet(
                       width: 60,
                       height: 60,
                       child: posterUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               errorWidget: (_, __, ___) =>

--- a/services/service_lidarr/lib/src/features/artists/widgets/album_card.dart
+++ b/services/service_lidarr/lib/src/features/artists/widgets/album_card.dart
@@ -1,5 +1,5 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -57,7 +57,7 @@ void showLidarrAlbumActionSheet(
                       width: 56,
                       height: 56,
                       child: coverUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: coverUrl,
                               fit: BoxFit.cover,
                               errorWidget: (_, __, ___) =>
@@ -405,7 +405,7 @@ class _AlbumCardState extends ConsumerState<AlbumCard> {
                   width: 54,
                   height: 54,
                   child: coverUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: coverUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(

--- a/services/service_lidarr/lib/src/features/artists/widgets/artist_grid.dart
+++ b/services/service_lidarr/lib/src/features/artists/widgets/artist_grid.dart
@@ -1,5 +1,5 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/lidarr_formatters.dart';
@@ -95,7 +95,7 @@ class ArtistGrid extends StatelessWidget {
                       fit: StackFit.expand,
                       children: [
                         posterUrl != null
-                            ? CachedNetworkImage(
+                            ? AtriumNetworkImage(
                                 imageUrl: posterUrl,
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) => Container(

--- a/services/service_lidarr/lib/src/features/artists/widgets/artist_list.dart
+++ b/services/service_lidarr/lib/src/features/artists/widgets/artist_list.dart
@@ -1,5 +1,5 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../../core/lidarr_formatters.dart';
@@ -103,7 +103,7 @@ class ArtistList extends StatelessWidget {
                   // 1. Fanart Backdrop
                   if (fanartUrl != null)
                     Positioned.fill(
-                      child: CachedNetworkImage(
+                      child: AtriumNetworkImage(
                         imageUrl: fanartUrl,
                         fit: BoxFit.cover,
                         alignment: Alignment.centerRight,
@@ -145,7 +145,7 @@ class ArtistList extends StatelessWidget {
                             bottomLeft: Radius.circular(12),
                           ),
                           child: posterUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   errorWidget: (_, __, ___) => Container(

--- a/services/service_lidarr/lib/src/features/wanted/widgets/wanted_album_card.dart
+++ b/services/service_lidarr/lib/src/features/wanted/widgets/wanted_album_card.dart
@@ -1,5 +1,5 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
+import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../../generated/generated.dart';
@@ -86,7 +86,7 @@ class WantedAlbumCard extends StatelessWidget {
                   width: 52,
                   height: 52,
                   child: coverUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: coverUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(

--- a/services/service_plex/lib/src/plex_home.dart
+++ b/services/service_plex/lib/src/plex_home.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -446,7 +445,7 @@ class _FeaturedHero extends ConsumerWidget {
             children: <Widget>[
               if (backdropUrl != null)
                 Image(
-                  image: CachedNetworkImageProvider(backdropUrl),
+                  image: atriumImageProvider(backdropUrl),
                   fit: BoxFit.cover,
                   errorBuilder: (_, __, ___) => Container(
                     color: theme.colorScheme.surfaceContainerHighest,
@@ -630,7 +629,7 @@ class _SessionCard extends ConsumerWidget {
             children: <Widget>[
               if (backdropUrl != null)
                 Image(
-                  image: CachedNetworkImageProvider(backdropUrl),
+                  image: atriumImageProvider(backdropUrl),
                   fit: BoxFit.cover,
                   errorBuilder: (_, __, ___) => const SizedBox.shrink(),
                 ),
@@ -664,7 +663,7 @@ class _SessionCard extends ConsumerWidget {
                                 Colors.black.withValues(alpha: 0.4),
                             foregroundImage: avatarUrl == null
                                 ? null
-                                : CachedNetworkImageProvider(avatarUrl),
+                                : atriumImageProvider(avatarUrl),
                             onForegroundImageError:
                                 avatarUrl == null ? null : (_, __) {},
                             child: const Icon(
@@ -995,7 +994,7 @@ class PlexPosterCard extends ConsumerWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 400,

--- a/services/service_plex/lib/src/plex_item_detail.dart
+++ b/services/service_plex/lib/src/plex_item_detail.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -49,7 +48,7 @@ class _PlexItemDetailScreenState extends ConsumerState<PlexItemDetailScreen> {
 
     // maximumColorCount is left at its default of 16.
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
       timeout: Duration.zero,
     ).then((PaletteGenerator palette) {
@@ -253,7 +252,7 @@ class _BackdropHeader extends StatelessWidget {
       child: Stack(
         children: <Widget>[
           Positioned.fill(
-            child: CachedNetworkImage(
+            child: AtriumNetworkImage(
               key: ValueKey<String>(backdropUrl!),
               imageUrl: backdropUrl!,
               fit: BoxFit.cover,
@@ -324,7 +323,7 @@ class _Header extends StatelessWidget {
             child: ClipRRect(
               borderRadius: BorderRadius.circular(16),
               child: posterUrl != null
-                  ? CachedNetworkImage(
+                  ? AtriumNetworkImage(
                       imageUrl: posterUrl,
                       width: 140,
                       height: 210,
@@ -566,7 +565,7 @@ class _CastRow extends StatelessWidget {
                       CircleAvatar(
                         radius: 50,
                         backgroundImage: image != null
-                            ? CachedNetworkImageProvider(image)
+                            ? atriumImageProvider(image)
                             : null,
                         child: image == null
                             ? const Icon(Icons.person, size: 40)

--- a/services/service_plex/lib/src/plex_music_screens.dart
+++ b/services/service_plex/lib/src/plex_music_screens.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -168,7 +167,7 @@ class _AlbumCard extends StatelessWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 320,
@@ -232,7 +231,7 @@ class PlexAlbumScreen extends ConsumerWidget {
                       child: Stack(
                         children: <Widget>[
                           Positioned.fill(
-                            child: CachedNetworkImage(
+                            child: AtriumNetworkImage(
                               imageUrl: albumImageUrl,
                               fit: BoxFit.cover,
                             ),
@@ -351,7 +350,7 @@ class PlexAlbumScreen extends ConsumerWidget {
           if (albumImageUrl != null)
             ClipRRect(
               borderRadius: Radii.card,
-              child: CachedNetworkImage(
+              child: AtriumNetworkImage(
                 imageUrl: albumImageUrl,
                 width: 140,
                 height: 140,

--- a/services/service_plex/lib/src/plex_season_screen.dart
+++ b/services/service_plex/lib/src/plex_season_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -109,7 +108,7 @@ class PlexSeasonCard extends StatelessWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 128,

--- a/services/service_plex/lib/src/plex_session_detail_screen.dart
+++ b/services/service_plex/lib/src/plex_session_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:ui';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_networking/core_networking.dart';
@@ -59,7 +58,7 @@ class _PlexSessionDetailScreenState
 
     // maximumColorCount is left at its default of 16.
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
       timeout: Duration.zero,
     ).then((PaletteGenerator palette) {
@@ -268,7 +267,7 @@ class _PlexSessionDetailScreenState
             // Blurred backdrop behind everything.
             if (backdropUrl != null)
               Image(
-                image: CachedNetworkImageProvider(backdropUrl),
+                image: atriumImageProvider(backdropUrl),
                 fit: BoxFit.cover,
                 errorBuilder: (_, __, ___) =>
                     Container(color: theme.colorScheme.surface),
@@ -336,7 +335,7 @@ class _PlexSessionDetailScreenState
                                     )
                                   : Image(
                                       image:
-                                          CachedNetworkImageProvider(posterUrl),
+                                          atriumImageProvider(posterUrl),
                                       fit: BoxFit.cover,
                                       errorBuilder: (_, __, ___) => Icon(
                                         Icons.movie_outlined,
@@ -554,7 +553,7 @@ class _UserRow extends StatelessWidget {
           radius: 16,
           backgroundColor: Colors.white.withValues(alpha: 0.2),
           foregroundImage:
-              avatarUrl == null ? null : CachedNetworkImageProvider(avatarUrl!),
+              avatarUrl == null ? null : atriumImageProvider(avatarUrl!),
           onForegroundImageError: avatarUrl == null ? null : (_, __) {},
           child: Text(
             initial,

--- a/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
+++ b/services/service_qbittorrent/lib/src/add_torrent_sheet.dart
@@ -85,6 +85,18 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
   final List<TorrentFileArg> _files = <TorrentFileArg>[];
   int _done = 0;
   String? _category;
+
+  /// The server's global save path, once preferences arrive.
+  String _defaultSavePath = '';
+
+  /// Whether the field has been filled in from the server yet. The prefill is
+  /// one-shot: it must not keep reasserting itself over someone's typing every
+  /// time this rebuilds.
+  bool _prefilledSavePath = false;
+
+  /// Set once the field is edited by hand, so a slow preferences fetch landing
+  /// afterwards does not overwrite what was typed.
+  bool _savePathEdited = false;
   bool _paused = false;
   bool _sequential = false;
   bool _skipHashCheck = false;
@@ -215,11 +227,46 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
     }
   }
 
+  /// Fills the save path in from the server the first time it is known.
+  ///
+  /// Called from build rather than initState because the value arrives with
+  /// the preferences fetch. It only writes to the controller, so there is no
+  /// setState and no rebuild loop.
+  void _prefillSavePath(Map<String, dynamic>? prefs) {
+    if (prefs == null) {
+      return;
+    }
+    _defaultSavePath = prefs['save_path']?.toString() ?? '';
+    if (_prefilledSavePath || _savePathEdited || _defaultSavePath.isEmpty) {
+      return;
+    }
+    if (_savePath.text.isEmpty) {
+      _savePath.text = _defaultSavePath;
+    }
+    _prefilledSavePath = true;
+  }
+
+  /// Moves the save path to match a newly chosen category.
+  ///
+  /// This is what qBittorrent's own web interface does: picking a category
+  /// rewrites the field, and a category that defines no path of its own falls
+  /// back to the global default rather than blanking it.
+  void _applyCategoryPath(String? category, Map<String, String> paths) {
+    final String forCategory = category == null ? '' : (paths[category] ?? '');
+    _savePath.text =
+        forCategory.isNotEmpty ? forCategory : _defaultSavePath;
+    // The field now holds a server value again, not a hand-typed one.
+    _savePathEdited = false;
+  }
+
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
-    final AsyncValue<List<String>> categories =
-        ref.watch(qbitCategoriesProvider(widget.instance));
+    final AsyncValue<Map<String, String>> categoryPaths =
+        ref.watch(qbitCategoryPathsProvider(widget.instance));
+    _prefillSavePath(
+      ref.watch(qbitPreferencesProvider(widget.instance)).value,
+    );
 
     return AlertDialog(
       title: const Text('Add torrent'),
@@ -248,26 +295,32 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
                 label: Text(_fileLabel),
               ),
             const SizedBox(height: Insets.md),
-            categories.when(
-              data: (List<String> cats) => DropdownButtonFormField<String>(
-                initialValue: _category,
-                decoration: const InputDecoration(
-                  labelText: 'Category (optional)',
-                  border: OutlineInputBorder(),
-                ),
-                items: <DropdownMenuItem<String>>[
-                  const DropdownMenuItem<String>(
-                    child: Text('None'),
+            categoryPaths.when(
+              data: (Map<String, String> paths) {
+                final List<String> cats = paths.keys.toList()..sort();
+                return DropdownButtonFormField<String>(
+                  initialValue: _category,
+                  decoration: const InputDecoration(
+                    labelText: 'Category (optional)',
+                    border: OutlineInputBorder(),
                   ),
-                  ...cats.map(
-                    (String c) => DropdownMenuItem<String>(
-                      value: c,
-                      child: Text(c),
+                  items: <DropdownMenuItem<String>>[
+                    const DropdownMenuItem<String>(
+                      child: Text('None'),
                     ),
-                  ),
-                ],
-                onChanged: (String? v) => setState(() => _category = v),
-              ),
+                    ...cats.map(
+                      (String c) => DropdownMenuItem<String>(
+                        value: c,
+                        child: Text(c),
+                      ),
+                    ),
+                  ],
+                  onChanged: (String? v) {
+                    setState(() => _category = v);
+                    _applyCategoryPath(v, paths);
+                  },
+                );
+              },
               loading: () => const LinearProgressIndicatorM3E(
                 shape: ProgressM3EShape.flat,
               ),
@@ -276,8 +329,9 @@ class _AddTorrentSheetState extends ConsumerState<AddTorrentSheet> {
             const SizedBox(height: Insets.sm),
             TextField(
               controller: _savePath,
+              onChanged: (_) => _savePathEdited = true,
               decoration: const InputDecoration(
-                labelText: 'Save path (optional)',
+                labelText: 'Save path',
                 hintText: 'Leave blank for the default',
                 border: OutlineInputBorder(),
               ),

--- a/services/service_qbittorrent/lib/src/qbittorrent_client.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_client.dart
@@ -335,14 +335,27 @@ class QbittorrentClient {
         );
       });
 
-  /// All category names defined on the server (sorted).
-  Future<List<String>> getCategories() => _guarded(() async {
+  /// Every category on the server, mapped to the save path it defines.
+  ///
+  /// A category is free to define no path of its own, which comes back as an
+  /// empty string and means the server's global default applies. Note the key
+  /// is `savePath` here while the same idea is `save_path` in
+  /// `app/preferences`; qBittorrent is inconsistent between the two endpoints,
+  /// so both spellings are accepted.
+  Future<Map<String, String>> getCategories() => _guarded(() async {
         final Response<dynamic> resp =
             await _dio.get<dynamic>('api/v2/torrents/categories');
         final Map<String, dynamic> map =
             (resp.data as Map<String, dynamic>?) ?? <String, dynamic>{};
-        final List<String> names = map.keys.toList()..sort();
-        return names;
+        final Map<String, String> paths = <String, String>{};
+        for (final MapEntry<String, dynamic> e in map.entries) {
+          final dynamic v = e.value;
+          final Object? raw = v is Map<String, dynamic>
+              ? (v['savePath'] ?? v['save_path'])
+              : null;
+          paths[e.key] = raw?.toString() ?? '';
+        }
+        return paths;
       });
 
   /// Moves a torrent into [category] (empty string clears it).

--- a/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
+++ b/services/service_qbittorrent/lib/src/qbittorrent_providers.dart
@@ -428,16 +428,31 @@ final qbitTransferProvider =
   return client.getTransferInfo();
 });
 
-/// Category names defined on an instance. Fetched on demand (no polling -
-/// categories rarely change).
-final qbitCategoriesProvider =
-    FutureProvider.autoDispose.family<List<String>, Instance>((
+/// Categories on an instance mapped to the save path each defines, empty
+/// where a category leaves it to the server default. Fetched on demand (no
+/// polling - categories rarely change).
+final qbitCategoryPathsProvider =
+    FutureProvider.autoDispose.family<Map<String, String>, Instance>((
   Ref ref,
   Instance instance,
 ) async {
   final QbittorrentClient client =
       await ref.watch(qbittorrentClientProvider(instance).future);
   return client.getCategories();
+});
+
+/// Category names defined on an instance (sorted).
+///
+/// Derived from [qbitCategoryPathsProvider] rather than fetching again, so the
+/// callers that only want names cost no extra request.
+final qbitCategoriesProvider =
+    FutureProvider.autoDispose.family<List<String>, Instance>((
+  Ref ref,
+  Instance instance,
+) async {
+  final Map<String, String> paths =
+      await ref.watch(qbitCategoryPathsProvider(instance).future);
+  return paths.keys.toList()..sort();
 });
 
 /// Tag names defined on an instance. Fetched on demand for the tag picker.

--- a/services/service_qbittorrent/test/qbit_category_paths_test.dart
+++ b/services/service_qbittorrent/test/qbit_category_paths_test.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:cookie_jar/cookie_jar.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:service_qbittorrent/service_qbittorrent.dart';
+
+/// Answers the categories endpoint with a fixed body.
+class _CannedAdapter implements HttpClientAdapter {
+  _CannedAdapter(this.body);
+
+  final String body;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async =>
+      ResponseBody.fromString(
+        body,
+        200,
+        headers: <String, List<String>>{
+          Headers.contentTypeHeader: <String>[Headers.jsonContentType],
+        },
+      );
+
+  @override
+  void close({bool force = false}) {}
+}
+
+QbittorrentClient _clientFor(String body) => QbittorrentClient(
+      dio: Dio(BaseOptions(baseUrl: 'https://qbit.example.test/'))
+        ..httpClientAdapter = _CannedAdapter(body),
+      cookies: CookieJar(),
+      username: '',
+      password: '',
+      apiKey: 'k',
+    );
+
+/// The save path a category defines has to survive the trip.
+///
+/// Issue #150: the add sheet left the save path blank, so the whole path had
+/// to be typed for every torrent. Prefilling it needs the per-category path,
+/// which this endpoint carries and the client used to throw away.
+void main() {
+  test('a category keeps the save path it defines', () async {
+    // Shape taken from a live qBittorrent 5.1 server.
+    final String body = jsonEncode(<String, dynamic>{
+      'movies': <String, dynamic>{
+        'name': 'movies',
+        'savePath': '/data/torrents/movies',
+        'download_path': null,
+      },
+    });
+
+    final Map<String, String> paths = await _clientFor(body).getCategories();
+
+    expect(paths, <String, String>{'movies': '/data/torrents/movies'});
+  });
+
+  test('a category defining no path comes back empty, not missing', () async {
+    // Real servers have plenty of these. Empty means "use the global default",
+    // and the sheet relies on being able to tell that apart from a category it
+    // has never heard of.
+    final String body = jsonEncode(<String, dynamic>{
+      'games': <String, dynamic>{'name': 'games', 'savePath': ''},
+    });
+
+    final Map<String, String> paths = await _clientFor(body).getCategories();
+
+    expect(paths.containsKey('games'), isTrue);
+    expect(paths['games'], isEmpty);
+  });
+
+  test('the save_path spelling is accepted too', () async {
+    // qBittorrent says savePath here and save_path in app/preferences. Reading
+    // only one spelling would silently yield an empty path if that ever moved.
+    final String body = jsonEncode(<String, dynamic>{
+      'books': <String, dynamic>{'name': 'books', 'save_path': '/data/books'},
+    });
+
+    final Map<String, String> paths = await _clientFor(body).getCategories();
+
+    expect(paths['books'], '/data/books');
+  });
+
+  test('a category that is not a map does not bring the list down', () async {
+    // Older servers answered with a bare name list. One odd entry must not
+    // cost the rest of the categories.
+    final String body = jsonEncode(<String, dynamic>{
+      'odd': 'not-an-object',
+      'movies': <String, dynamic>{'name': 'movies', 'savePath': '/data/m'},
+    });
+
+    final Map<String, String> paths = await _clientFor(body).getCategories();
+
+    expect(paths['odd'], isEmpty);
+    expect(paths['movies'], '/data/m');
+  });
+
+  test('no categories at all is empty rather than an error', () async {
+    final Map<String, String> paths = await _clientFor('{}').getCategories();
+
+    expect(paths, isEmpty);
+  });
+}

--- a/services/service_radarr/lib/src/add_movie_screen.dart
+++ b/services/service_radarr/lib/src/add_movie_screen.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -795,7 +794,7 @@ class _PosterImage extends ConsumerWidget {
       );
     }
 
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: url,
       fit: BoxFit.cover,
       placeholder: (context, url) => Container(

--- a/services/service_radarr/lib/src/home/activity_tab.dart
+++ b/services/service_radarr/lib/src/home/activity_tab.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:math';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -492,7 +491,7 @@ class _QueueCard extends ConsumerWidget {
                   width: 50,
                   height: 75,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(
@@ -1201,7 +1200,7 @@ class _HistoryCard extends ConsumerWidget {
                   width: 40,
                   height: 60,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(
@@ -1369,7 +1368,7 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                       width: 36,
                       height: 54,
                       child: posterUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
@@ -1714,7 +1713,7 @@ class _BlocklistCard extends ConsumerWidget {
                   width: 40,
                   height: 60,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(
@@ -1909,7 +1908,7 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                         fit: StackFit.expand,
                         children: [
                           posterUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   placeholder: (context, url) => Container(

--- a/services/service_radarr/lib/src/home/movies_tab.dart
+++ b/services/service_radarr/lib/src/home/movies_tab.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -698,7 +697,7 @@ class _MovieBannerCard extends ConsumerWidget {
             children: <Widget>[
               if (bannerUrl != null)
                 Positioned.fill(
-                  child: CachedNetworkImage(
+                  child: AtriumNetworkImage(
                     imageUrl: bannerUrl,
                     fit: BoxFit.cover,
                     alignment: Alignment.centerRight,
@@ -764,7 +763,7 @@ class _MovieBannerCard extends ConsumerWidget {
                       child: posterUrl != null
                           ? Hero(
                               tag: 'movie-poster-${movie.id}',
-                              child: CachedNetworkImage(
+                              child: AtriumNetworkImage(
                                 imageUrl: posterUrl,
                                 fit: BoxFit.cover,
                                 memCacheWidth: 500,
@@ -872,7 +871,7 @@ class _Poster extends StatelessWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 500,

--- a/services/service_radarr/lib/src/home/wanted_tab.dart
+++ b/services/service_radarr/lib/src/home/wanted_tab.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -586,7 +585,7 @@ class _WantedMovieCard extends ConsumerWidget {
                   width: 50,
                   height: 75,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(

--- a/services/service_radarr/lib/src/movie_detail_screen.dart
+++ b/services/service_radarr/lib/src/movie_detail_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:math';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -373,7 +372,7 @@ class _Backdrop extends StatelessWidget {
       fit: StackFit.expand,
       children: <Widget>[
         if (fanartUrl != null)
-          CachedNetworkImage(
+          AtriumNetworkImage(
             imageUrl: fanartUrl!,
             fit: BoxFit.cover,
             memCacheWidth: 1080,
@@ -440,7 +439,7 @@ class _HeroInfoCard extends StatelessWidget {
                   width: 110,
                   height: 165,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl!,
                           fit: BoxFit.cover,
                           memCacheWidth: 500,

--- a/services/service_seerr/lib/src/seerr_genre_screen.dart
+++ b/services/service_seerr/lib/src/seerr_genre_screen.dart
@@ -98,6 +98,7 @@ class _SeerrGenrePosterCard extends ConsumerWidget {
                   child: posterUrl != null
                       ? Image.network(
                           posterUrl,
+                          headers: ArtworkHeaders.forUrl(posterUrl),
                           fit: BoxFit.cover,
                           errorBuilder: (_, __, ___) => const _Placeholder(),
                         )

--- a/services/service_seerr/lib/src/seerr_issue_detail_screen.dart
+++ b/services/service_seerr/lib/src/seerr_issue_detail_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -382,7 +381,7 @@ class _IssueHeader extends ConsumerWidget {
               width: 72,
               height: 108,
               child: posterUrl != null
-                  ? CachedNetworkImage(
+                  ? AtriumNetworkImage(
                       imageUrl: posterUrl,
                       fit: BoxFit.cover,
                       errorWidget: (_, __, ___) => _posterFallback(cs),

--- a/services/service_seerr/lib/src/seerr_issues_screen.dart
+++ b/services/service_seerr/lib/src/seerr_issues_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -178,7 +177,7 @@ class _IssueCard extends ConsumerWidget {
                   width: 56,
                   height: 84,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => _thumbFallback(cs),

--- a/services/service_seerr/lib/src/seerr_item_detail.dart
+++ b/services/service_seerr/lib/src/seerr_item_detail.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -58,7 +57,7 @@ class _SeerrItemDetailScreenState extends ConsumerState<SeerrItemDetailScreen> {
     _lastPosterUrl = posterUrl;
 
     PaletteGenerator.fromImageProvider(
-      CachedNetworkImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
+      atriumImageProvider(posterUrl, maxWidth: 200, maxHeight: 300),
       size: const Size(200, 300),
       timeout: Duration.zero,
     ).then((PaletteGenerator palette) {
@@ -158,7 +157,7 @@ class _SeerrItemDetailScreenState extends ConsumerState<SeerrItemDetailScreen> {
                       children: <Widget>[
                         Positioned.fill(
                           child: backdropUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   key: ValueKey<String>(backdropUrl),
                                   imageUrl: backdropUrl,
                                   fit: BoxFit.cover,
@@ -338,7 +337,7 @@ class _DetailHeader extends StatelessWidget {
           ClipRRect(
             borderRadius: BorderRadius.circular(Radii.lg),
             child: posterUrl != null
-                ? CachedNetworkImage(
+                ? AtriumNetworkImage(
                     key: ValueKey<String>(posterUrl!),
                     imageUrl: posterUrl!,
                     width: 120,
@@ -540,7 +539,7 @@ class _CastRow extends StatelessWidget {
                       backgroundColor:
                           theme.colorScheme.surfaceContainerHighest,
                       backgroundImage: profileUrl != null
-                          ? CachedNetworkImageProvider(profileUrl)
+                          ? atriumImageProvider(profileUrl)
                           : null,
                       onBackgroundImageError:
                           profileUrl != null ? (_, __) {} : null,
@@ -669,7 +668,7 @@ class _PosterCard extends StatelessWidget {
                   fit: StackFit.expand,
                   children: <Widget>[
                     api?.imageUrl(item.posterPath) != null
-                        ? CachedNetworkImage(
+                        ? AtriumNetworkImage(
                             imageUrl: api!.imageUrl(item.posterPath)!,
                             fit: BoxFit.cover,
                             errorWidget: (_, __, ___) => _posterFallback(theme),

--- a/services/service_seerr/lib/src/seerr_media_card.dart
+++ b/services/service_seerr/lib/src/seerr_media_card.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
 
@@ -48,7 +47,7 @@ class SeerrMediaCard extends StatelessWidget {
                   fit: StackFit.expand,
                   children: <Widget>[
                     if (api?.imageUrl(item.posterPath) != null)
-                      CachedNetworkImage(
+                      AtriumNetworkImage(
                         imageUrl: api!.imageUrl(item.posterPath)!,
                         fit: BoxFit.cover,
                         errorWidget: (_, __, ___) => const _PosterFallback(),
@@ -219,7 +218,7 @@ class SeerrRequestCard extends StatelessWidget {
         children: <Widget>[
           if (api?.imageUrl(backdrop, size: 'w780') != null)
             Positioned.fill(
-              child: CachedNetworkImage(
+              child: AtriumNetworkImage(
                 imageUrl: api!.imageUrl(backdrop, size: 'w780')!,
                 fit: BoxFit.cover,
                 errorWidget: (_, __, ___) => const SizedBox.shrink(),
@@ -315,7 +314,7 @@ class SeerrRequestCard extends StatelessWidget {
                         width: 76,
                         height: 114,
                         child: api?.imageUrl(item.posterPath) != null
-                            ? CachedNetworkImage(
+                            ? AtriumNetworkImage(
                                 imageUrl: api!.imageUrl(item.posterPath)!,
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) =>

--- a/services/service_seerr/lib/src/seerr_search.dart
+++ b/services/service_seerr/lib/src/seerr_search.dart
@@ -132,6 +132,7 @@ class _SeerrSearchPosterCard extends ConsumerWidget {
                   child: posterUrl != null
                       ? Image.network(
                           posterUrl,
+                          headers: ArtworkHeaders.forUrl(posterUrl),
                           fit: BoxFit.cover,
                           errorBuilder: (_, __, ___) => const _Placeholder(),
                         )

--- a/services/service_sonarr/lib/src/home/activity_tab.dart
+++ b/services/service_sonarr/lib/src/home/activity_tab.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -567,7 +566,7 @@ class _QueueItemCard extends ConsumerWidget {
                     fit: StackFit.expand,
                     children: [
                       posterUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
@@ -1231,7 +1230,7 @@ class _GroupedHistoryCardState extends ConsumerState<_GroupedHistoryCard> {
                       width: 36,
                       height: 54,
                       child: posterUrl != null
-                          ? CachedNetworkImage(
+                          ? AtriumNetworkImage(
                               imageUrl: posterUrl,
                               fit: BoxFit.cover,
                               placeholder: (context, url) => Container(
@@ -1702,7 +1701,7 @@ class _GroupedBlocklistCardState extends ConsumerState<_GroupedBlocklistCard> {
                         fit: StackFit.expand,
                         children: [
                           posterUrl != null
-                              ? CachedNetworkImage(
+                              ? AtriumNetworkImage(
                                   imageUrl: posterUrl,
                                   fit: BoxFit.cover,
                                   placeholder: (context, url) => Container(

--- a/services/service_sonarr/lib/src/home/series_tab.dart
+++ b/services/service_sonarr/lib/src/home/series_tab.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -679,7 +678,7 @@ class _SeriesBannerCard extends ConsumerWidget {
             children: <Widget>[
               if (bannerUrl != null)
                 Positioned.fill(
-                  child: CachedNetworkImage(
+                  child: AtriumNetworkImage(
                     imageUrl: bannerUrl,
                     fit: BoxFit.cover,
                     alignment: Alignment.centerRight,
@@ -745,7 +744,7 @@ class _SeriesBannerCard extends ConsumerWidget {
                       child: posterUrl != null
                           ? Hero(
                               tag: 'series-poster-${series.id}',
-                              child: CachedNetworkImage(
+                              child: AtriumNetworkImage(
                                 imageUrl: posterUrl,
                                 fit: BoxFit.cover,
                                 memCacheWidth: 500,
@@ -852,7 +851,7 @@ class _Poster extends StatelessWidget {
     if (imageUrl == null) {
       return fallback;
     }
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: imageUrl!,
       fit: BoxFit.cover,
       memCacheWidth: 500,

--- a/services/service_sonarr/lib/src/home/wanted_tab.dart
+++ b/services/service_sonarr/lib/src/home/wanted_tab.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -694,7 +693,7 @@ class _EpisodeListLayout extends ConsumerWidget {
                         if (posterUrl != null)
                           ClipRRect(
                             borderRadius: BorderRadius.circular(8),
-                            child: CachedNetworkImage(
+                            child: AtriumNetworkImage(
                               imageUrl: posterUrl,
                               width: 48,
                               height: 72,
@@ -1024,7 +1023,7 @@ class _GroupedEpisodeCardState extends ConsumerState<_GroupedEpisodeCard> {
                   if (posterUrl != null)
                     ClipRRect(
                       borderRadius: BorderRadius.circular(8),
-                      child: CachedNetworkImage(
+                      child: AtriumNetworkImage(
                         imageUrl: posterUrl,
                         width: 36,
                         height: 54,

--- a/services/service_sonarr/lib/src/series_detail_screen.dart
+++ b/services/service_sonarr/lib/src/series_detail_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -522,7 +521,7 @@ class _HeroInfoCard extends StatelessWidget {
                   width: 110,
                   height: 165,
                   child: posterUrl != null
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: posterUrl!,
                           fit: BoxFit.cover,
                           memCacheWidth: 500,
@@ -2505,7 +2504,7 @@ class _Backdrop extends StatelessWidget {
       fit: StackFit.expand,
       children: <Widget>[
         if (fanartUrl != null)
-          CachedNetworkImage(
+          AtriumNetworkImage(
             imageUrl: fanartUrl!,
             fit: BoxFit.cover,
             memCacheWidth: 1080,

--- a/services/service_sonarr/lib/src/sonarr_add_series_search_screen.dart
+++ b/services/service_sonarr/lib/src/sonarr_add_series_search_screen.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -435,7 +434,7 @@ class _PosterImage extends ConsumerWidget {
       );
     }
 
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: url,
       fit: BoxFit.cover,
       placeholder: (context, url) => Container(

--- a/services/service_sonarr/lib/src/sonarr_add_series_sheet.dart
+++ b/services/service_sonarr/lib/src/sonarr_add_series_sheet.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
@@ -567,7 +566,7 @@ class _PosterImage extends ConsumerWidget {
       );
     }
 
-    return CachedNetworkImage(
+    return AtriumNetworkImage(
       imageUrl: url,
       fit: BoxFit.cover,
       placeholder: (context, url) => Container(

--- a/services/service_tautulli/lib/src/tautulli_home.dart
+++ b/services/service_tautulli/lib/src/tautulli_home.dart
@@ -1,6 +1,5 @@
 import 'dart:math' as math;
 
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_networking/core_networking.dart';
 import 'package:core_ui/core_ui.dart';
@@ -300,7 +299,7 @@ class _SessionCard extends StatelessWidget {
             fit: StackFit.expand,
             children: <Widget>[
               if (imageUrl != null && imageUrl.isNotEmpty)
-                CachedNetworkImage(
+                AtriumNetworkImage(
                   imageUrl: imageUrl,
                   fit: BoxFit.cover,
                   placeholder: (BuildContext context, String _) => ColoredBox(
@@ -1332,7 +1331,7 @@ class _Poster extends StatelessWidget {
       borderRadius: BorderRadius.circular(8),
       child: (url == null || url!.isEmpty)
           ? fallback
-          : CachedNetworkImage(
+          : AtriumNetworkImage(
               imageUrl: url!,
               width: width,
               height: height,
@@ -1369,7 +1368,7 @@ class _Avatar extends StatelessWidget {
       return CircleAvatar(
         radius: radius,
         backgroundColor: theme.colorScheme.surfaceContainerHighest,
-        foregroundImage: CachedNetworkImageProvider(url!),
+        foregroundImage: atriumImageProvider(url!),
         // If the image fails, the initial below shows through.
         child: Text(
           initial,

--- a/services/service_tracearr/lib/src/activity/widgets/active_stream_card.dart
+++ b/services/service_tracearr/lib/src/activity/widgets/active_stream_card.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -120,7 +119,7 @@ class ActiveStreamCard extends StatelessWidget {
                         height: 72,
                         child: stream.posterUrl != null &&
                                 stream.posterUrl!.isNotEmpty
-                            ? CachedNetworkImage(
+                            ? AtriumNetworkImage(
                                 imageUrl: stream.posterUrl!,
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) => Container(
@@ -203,7 +202,7 @@ class ActiveStreamCard extends StatelessWidget {
                                     child: stream.userAvatarUrl != null &&
                                             stream.userAvatarUrl!.isNotEmpty
                                         ? ClipOval(
-                                            child: CachedNetworkImage(
+                                            child: AtriumNetworkImage(
                                               imageUrl: stream.userAvatarUrl!,
                                               width: 18,
                                               height: 18,

--- a/services/service_tracearr/lib/src/activity/widgets/history_item_card.dart
+++ b/services/service_tracearr/lib/src/activity/widgets/history_item_card.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -127,7 +126,7 @@ class HistoryItemCard extends StatelessWidget {
                   width: 42,
                   height: 60,
                   child: item.posterUrl != null && item.posterUrl!.isNotEmpty
-                      ? CachedNetworkImage(
+                      ? AtriumNetworkImage(
                           imageUrl: item.posterUrl!,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) => Container(
@@ -237,7 +236,7 @@ class HistoryItemCard extends StatelessWidget {
                               child: item.userAvatarUrl != null &&
                                       item.userAvatarUrl!.isNotEmpty
                                   ? ClipOval(
-                                      child: CachedNetworkImage(
+                                      child: AtriumNetworkImage(
                                         imageUrl: item.userAvatarUrl!,
                                         width: 16,
                                         height: 16,

--- a/services/service_tracearr/lib/src/media/screens/tracearr_media_detail_screen.dart
+++ b/services/service_tracearr/lib/src/media/screens/tracearr_media_detail_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -224,14 +223,14 @@ class _TracearrMediaDetailScreenState
                     children: [
                       if (effectivePosterUrl != null &&
                           effectivePosterUrl.isNotEmpty)
-                        CachedNetworkImage(
+                        AtriumNetworkImage(
                           imageUrl: effectivePosterUrl,
                           fit: BoxFit.cover,
                           errorWidget: (context, url, error) {
                             if (heroFallbackPoster != null &&
                                 heroFallbackPoster.isNotEmpty &&
                                 heroFallbackPoster != effectivePosterUrl) {
-                              return CachedNetworkImage(
+                              return AtriumNetworkImage(
                                 imageUrl: heroFallbackPoster,
                                 fit: BoxFit.cover,
                                 errorWidget: (_, __, ___) =>
@@ -243,7 +242,7 @@ class _TracearrMediaDetailScreenState
                         )
                       else if (heroFallbackPoster != null &&
                           heroFallbackPoster.isNotEmpty)
-                        CachedNetworkImage(
+                        AtriumNetworkImage(
                           imageUrl: heroFallbackPoster,
                           fit: BoxFit.cover,
                           errorWidget: (_, __, ___) =>

--- a/services/service_tracearr/lib/src/media/widgets/recently_added_card.dart
+++ b/services/service_tracearr/lib/src/media/widgets/recently_added_card.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -67,7 +66,7 @@ class RecentlyAddedCard extends StatelessWidget {
                 width: 48,
                 height: 72,
                 child: posterUrl != null && posterUrl.isNotEmpty
-                    ? CachedNetworkImage(
+                    ? AtriumNetworkImage(
                         imageUrl: posterUrl,
                         fit: BoxFit.cover,
                         errorWidget: (c, u, e) => Container(

--- a/services/service_tracearr/lib/src/media/widgets/recently_added_poster_tile.dart
+++ b/services/service_tracearr/lib/src/media/widgets/recently_added_poster_tile.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -69,7 +68,7 @@ class RecentlyAddedPosterTile extends StatelessWidget {
                 fit: StackFit.expand,
                 children: [
                   if (posterUrl != null && posterUrl.isNotEmpty)
-                    CachedNetworkImage(
+                    AtriumNetworkImage(
                       imageUrl: posterUrl,
                       fit: BoxFit.cover,
                       errorWidget: (context, url, error) => Container(

--- a/services/service_tracearr/lib/src/people/screens/tracearr_user_dossier_screen.dart
+++ b/services/service_tracearr/lib/src/people/screens/tracearr_user_dossier_screen.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -126,7 +125,7 @@ class TracearrUserDossierScreen extends ConsumerWidget {
                       backgroundColor: colorScheme.primaryContainer,
                       child: avatar != null && avatar.isNotEmpty
                           ? ClipOval(
-                              child: CachedNetworkImage(
+                              child: AtriumNetworkImage(
                                 imageUrl: avatar,
                                 width: 64,
                                 height: 64,

--- a/services/service_tracearr/lib/src/people/widgets/user_roster_card.dart
+++ b/services/service_tracearr/lib/src/people/widgets/user_roster_card.dart
@@ -1,4 +1,3 @@
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:core_models/core_models.dart';
 import 'package:core_ui/core_ui.dart';
 import 'package:flutter/material.dart';
@@ -79,7 +78,7 @@ class UserRosterCard extends ConsumerWidget {
               backgroundColor: colorScheme.primaryContainer,
               child: avatarUrl != null && avatarUrl.isNotEmpty
                   ? ClipOval(
-                      child: CachedNetworkImage(
+                      child: AtriumNetworkImage(
                         imageUrl: avatarUrl,
                         width: 44,
                         height: 44,

--- a/services/service_unraid/lib/src/tabs/unraid_docker_tab.dart
+++ b/services/service_unraid/lib/src/tabs/unraid_docker_tab.dart
@@ -369,6 +369,7 @@ class _ContainerAvatar extends StatelessWidget {
           borderRadius: BorderRadius.circular(Radii.sm),
           child: Image.network(
             url,
+            headers: ArtworkHeaders.forUrl(url),
             width: 36,
             height: 36,
             fit: BoxFit.cover,

--- a/site/src/components/hero.html
+++ b/site/src/components/hero.html
@@ -1,7 +1,7 @@
 <section class="hero-section">
   <div class="grid middle-align">
     <div class="s12 m6 hero-text-col center-align-mobile">
-      <div class="chip border round">v1.6.0 Release</div>
+      <div class="chip border round">v1.6.1 Release</div>
       <h1 class="hero-title">Your self-hosted media, unified.</h1>
       <p class="hero-subtitle">One premium Android app that fronts Sonarr, Radarr, Plex, Jellyfin, qBittorrent, and more. Material 3 Expressive, multi-instance, and fully secure.</p>
       <div class="row hero-actions">


### PR DESCRIPTION
Release 1.6.1, build 22. Version codes 221 / 222 / 223.

Mostly about running Atrium behind a reverse proxy, with a few small additions.

### What is in it

- **Reverse proxies**: artwork now carries your custom headers, so posters and backdrops load behind Authelia, Cloudflare Access and the like. Headers set for the whole profile reach every request, including Test connection, the health dot and the Beszel, dashdot and Glances clients, all of which were dropping them. The health check no longer reports a proxy's login page as a working server. The custom headers screen warns when a header name will not survive the request and suggests Proxy-Authorization.
- **Dashboard**: a Wake-on-LAN widget (#151), and Active downloads shows what is downloading rather than what is queued (#144).
- **qBittorrent**: adding a torrent fills in the save path from the server, including each category's path (#150).
- **Sidebar**: pull to refresh service health, a check on open when it has gone stale, and a poll while it stays open (#152, by @Bhavyashah94).

### Release chores

Version bumped in all seven places that carry it. The runbook listed only four of them and pointed at a changelog file that has since moved, so it now lists all seven.

### Not yet verified

The reverse-proxy fixes were checked end to end against Authelia behind nginx forward-auth, nginx basic auth on a sub-path, and a header-gated proxy in front of twenty services. The user who reported the original problem has not yet confirmed them on his own setup. Cloudflare Access was not tested directly, since it needs an account and tunnel; it uses its own header names, so it does not meet the collisions the others hit.
